### PR TITLE
Integrate tape clear into tape parse

### DIFF
--- a/benches/jomini_bench.rs
+++ b/benches/jomini_bench.rs
@@ -108,7 +108,6 @@ pub fn binary_parse_benchmark(c: &mut Criterion) {
         let mut tape = BinaryTape::default();
         b.iter(|| {
             tape.parse(&data[..]).unwrap();
-            tape.clear();
         })
     });
     group.finish();
@@ -122,7 +121,6 @@ pub fn text_parse_benchmark(c: &mut Criterion) {
         let mut tape = TextTape::default();
         b.iter(|| {
             tape.parse(&data[..]).unwrap();
-            tape.clear();
         })
     });
     group.finish();


### PR DESCRIPTION
Previously it was error prone to remember to call clear before a call to
parse. I couldn't find a use case where one wouldn't want to call clear
for every parse, so now a tape is cleared on every parse.

Also according to API guidelines, if an object provides a `Default`
implementation, it should also include a `new` constructor.