### PR TITLE
Migrate tape parsers to private fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ use jomini::{TextTape, TextToken, Scalar};
 let data = b"foo=bar";
 
 assert_eq!(
-    TextTape::from_slice(&data[..]).unwrap().token_tape,
-    vec![
+    TextTape::from_slice(&data[..])?.tokens(),
+    &[
         TextToken::Scalar(Scalar::new(b"foo")),
         TextToken::Scalar(Scalar::new(b"bar")),
     ]

--- a/examples/tape_binary.rs
+++ b/examples/tape_binary.rs
@@ -4,9 +4,8 @@ use std::io::{self, Read};
 fn main() -> Result<(), Box<dyn error::Error>> {
     let mut data = Vec::new();
     io::stdin().read_to_end(&mut data)?;
-    let res = jomini::BinaryTape::from_slice(&data);
-    match res {
-        Ok(t) => println!("{:#?}", t.token_tape),
+    match jomini::BinaryTape::from_slice(&data) {
+        Ok(t) => println!("{:#?}", t.tokens()),
         Err(e) => println!("errored with {}", e),
     }
 

--- a/examples/tape_text.rs
+++ b/examples/tape_text.rs
@@ -4,10 +4,10 @@ use std::io::{self, Read};
 fn main() -> Result<(), Box<dyn error::Error>> {
     let mut data = Vec::new();
     io::stdin().read_to_end(&mut data)?;
-    println!(
-        "{:#?}",
-        jomini::TextTape::from_slice(&data).unwrap().token_tape
-    );
+    match jomini::TextTape::from_slice(&data) {
+        Ok(t) => println!("{:#?}", t.tokens()),
+        Err(e) => println!("errored with {}", e),
+    }
 
     Ok(())
 }

--- a/src/binary/tape.rs
+++ b/src/binary/tape.rs
@@ -70,7 +70,7 @@ pub struct Rgb {
 /// Houses the tape of tokens that is extracted from binary data
 #[derive(Debug, Default)]
 pub struct BinaryTape<'a> {
-    pub token_tape: Vec<BinaryToken<'a>>,
+    token_tape: Vec<BinaryToken<'a>>,
     original_length: usize,
 }
 
@@ -91,6 +91,10 @@ impl<'a> BinaryTape<'a> {
         let mut parser = BinaryTape::new();
         parser.parse(data)?;
         Ok(parser)
+    }
+
+    pub fn tokens(&self) -> &[BinaryToken<'a>] {
+        self.token_tape.as_slice()
     }
 
     fn offset(&self, data: &[u8]) -> usize {
@@ -635,7 +639,7 @@ mod tests {
             ErrorKind::InvalidSyntax { offset, .. } => {
                 assert_eq!(*offset, 6);
             }
-            _ => assert!(false)
+            _ => assert!(false),
         }
 
         let data2 = [0x82, 0x2d, 0x01, 0x00, 0x01, 0x00];
@@ -645,7 +649,7 @@ mod tests {
             ErrorKind::InvalidSyntax { offset, .. } => {
                 assert_eq!(*offset, 4);
             }
-            _ => assert!(false)
+            _ => assert!(false),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,12 +115,13 @@ use jomini::{TextTape, TextToken, Scalar};
 let data = b"foo=bar";
 
 assert_eq!(
-    TextTape::from_slice(&data[..]).unwrap().token_tape,
-    vec![
+    TextTape::from_slice(&data[..])?.tokens(),
+    &[
         TextToken::Scalar(Scalar::new(b"foo")),
         TextToken::Scalar(Scalar::new(b"bar")),
     ]
 );
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
 */

--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -21,7 +21,7 @@ pub enum TextToken<'a> {
 /// Houses the tape of tokens that is extracted from plaintext data
 #[derive(Debug, Default)]
 pub struct TextTape<'a> {
-    pub token_tape: Vec<TextToken<'a>>,
+    token_tape: Vec<TextToken<'a>>,
     original_length: usize,
 }
 
@@ -45,6 +45,10 @@ impl<'a> TextTape<'a> {
         let mut tape = TextTape::new();
         tape.parse(data)?;
         Ok(tape)
+    }
+
+    pub fn tokens(&self) -> &[TextToken<'a>] {
+        self.token_tape.as_slice()
     }
 
     fn offset(&self, data: &[u8]) -> usize {
@@ -406,7 +410,7 @@ mod tests {
             ErrorKind::StackEmpty { offset, .. } => {
                 assert_eq!(*offset, 6);
             }
-            _ => assert!(false)
+            _ => assert!(false),
         }
     }
 


### PR DESCRIPTION
Previously the tokens vector was exposed as a public member, but
according to the API guidelines, structs should only have private
fields:

https://rust-lang.github.io/api-guidelines/future-proofing.html#structs-have-private-fields-c-struct-private