### PR TITLE
Scalar to_utf8 trims trailing whitespace

### DIFF
--- a/fuzz/fuzz_targets/fuzz_scalar_text.rs
+++ b/fuzz/fuzz_targets/fuzz_scalar_text.rs
@@ -5,7 +5,7 @@ use libfuzzer_sys::fuzz_target;
 fuzz_target!(|data: &[u8]| {
     let scalar = Scalar::new(data);
     let (cow, _) = encoding_rs::WINDOWS_1252.decode_without_bom_handling(data);
-    assert_eq!(scalar.to_utf8(), cow);
+    assert_eq!(scalar.to_utf8(), cow.trim_end());
     let _ = scalar.to_f64();
     let _ = scalar.to_u64();
     let _ = scalar.to_i64();

--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -843,7 +843,7 @@ mod tests {
         let mut expected_map = HashMap::new();
         expected_map.insert(
             String::from("schools_initiated"),
-            String::from("1444.11.11\n"),
+            String::from("1444.11.11"),
         );
 
         let actual: MyStruct = from_slice(&data[..], &map).unwrap();

--- a/src/data.rs
+++ b/src/data.rs
@@ -261,6 +261,16 @@ pub(crate) const BOUNDARY: u8 = 1;
 pub(crate) const WHITESPACE: u8 = 2;
 pub(crate) const OPERATOR: u8 = 4;
 
+#[inline]
+pub(crate) fn is_whitespace(b: u8) -> bool {
+    CHARACTER_CLASS[usize::from(b)] & WHITESPACE == WHITESPACE
+}
+
+#[inline]
+pub(crate) fn is_boundary(b: u8) -> bool {
+    CHARACTER_CLASS[usize::from(b)] & BOUNDARY == BOUNDARY
+}
+
 /// This table probably looks pretty weird but it serves as a way to encode multiple attributes of
 /// a character in a single place. This way we increase the likelihood that the table is in the
 /// cache as it is used in multiple call sites. The reason why the table has (0 - 0) is so that I
@@ -280,8 +290,8 @@ pub(crate) static CHARACTER_CLASS: [u8; 256] = [
     (8 - 8),
     (9 - 9) + BOUNDARY + WHITESPACE,   // \t
     (10 - 10) + BOUNDARY + WHITESPACE, // \n
-    (11 - 11),
-    (12 - 12),
+    (11 - 11) + BOUNDARY + WHITESPACE, // \v
+    (12 - 12) + BOUNDARY + WHITESPACE, // \f
     (13 - 13) + BOUNDARY + WHITESPACE, // \r
     (14 - 14),
     (15 - 15),

--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -1,4 +1,4 @@
-use crate::data::{BOUNDARY, CHARACTER_CLASS, WHITESPACE};
+use crate::data::{is_boundary, is_whitespace};
 use crate::util::le_u64;
 use crate::{Error, ErrorKind, Scalar};
 
@@ -368,16 +368,6 @@ fn contains_zero_byte(x: u64) -> bool {
 #[inline(always)]
 const fn repeat_byte(b: u8) -> u64 {
     (b as u64) * (u64::MAX / 255)
-}
-
-#[inline]
-fn is_whitespace(b: u8) -> bool {
-    CHARACTER_CLASS[usize::from(b)] & WHITESPACE == WHITESPACE
-}
-
-#[inline]
-fn is_boundary(b: u8) -> bool {
-    CHARACTER_CLASS[usize::from(b)] & BOUNDARY == BOUNDARY
 }
 
 #[cfg(test)]


### PR DESCRIPTION
EU4 binary files contain a `flags` section. In this section, the values
contain a trailing newline. This is a marked difference from the text
format where these values don't end with a newline. In order for both
binary and text formats to deserialize to the same value, there needs to
be some intermediate layer. In EU4save, this was done at the serde layer
for EU4 dates (as this is the only case in EU4 saves where the binary
value differs from text value). By trimming whitespace for all scalars
converted to strings, we avoid this for all situations.

I can't imagine the value add for keeping around the newline on purpose
(but if desired, can be seen in `view_data`)

This commit introduces the precedent of modifying the input to a scalar.

Benchmarks show that trimming the end from strings is a non-negligible
operation for short strings that don't need to be heap allocated
(`to_utf8()` (not `to_utf8_owned()`)). Time to decode strings of length
1 to utf-8 increased 36%. This penalty decreases the longer the string.
Latency for strings of length 4 increased 10%.