### PR TITLE
Remove optional encoding-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,6 @@ members = ["jomini_derive"]
 serde = { version = "1", optional = true }
 jomini_derive = { path = "jomini_derive", version = "^0.1.2-pre", optional = true }
 
-# Make encoding_rs optional as it adds 150KB to the wasm bundle and the
-# performance in real world tests didn't change
-encoding_rs = { version = "0.8", optional = true }
-
 [features]
 default = ["derive"]
 derive = ["serde", "jomini_derive"]

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -163,27 +163,11 @@ fn to_utf8(mut d: &[u8]) -> Cow<str> {
     }
 }
 
-#[cfg(not(feature = "encoding_rs"))]
 #[inline]
 fn to_windows_1252(d: &[u8]) -> String {
     d.iter()
         .map(|&x| crate::data::WINDOWS_1252[x as usize])
         .collect()
-}
-
-#[cfg(feature = "encoding_rs")]
-#[inline]
-fn to_windows_1252(d: &[u8]) -> String {
-    // For short strings, creating the string a byte at a time is 50% faster than encoding_rs.
-    // Since we deal with a lot of short strings, this optimization is worth it for when
-    // encountering non-ascii text
-    if d.len() < 10 {
-        use crate::data::WINDOWS_1252;
-        d.iter().map(|&x| WINDOWS_1252[x as usize]).collect()
-    } else {
-        let (cow, _) = encoding_rs::WINDOWS_1252.decode_without_bom_handling(d);
-        cow.into_owned()
-    }
 }
 
 #[inline]


### PR DESCRIPTION
Previously it was an optional dependency, but now has been removed
outright. I do not see any benefit to keeping it around. It is slower
for string sizes we're interested in and can be a hefty dependency