### PR TITLE
Parse and decode escaped strings

### DIFF
--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -856,6 +856,37 @@ mod tests {
     }
 
     #[test]
+    fn test_escaped_string_keys() {
+        let mut data = vec![0xcc, 0x29, 0x01, 0x00, 0x03, 0x00, 0x0f, 0x00, 0x11, 0x00];
+        data.extend_from_slice(b"schools_initiated");
+        data.extend_from_slice(&[0x01, 0x00, 0x0f, 0x00, 0x16, 0x00]);
+        data.extend_from_slice(br#"Joe \"Captain\" Rogers"#);
+        data.extend_from_slice(&0x0004u16.to_le_bytes());
+
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct MyStruct {
+            flags: HashMap<String, String>,
+        }
+
+        let mut map = HashMap::new();
+        map.insert(0x29cc, String::from("flags"));
+
+        let mut expected_map = HashMap::new();
+        expected_map.insert(
+            String::from("schools_initiated"),
+            String::from(r#"Joe "Captain" Rogers"#),
+        );
+
+        let actual: MyStruct = from_slice(&data[..], &map).unwrap();
+        assert_eq!(
+            actual,
+            MyStruct {
+                flags: expected_map
+            }
+        )
+    }
+
+    #[test]
     fn test_no_equal_object() {
         let data = [
             0xf1, 0x36, 0x03, 0x00, 0xe1, 0x00, 0x01, 0x00, 0xbe, 0x28, 0x04, 0x00,

--- a/src/text/de.rs
+++ b/src/text/de.rs
@@ -859,6 +859,24 @@ mod tests {
     }
 
     #[test]
+    fn test_escaped_field() {
+        let data = br#"name = "Joe \"Captain\" Rogers""#;
+
+        #[derive(Deserialize, PartialEq, Eq, Debug)]
+        struct MyStruct {
+            name: String,
+        }
+
+        let actual: MyStruct = from_slice(&data[..]).unwrap();
+        assert_eq!(
+            actual,
+            MyStruct {
+                name: r#"Joe "Captain" Rogers"#.to_string(),
+            }
+        );
+    }
+
+    #[test]
     fn test_false_field() {
         let data = b"field1=no";
 

--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -1,5 +1,5 @@
 use crate::data::{is_boundary, is_whitespace};
-use crate::util::le_u64;
+use crate::util::{contains_zero_byte, le_u64, repeat_byte};
 use crate::{Error, ErrorKind, Scalar};
 
 /// Represents a valid text value
@@ -91,7 +91,7 @@ impl<'a> TextTape<'a> {
             } else if d[pos] == b'"' {
                 let scalar = Scalar::new(&d[1..pos]);
                 self.token_tape.push(TextToken::Scalar(scalar));
-                return Ok(&d[pos + 1..])
+                return Ok(&d[pos + 1..]);
             } else {
                 pos += 1;
             }
@@ -128,7 +128,7 @@ impl<'a> TextTape<'a> {
                 let end_idx = pos + offset;
                 let scalar = Scalar::new(&sd[..end_idx]);
                 self.token_tape.push(TextToken::Scalar(scalar));
-                return Ok(&d[end_idx + 2..])
+                return Ok(&d[end_idx + 2..]);
             } else {
                 pos += 1;
             }
@@ -384,19 +384,6 @@ unsafe fn forward_search<F: Fn(u8) -> bool>(
     }
 
     None
-}
-
-/// From the memchr crate which bases its implementation on several others
-#[inline(always)]
-fn contains_zero_byte(x: u64) -> bool {
-    const LO_U64: u64 = 0x0101010101010101;
-    const HI_U64: u64 = 0x8080808080808080;
-    x.wrapping_sub(LO_U64) & !x & HI_U64 != 0
-}
-
-#[inline(always)]
-const fn repeat_byte(b: u8) -> u64 {
-    (b as u64) * (u64::MAX / 255)
 }
 
 #[cfg(test)]

--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -79,6 +79,27 @@ impl<'a> TextTape<'a> {
         }
     }
 
+    /// I'm not smart enough to figure out the behavior of handling escape sequences when
+    /// when scanning multi-bytes, so this fallback is for when I was to reset and
+    /// process bytewise. It is much slower, but escaped strings should be rare enough
+    /// that this shouldn't be an issue
+    fn parse_quote_scalar_fallback(&mut self, d: &'a [u8]) -> Result<&'a [u8], Error> {
+        let mut pos = 1;
+        while pos < d.len() {
+            if d[pos] == b'\\' {
+                pos += 2;
+            } else if d[pos] == b'"' {
+                let scalar = Scalar::new(&d[1..pos]);
+                self.token_tape.push(TextToken::Scalar(scalar));
+                return Ok(&d[pos + 1..])
+            } else {
+                pos += 1;
+            }
+        }
+
+        Err(Error::eof())
+    }
+
     #[inline]
     fn parse_quote_scalar(&mut self, d: &'a [u8]) -> Result<&'a [u8], Error> {
         let sd = &d[1..];
@@ -86,26 +107,34 @@ impl<'a> TextTape<'a> {
         let mut chunk_iter = sd.chunks_exact(8);
         while let Some(n) = chunk_iter.next() {
             let acc = le_u64(n);
-            if contains_zero_byte(acc ^ repeat_byte(b'"')) {
+            if contains_zero_byte(acc ^ repeat_byte(b'\\')) {
+                return self.parse_quote_scalar_fallback(d);
+            } else if contains_zero_byte(acc ^ repeat_byte(b'"')) {
                 let end_idx = n.iter().position(|&x| x == b'"').unwrap_or(0) + offset;
-                self.token_tape
-                    .push(TextToken::Scalar(Scalar::new(&sd[..end_idx])));
+                let scalar = Scalar::new(&sd[..end_idx]);
+                self.token_tape.push(TextToken::Scalar(scalar));
                 return Ok(&d[end_idx + 2..]);
             }
 
             offset += 8;
         }
 
-        let pos = chunk_iter
-            .remainder()
-            .iter()
-            .position(|&x| x == b'"')
-            .ok_or_else(Error::eof)?;
+        let remainder = chunk_iter.remainder();
+        let mut pos = 0;
+        while pos < remainder.len() {
+            if remainder[pos] == b'\\' {
+                pos += 2;
+            } else if remainder[pos] == b'"' {
+                let end_idx = pos + offset;
+                let scalar = Scalar::new(&sd[..end_idx]);
+                self.token_tape.push(TextToken::Scalar(scalar));
+                return Ok(&d[end_idx + 2..])
+            } else {
+                pos += 1;
+            }
+        }
 
-        let end_idx = pos + offset;
-        self.token_tape
-            .push(TextToken::Scalar(Scalar::new(&sd[..end_idx])));
-        Ok(&d[end_idx + 2..])
+        Err(Error::eof())
     }
 
     #[inline]
@@ -429,6 +458,45 @@ mod tests {
                 TextToken::Scalar(Scalar::new(b"bar")),
                 TextToken::Scalar(Scalar::new(b"3")),
                 TextToken::Scalar(Scalar::new(b"1444.11.11")),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_escaped_quotes() {
+        let data = br#"name = "Joe \"Captain\" Rogers""#;
+
+        assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Scalar(Scalar::new(b"name")),
+                TextToken::Scalar(Scalar::new(br#"Joe \"Captain\" Rogers"#)),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_escaped_quotes_short() {
+        let data = br#"name = "J Rogers \"a""#;
+
+        assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Scalar(Scalar::new(b"name")),
+                TextToken::Scalar(Scalar::new(br#"J Rogers \"a"#)),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_escaped_quotes_crazy() {
+        let data = br#"custom_name="THE !@#$%^&*( '\"LEGION\"')""#;
+
+        assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Scalar(Scalar::new(b"custom_name")),
+                TextToken::Scalar(Scalar::new(br#"THE !@#$%^&*( '\"LEGION\"')"#)),
             ]
         );
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,3 +25,16 @@ pub(crate) fn le_i32(data: &[u8]) -> i32 {
     let ptr = data.as_ptr() as *const u8 as *const i32;
     unsafe { ::std::ptr::read_unaligned(ptr).to_le() }
 }
+
+#[inline(always)]
+pub(crate) const fn repeat_byte(b: u8) -> u64 {
+    (b as u64) * (u64::MAX / 255)
+}
+
+/// From the memchr crate which bases its implementation on several others
+#[inline(always)]
+pub(crate) fn contains_zero_byte(x: u64) -> bool {
+    const LO_U64: u64 = 0x0101010101010101;
+    const HI_U64: u64 = 0x8080808080808080;
+    x.wrapping_sub(LO_U64) & !x & HI_U64 != 0
+}


### PR DESCRIPTION
At least in Stellaris and Imperator, quoted strings can contained nested
quotes. These quotes are escaped with a backslash.

```
name = "Captain \"Joe\" Rogers"
```

Now the text tape will be able to parse the following into a single
scalar:

```
Captain \"Joe\" Rogers
```

This was implemented with a minimal impact to benchmarks.

And now that the text tape can parse quotes that contain escaped strings,
these escaped strings should be decoded unescaped. This logic has now
been embedded in `Scalar::to_utf8`.

```
Joe \"Captain\" Rogers
```

after `to_utf8` will be returned as:

```
Joe "Captain" Rogers
```

As can be imagined, when an escaped is encountered, a string allocation
is necessary

This implementation actually improved benchmarks significantly for short
strings up to 80% faster. Long strings, 128+ characters took a
significant hit (like 3x longer), but since these long strings are rare
this should be seen a net win.

Closes #4 