### PR TITLE
TextTape parser supports rgb color values

### DIFF
--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -6,4 +6,4 @@ mod tape;
 #[cfg(feature = "derive")]
 pub use self::de::{BinaryDeserializer, BinaryDeserializerBuilder};
 pub use self::resolver::{FailedResolveStrategy, TokenResolver};
-pub use self::tape::{BinaryTape, BinaryToken, Rgb};
+pub use self::tape::{BinaryTape, BinaryToken};

--- a/src/binary/tape.rs
+++ b/src/binary/tape.rs
@@ -1,5 +1,5 @@
 use crate::util::{le_i32, le_u16, le_u32, le_u64};
-use crate::{Error, ErrorKind, Scalar};
+use crate::{Error, ErrorKind, Rgb, Scalar};
 
 /// Represents any valid binary value
 #[derive(Debug, PartialEq)]
@@ -53,19 +53,6 @@ const STRING_2: u16 = 0x0017;
 const F32: u16 = 0x000d;
 const Q16: u16 = 0x0167;
 const RGB: u16 = 0x0243;
-
-/// Extracted color info
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Rgb {
-    /// Red channel
-    pub r: u32,
-
-    /// Green channel
-    pub g: u32,
-
-    /// Blue channel
-    pub b: u32,
-}
 
 /// Houses the tape of tokens that is extracted from binary data
 #[derive(Debug, Default)]

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,3 +1,16 @@
+/// Extracted color info
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rgb {
+    /// Red channel
+    pub r: u32,
+
+    /// Green channel
+    pub g: u32,
+
+    /// Blue channel
+    pub b: u32,
+}
+
 pub(crate) static WINDOWS_1252: [char; 256] = [
     0 as char,
     1 as char,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ mod text;
 pub(crate) mod util;
 
 pub use self::binary::*;
+pub use self::data::Rgb;
 pub use self::errors::*;
 pub use self::scalar::{Scalar, ScalarError};
 pub use self::text::*;

--- a/src/text/de.rs
+++ b/src/text/de.rs
@@ -665,6 +665,9 @@ impl<'b, 'de, 'r> de::Deserializer<'de> for &'r mut BinarySequence<'b, 'de> {
                 idx: self.de_idx + 1,
                 end_idx: *x,
             }),
+            TextToken::Rgb(_) => Err(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("unable to deserialize rgb")),
+            }),
             TextToken::Scalar(_x) => self.deserialize_str(visitor),
             TextToken::End(_x) => Err(DeserializeError {
                 kind: DeserializeErrorKind::Unsupported(String::from(


### PR DESCRIPTION
The binary parser already supports parsing RGB color info found in
imperator saves, so the text parser should too.

The format looks like the following:

```
color = rgb { 100 200 150 }
```

This does not implement deserialization

Benchmarks did decrease. Latency to parse text increased by about 5%. I
tried to lower this number through various mechanisms (like putting
least used paths in another branch) but was unsuccessful.

Closes #6 