### PR TITLE
Binary token resolver results now outlive deserializer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ criterion = "0.3"
 quickcheck = "0.9"
 quickcheck_macros = "0.9"
 serde = { version = "1", features = ["derive"] }
+eu4save = "0.1"
 
 [[bench]]
 name = "jomini_bench"

--- a/src/binary/tape.rs
+++ b/src/binary/tape.rs
@@ -75,7 +75,7 @@ impl<'a> BinaryTape<'a> {
         Default::default()
     }
 
-    /// Convenience method for creating a text tape and parsing the given input
+    /// Convenience method for creating a binary tape and parsing the given input
     pub fn from_slice(data: &[u8]) -> Result<BinaryTape<'_>, Error> {
         let mut parser = BinaryTape::new();
         parser.parse(data)?;


### PR DESCRIPTION
Previously the binary deserializer would call `visitor.visit_str` for
all known tokens. This worked, but whenever a serde visitor wanted the
next text value (and that value could be a resolved token) it'd need to
deserialize it as `String` instead of `&str` even though a
`TokenResolver` returns a `Option<&str>`.

This behavior is undesirable as I don't want to pay the cost of heap
allocating known tokens.

This PR now forces that caller to pass a TokenResolver by reference and
dictate that the Resolver outlive the data. This may be a swing too far
in the other direction and this restriction may be loosened over time,
but doesn't look like it should be too troublesome.

This PR now allows the following when driving serde visitors:

```diff
 fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
 where
     A: de::MapAccess<'de>,
 {
     let mut version = String::new();
-     while let Some(key) = map.next_key::<String>()? {
+     while let Some(key) = map.next_key::<&str>()? {
         match key {
             "first" => {
             	 let nv = map.next_value::<&str>()?;
                 version.extend(nv);
             }
             _ => {
                 map.next_value::<de::IgnoredAny>()?;
             }
         }
     }

     Ok(SaveVersion(version))
 }
```