### PR TITLE
Introduce the concept of a binary flavor

### DIFF
--- a/benches/jomini_bench.rs
+++ b/benches/jomini_bench.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use jomini::{BinaryDeserializer, BinaryTape, Scalar, TextDeserializer, TextTape};
-use std::collections::HashMap;
 use std::cell::Cell;
+use std::collections::HashMap;
 
 const METADATA_BIN: &'static [u8] = include_bytes!("../tests/fixtures/meta.bin");
 const METADATA_TXT: &'static [u8] = include_bytes!("../tests/fixtures/meta.txt");
@@ -109,7 +109,9 @@ pub fn binary_parse_benchmark(c: &mut Criterion) {
         let tape = Cell::new(BinaryTape::default());
         b.iter(move || {
             let t = tape.take();
-            let nt = BinaryTape::parser().parse_slice_with_tape(&data[..], t).unwrap();
+            let nt = BinaryTape::parser()
+                .parse_slice_with_tape(&data[..], t)
+                .unwrap();
             tape.set(nt);
         })
     });

--- a/benches/jomini_bench.rs
+++ b/benches/jomini_bench.rs
@@ -105,9 +105,8 @@ pub fn binary_parse_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("parse");
     group.throughput(Throughput::Bytes(data.len() as u64));
     group.bench_function("binary", |b| {
-        let mut tape = BinaryTape::default();
         b.iter(|| {
-            tape.parse(&data[..]).unwrap();
+            BinaryTape::from_slice(&data[..]).unwrap()
         })
     });
     group.finish();

--- a/benches/jomini_bench.rs
+++ b/benches/jomini_bench.rs
@@ -1,6 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use jomini::{BinaryDeserializer, BinaryTape, Scalar, TextDeserializer, TextTape};
-use std::cell::Cell;
 use std::collections::HashMap;
 
 const METADATA_BIN: &'static [u8] = include_bytes!("../tests/fixtures/meta.bin");
@@ -106,13 +105,11 @@ pub fn binary_parse_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("parse");
     group.throughput(Throughput::Bytes(data.len() as u64));
     group.bench_function("binary", |b| {
-        let tape = Cell::new(BinaryTape::default());
+        let mut tape = BinaryTape::default();
         b.iter(move || {
-            let t = tape.take();
-            let nt = BinaryTape::parser()
-                .parse_slice_with_tape(&data[..], t)
+            BinaryTape::parser()
+                .parse_slice_into_tape(&data[..], &mut tape)
                 .unwrap();
-            tape.set(nt);
         })
     });
     group.finish();

--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -1,6 +1,6 @@
 use crate::{
-    de::ColorSequence, BinaryTape, BinaryToken, DeserializeError, DeserializeErrorKind, Error,
-    FailedResolveStrategy, TokenResolver, BinaryFlavor, DefaultFlavor
+    de::ColorSequence, BinaryFlavor, BinaryTape, BinaryToken, DefaultFlavor, DeserializeError,
+    DeserializeErrorKind, Error, FailedResolveStrategy, TokenResolver,
 };
 use serde::de::{self, Deserialize, DeserializeSeed, MapAccess, SeqAccess, Visitor};
 use std::borrow::Cow;
@@ -68,8 +68,11 @@ impl BinaryDeserializer {
         BinaryDeserializerBuilder::with_flavor(DefaultFlavor)
     }
 
-    /// Create a builder to custom binary deserialization
-    pub fn builder_flavor<F>(flavor: F) -> BinaryDeserializerBuilder<F> where F: BinaryFlavor {
+    /// A customized builder for a certain flavor of binary data
+    pub fn builder_flavor<F>(flavor: F) -> BinaryDeserializerBuilder<F>
+    where
+        F: BinaryFlavor,
+    {
         BinaryDeserializerBuilder::with_flavor(flavor)
     }
 
@@ -146,14 +149,17 @@ pub struct BinaryDeserializerBuilder<F> {
     flavor: F,
 }
 
-impl<F> BinaryDeserializerBuilder<F> where F: BinaryFlavor {
+impl<F> BinaryDeserializerBuilder<F>
+where
+    F: BinaryFlavor,
+{
     /// Create a new builder instance
     pub fn with_flavor(flavor: F) -> Self {
         BinaryDeserializerBuilder {
             failed_resolve_strategy: FailedResolveStrategy::Ignore,
             flavor,
         }
-    } 
+    }
 
     /// Set the behavior when a unknown token is encountered
     pub fn on_failed_resolve(&mut self, strategy: FailedResolveStrategy) -> &mut Self {
@@ -350,8 +356,8 @@ fn visit_key<'c, 'b: 'c, 'de: 'b, 'res: 'de, RES: TokenResolver, V: Visitor<'de>
             Cow::Borrowed(s) => visitor.visit_borrowed_str(s),
             Cow::Owned(s) => visitor.visit_string(s),
         },
-        BinaryToken::F32(x) => visitor.visit_f32(x),
-        BinaryToken::Q16(x) => visitor.visit_f32(x),
+        BinaryToken::F32_1(x) => visitor.visit_f32(x),
+        BinaryToken::F32_2(x) => visitor.visit_f32(x),
         BinaryToken::Token(s) => match config.resolver.resolve(s) {
             Some(id) => visitor.visit_borrowed_str(id),
             None => match config.failed_resolve_strategy {

--- a/src/binary/flavor.rs
+++ b/src/binary/flavor.rs
@@ -1,21 +1,28 @@
 use crate::util::le_i32;
 
+/// Trait customizing decoding values from binary data
 pub trait BinaryFlavor: Sized {
-    fn visit_f32(&self, data: &[u8]) -> f32;
-    fn visit_q16(&self, data: &[u8]) -> f32;
+    /// Decode a f32 from 4 bytes of data
+    fn visit_f32_1(&self, data: &[u8]) -> f32;
+
+    /// Decode a f32 from 8 bytes of data
+    fn visit_f32_2(&self, data: &[u8]) -> f32;
 }
 
+/// The default binary flavor
 #[derive(Debug)]
 pub struct DefaultFlavor;
 
 impl BinaryFlavor for DefaultFlavor {
-    fn visit_f32(&self, data: &[u8]) -> f32 {
+    fn visit_f32_1(&self, data: &[u8]) -> f32 {
+        // First encoding is an i32 that has a fixed point offset of 3 decimal digits
         (le_i32(data) as f32) / 1000.0
     }
 
-    fn visit_q16(&self, data: &[u8]) -> f32 {
-        let mut val = le_i32(data) as f32;
-        val = val * 2.0 / 65536.0 * 100_000.0;
-        val.floor() / 100_000.0
+    fn visit_f32_2(&self, data: &[u8]) -> f32 {
+        // Second encoding is Q17.15 with 5 fractional digits
+        // https://en.wikipedia.org/wiki/Q_(number_format)
+        let val = le_i32(data) as f32 / 32768.0;
+        (val * 10_0000.0).floor() / 10_0000.0
     }
 }

--- a/src/binary/flavor.rs
+++ b/src/binary/flavor.rs
@@ -1,0 +1,14 @@
+use crate::util::le_i32;
+
+pub trait BinaryFlavor: Sized {
+    fn visit_f32(&self, data: &[u8]) -> f32;
+}
+
+#[derive(Debug)]
+pub struct DefaultFlavor;
+
+impl BinaryFlavor for DefaultFlavor {
+    fn visit_f32(&self, data: &[u8]) -> f32 {
+        (le_i32(data) as f32) / 1000.0
+    }
+}

--- a/src/binary/flavor.rs
+++ b/src/binary/flavor.rs
@@ -2,6 +2,7 @@ use crate::util::le_i32;
 
 pub trait BinaryFlavor: Sized {
     fn visit_f32(&self, data: &[u8]) -> f32;
+    fn visit_q16(&self, data: &[u8]) -> f32;
 }
 
 #[derive(Debug)]
@@ -10,5 +11,11 @@ pub struct DefaultFlavor;
 impl BinaryFlavor for DefaultFlavor {
     fn visit_f32(&self, data: &[u8]) -> f32 {
         (le_i32(data) as f32) / 1000.0
+    }
+
+    fn visit_q16(&self, data: &[u8]) -> f32 {
+        let mut val = le_i32(data) as f32;
+        val = val * 2.0 / 65536.0 * 100_000.0;
+        val.floor() / 100_000.0
     }
 }

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -2,8 +2,10 @@
 mod de;
 mod resolver;
 mod tape;
+mod flavor;
 
 #[cfg(feature = "derive")]
 pub use self::de::{BinaryDeserializer, BinaryDeserializerBuilder};
 pub use self::resolver::{FailedResolveStrategy, TokenResolver};
 pub use self::tape::{BinaryTape, BinaryToken};
+pub use self::flavor::{BinaryFlavor, DefaultFlavor};

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -7,5 +7,5 @@ mod flavor;
 #[cfg(feature = "derive")]
 pub use self::de::{BinaryDeserializer, BinaryDeserializerBuilder};
 pub use self::resolver::{FailedResolveStrategy, TokenResolver};
-pub use self::tape::{BinaryTape, BinaryToken};
+pub use self::tape::{BinaryTape, BinaryToken, BinaryTapeParser};
 pub use self::flavor::{BinaryFlavor, DefaultFlavor};

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -1,11 +1,11 @@
 #[cfg(feature = "derive")]
 mod de;
+mod flavor;
 mod resolver;
 mod tape;
-mod flavor;
 
 #[cfg(feature = "derive")]
 pub use self::de::{BinaryDeserializer, BinaryDeserializerBuilder};
-pub use self::resolver::{FailedResolveStrategy, TokenResolver};
-pub use self::tape::{BinaryTape, BinaryToken, BinaryTapeParser};
 pub use self::flavor::{BinaryFlavor, DefaultFlavor};
+pub use self::resolver::{FailedResolveStrategy, TokenResolver};
+pub use self::tape::{BinaryTape, BinaryTapeParser, BinaryToken};

--- a/src/binary/tape.rs
+++ b/src/binary/tape.rs
@@ -80,20 +80,22 @@ impl<F> BinaryTapeParser<F> where F: BinaryFlavor {
         })
     }
 
-    // pub fn parse_slice_with_tape<'a>(self, data: &'a [u8], tape: TextTape<'a>) -> Result<BinaryTape<'a>, Error> {
-    //     let token_tape = tape.token_tape;
-    //     let mut state = ParserState {
-    //         data,
-    //         flavor: self.flavor,
-    //         original_length: data.len(),
-    //         token_tape: Vec::with_capacity(data.len() / 100 * 15),
-    //     };
+    pub fn parse_slice_with_tape<'a>(self, data: &'a [u8], tape: BinaryTape<'a>) -> Result<BinaryTape<'a>, Error> {
+        let mut token_tape = tape.token_tape;
+        token_tape.clear();
+        token_tape.reserve(data.len() / 100 * 15);
+        let mut state = ParserState {
+            data,
+            flavor: self.flavor,
+            original_length: data.len(),
+            token_tape,
+        };
 
-    //     state.parse()?;
-    //     Ok(BinaryTape {
-    //         token_tape: state.token_tape,
-    //     })
-    // }
+        state.parse()?;
+        Ok(BinaryTape {
+            token_tape: state.token_tape,
+        })
+    }
 }
 
 struct ParserState<'a, F> {
@@ -686,6 +688,14 @@ impl<'a> BinaryTape<'a> {
     /// Convenience method for creating a binary tape and parsing the given input
     pub fn from_slice(data: &[u8]) -> Result<BinaryTape<'_>, Error> {
         BinaryTapeParser::with_flavor(DefaultFlavor).parse_slice(data)
+    }
+
+    pub fn parser() -> BinaryTapeParser<DefaultFlavor> {
+        BinaryTape::parser_flavor(DefaultFlavor)
+    }
+
+    pub fn parser_flavor<F>(flavor: F) -> BinaryTapeParser<F> where F: BinaryFlavor {
+        BinaryTapeParser::with_flavor(flavor)
     }
 
     /// Return the parsed tokens


### PR DESCRIPTION
CK3 and EU4 seem to have a share a binary format that differs only in how rational (ie: not whole) numbers should be decoded.

While jomini can be used to parse HOI4 and Imperator saves, I have not yet run the numbers to ensure the values are being decoded correctly, so we'll assume, for the time being, that HOI4, Imperator, and EU4 all share the same format and that it is CK3 that introduces the change.

There are two tokens that signal a rational number is to be decoded next:

The first one is `0x000d`:

 - EU4 stores the value as a whole integer by multiplying the value by 1000. [So to follow berkley's lead](https://inst.eecs.berkeley.edu/~cs61c/sp06/handout/fixedpt.html), this is a `fixed<32,3>` value (32 bits wide, with 3 **decimal digit** (not binary) positions in the number)
 - CK3 decodes directly as a IEEE-754 floating point value (ie: `f32`)

The second one is `0x0167`:

- EU4 decodes it as a [Q17.15](https://en.wikipedia.org/wiki/Q_(number_format)) with 5 fractional digits
- CK3 decodes this how EU4 decodes `0x000d`

So this PR introduces the `BinaryFlavor` trait to `BinaryTape` (and consequentially to `BinaryDeserializer`) to know how to derive rational values from the data. This makes it easier to share the parsing code while allowing some extensibility while still maintaining [top tier performance (as the tape parser is monomorphized to the trait's implementation)](https://doc.rust-lang.org/book/ch10-01-syntax.html#performance-of-code-using-generics).

This PR also renames the `F32` and `Q16` binary tokens as they could be considered misnomers now. Since there isn't really distinctive nature of the two rational indicating tokens that the parser decodes into 32bit floating point values, I've named them `F32_1` and `F32_2`. 

Here's the longer story:

---

I was looking at a melted CK3 save and saw:

```
age=1053944.8
```

This can't be right, considering the standard save contains:

```
age=0.460000
```

Inside the binary ck3 save, that value is derived from

```
0d 00 8f c2 75 3e
```

So an F32 type is detected. One can get from the data to 0.46 (or 0.24 in this particular case) by reading the data into an f32.

The current behavior is to read 32 bits into an i32 and divide by 1000. This is how EU4 works, it's able to take 

```
0d 00 e0 2e 00 00
```

and transform it into:

```
value=12
```

Representing the longest_reign found in the header.

So how CK3 and EU4 interpret F32 data types is different.