### PR TITLE
Introduce TextTapeParser for conformity

### DIFF
--- a/benches/jomini_bench.rs
+++ b/benches/jomini_bench.rs
@@ -122,7 +122,9 @@ pub fn text_parse_benchmark(c: &mut Criterion) {
     group.bench_function("text", |b| {
         let mut tape = TextTape::default();
         b.iter(|| {
-            tape.parse(&data[..]).unwrap();
+            TextTape::parser()
+                .parse_slice_into_tape(&data[..], &mut tape)
+                .unwrap();
         })
     });
     group.finish();


### PR DESCRIPTION
Even though there is only a single flavor for the text format (thus
far), I wasn't comfortable with the fact knowing that the BinaryTape and
TextTape exposed a different API, so this commit rectifies the mismatch
by introducing a `TextTapeParser` that behaviors similarly to its binary
counterpart