### PR TITLE
Additional robustness to binary tape parsing

### DIFF
--- a/fuzz/fuzz_targets/fuzz_binary.rs
+++ b/fuzz/fuzz_targets/fuzz_binary.rs
@@ -43,6 +43,17 @@ fuzz_target!(|data: &[u8]| {
     hash.insert(0x209u16, "localization");
 
     let _: Result<Meta, _> = jomini::BinaryTape::from_eu4(&data).and_then(|tape| {
+        let tokens = tape.tokens();
+        for token in tokens {
+            match token {
+                jomini::BinaryToken::Array(ind) |
+                jomini::BinaryToken::Object(ind) |
+                jomini::BinaryToken::End(ind) if *ind == 0 => {
+                    panic!("zero ind encountered");
+                }
+                _ => {}
+            }
+        }
         jomini::BinaryDeserializer::eu4_builder().from_tape(&tape, &hash)
     });
 });

--- a/fuzz/fuzz_targets/fuzz_text.rs
+++ b/fuzz/fuzz_targets/fuzz_text.rs
@@ -26,5 +26,18 @@ struct Stat {
 
 fuzz_target!(|data: &[u8]| {
     let _: Result<Meta, _> = jomini::TextTape::from_slice(&data)
-        .and_then(|tape| jomini::TextDeserializer::from_windows1252_tape(&tape));
+        .and_then(|tape| {
+            let tokens = tape.tokens();
+            for token in tokens {
+                match token {
+                    jomini::TextToken::Array(ind) |
+                    jomini::TextToken::Object(ind) |
+                    jomini::TextToken::End(ind) if *ind == 0 => {
+                        panic!("zero ind encountered");
+                    }
+                    _ => {}
+                }
+            }
+            jomini::TextDeserializer::from_windows1252_tape(&tape)
+        });
 });


### PR DESCRIPTION
Make the binary tape fuzzer ensure that that there is no non-sensical
tokens (arrays / objects / end pointing to the 0th token)

This should make the melters in downstream crates more robust against
malicious input