### PR TITLE
Major binary parsing performance improvements

### DIFF
--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -380,7 +380,7 @@ impl<'c, 'b, 'de, 'res: 'de, RES: TokenResolver, E: Encoding> de::Deserializer<'
                 idx: idx + 1,
                 end_idx: *x,
             }),
-            BinaryToken::Rgb(x) => visitor.visit_seq(ColorSequence::new(**x)),
+            BinaryToken::Rgb(x) => visitor.visit_seq(ColorSequence::new(*x)),
             BinaryToken::Object(x) => {
                 visitor.visit_map(BinaryMap::new(&self.config, self.tokens, idx + 1, *x))
             }
@@ -406,7 +406,7 @@ impl<'c, 'b, 'de, 'res: 'de, RES: TokenResolver, E: Encoding> de::Deserializer<'
                 idx: idx + 1,
                 end_idx: *x,
             }),
-            BinaryToken::Rgb(x) => visitor.visit_seq(ColorSequence::new(**x)),
+            BinaryToken::Rgb(x) => visitor.visit_seq(ColorSequence::new(*x)),
             _ => Err(DeserializeError {
                 kind: DeserializeErrorKind::Unsupported(String::from(
                     "encountered non-array when trying to deserialize array",


### PR DESCRIPTION
Benchmarks show 30-80% increase in throughput (we can consistently
exceed 1.2 GiB/s now). Key insights:

- Having `BinaryToken::Rgb` be boxed (ie heap allocated) meant that a
`BinaryToken` needs to be dropped causing all sorts of slowdowns
(swapping values and clearing the vector would take 20% of the parse
time as the value would need to be dropped)
- Furthermore, inlining `Rgb` in the TextToken did not increase the size
of the enum (so it should have never been boxed in the first place).
- Rewrote parsing state machine to determine the token first before
looking at the state. When parsing scalar data, the next state can be
trivially determined