### PR TITLE
Add common game date implementation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,3 +63,4 @@ jobs:
         cargo fuzz build fuzz_binary
         cargo fuzz build fuzz_scalar_text
         cargo fuzz build fuzz_text
+        cargo fuzz build fuzz_date

--- a/benches/jomini_bench.rs
+++ b/benches/jomini_bench.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use jomini::{
-    BinaryDeserializer, BinaryTape, Scalar, TextDeserializer, TextTape, Utf8Encoding,
+    common::Date, BinaryDeserializer, BinaryTape, Scalar, TextDeserializer, TextTape, Utf8Encoding,
     Windows1252Encoding,
 };
 use std::collections::HashMap;
@@ -177,6 +177,20 @@ pub fn text_parse_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
+pub fn date_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("eu4date-parse");
+    group.bench_function("valid-date", |b| {
+        b.iter(|| Date::parse_from_str("1444.11.11").unwrap())
+    });
+    group.bench_function("invalid-date", |b| {
+        b.iter(|| Date::parse_from_str("marketplace").is_none())
+    });
+    group.bench_function("long-invalid-date", |b| {
+        b.iter(|| Date::parse_from_str("incidents_bur_inheritance.5").is_none())
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     is_ascii_benchmark,
@@ -188,5 +202,6 @@ criterion_group!(
     text_deserialize_benchmark,
     to_u64_benchmark,
     to_f64_benchmark,
+    date_benchmark,
 );
 criterion_main!(benches);

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -30,3 +30,9 @@ path = "fuzz_targets/fuzz_scalar_text.rs"
 [[bin]]
 name = "fuzz_binary"
 path = "fuzz_targets/fuzz_binary.rs"
+
+[[bin]]
+name = "fuzz_date"
+path = "fuzz_targets/fuzz_date.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_date.rs
+++ b/fuzz/fuzz_targets/fuzz_date.rs
@@ -1,0 +1,16 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 4 {
+        return;
+    }
+
+    let num = i32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+    let txt = jomini::Windows1252Encoding::decode(&data[4..]);
+    let _ = jomini::common::Date::from_binary(num);
+    if let Some(d) = jomini::common::Date::parse_from_str(txt) {
+        assert_eq!(d.days_until(&d.add_days(1)), 1);
+        assert_eq!(d.days_until(&d.add_days(-1)), -1);
+    }
+});

--- a/src/common/date.rs
+++ b/src/common/date.rs
@@ -1,0 +1,494 @@
+use crate::Scalar;
+use std::cmp::Ordering;
+
+const DAYS_PER_MONTH: [u8; 13] = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+/// Struct specialized to parsing, formatting, and manipulating dates in games
+///
+/// A game date does not follow any traditional calendar and instead views the
+/// world on simpler terms: that every year should be treated as a non-leap year.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Date {
+    year: u16,
+    month: u8,
+    day: u8,
+}
+
+impl PartialOrd for Date {
+    fn partial_cmp(&self, other: &Date) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Date {
+    fn cmp(&self, other: &Date) -> Ordering {
+        self.year
+            .cmp(&other.year)
+            .then_with(|| self.month.cmp(&other.month))
+            .then_with(|| self.day.cmp(&other.day))
+    }
+}
+
+impl Date {
+    /// Create a new date from year, month, and day parts
+    ///
+    /// Will return `None` if the date does not exist
+    ///
+    /// ```
+    /// use jomini::common::Date;
+    /// assert_eq!(Date::new(1444, 11, 11), Date::parse_from_str("1444.11.11"));
+    /// assert_eq!(Date::new(800, 5, 3), Date::parse_from_str("800.5.3"));
+    /// assert!(Date::new(800, 0, 3).is_none());
+    /// assert!(Date::new(800, 1, 0).is_none());
+    /// assert!(Date::new(800, 13, 1).is_none());
+    /// assert!(Date::new(800, 12, 32).is_none());
+    /// assert!(Date::new(2020, 2, 29).is_none());
+    /// ```
+    pub fn new(year: u16, month: u8, day: u8) -> Option<Self> {
+        if year != 0 && month != 0 && day != 0 {
+            if let Some(&days) = DAYS_PER_MONTH.get(usize::from(month)) {
+                if day <= days {
+                    return Some(Date { year, month, day });
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Year of the date
+    ///
+    /// ```
+    /// use jomini::common::Date;
+    /// let date = Date::parse_from_str("1445.02.03").expect("to parse date");
+    /// assert_eq!(date.year(), 1445);
+    /// ```
+    pub fn year(&self) -> u16 {
+        self.year
+    }
+
+    /// Month of the date
+    ///
+    /// ```
+    /// use jomini::common::Date;
+    /// let date = Date::parse_from_str("1445.02.03").expect("to parse date");
+    /// assert_eq!(date.month(), 2);
+    /// ```
+    pub fn month(&self) -> u8 {
+        self.month
+    }
+
+    /// Day of the date
+    ///
+    /// ```
+    /// use jomini::common::Date;
+    /// let date = Date::parse_from_str("1445.02.03").expect("to parse date");
+    /// assert_eq!(date.day(), 3);
+    /// ```
+    pub fn day(&self) -> u8 {
+        self.day
+    }
+
+    /// Parses a string and returns a new Date if valid.
+    ///
+    /// ```
+    /// use jomini::common::Date;
+    /// let date = Date::parse_from_str("1444.11.11").expect("to parse date");
+    /// assert_eq!(date.year(), 1444);
+    /// assert_eq!(date.month(), 11);
+    /// assert_eq!(date.day(), 11);
+    /// ```
+    pub fn parse_from_str<T: AsRef<str>>(s: T) -> Option<Self> {
+        let data = s.as_ref().as_bytes();
+        let mut state = 0;
+        let mut span1: &[u8] = &[];
+        let mut span2: &[u8] = &[];
+        let mut start = 0;
+
+        // micro-optimization: check the first byte to see if the first character (if available)
+        // is outside our upper bound (ie: not a number). This micro optimization doesn't
+        // harm the happy path (input is a date) by more than a few percent, but if the input
+        // is not a date, this shaves off 20-25% in date parsing benchmarks.
+        if data.get(0).map_or(true, |c| *c > b'9') {
+            return None;
+        }
+
+        for (pos, &c) in data.iter().enumerate() {
+            if c == b'.' {
+                match state {
+                    0 => {
+                        span1 = &data[start..pos];
+                        state = 1;
+                    }
+                    1 => {
+                        span2 = &data[start..pos];
+                        state = 2;
+                    }
+                    _ => return None,
+                }
+                start = pos + 1;
+            } else if c > b'9' || c < b'0' {
+                return None;
+            }
+        }
+
+        let span3 = &data[start..];
+
+        if let Ok(y) = Scalar::new(span1).to_u64() {
+            if let Ok(m) = Scalar::new(span2).to_u64() {
+                if let Ok(d) = Scalar::new(span3).to_u64() {
+                    return Date::new(y as u16, m as u8, d as u8);
+                }
+            }
+        }
+
+        None
+    }
+
+    fn days(&self) -> i32 {
+        let mut days: i32 = 0;
+        days += i32::from(self.year) * 365;
+        days += match self.month {
+            1 => -1,
+            2 => 30,
+            3 => 58,
+            4 => 89,
+            5 => 119,
+            6 => 150,
+            7 => 180,
+            8 => 211,
+            9 => 242,
+            10 => 272,
+            11 => 303,
+            12 => 333,
+            _ => unreachable!(),
+        };
+        days += i32::from(self.day);
+
+        days
+    }
+
+    /// Returns the number of days between two dates
+    ///
+    /// ```
+    /// use jomini::common::Date;
+    /// let date = Date::parse_from_str("1400.1.2").unwrap();
+    /// let date2 = Date::parse_from_str("1400.1.3").unwrap();
+    /// let date3 = Date::parse_from_str("1401.1.2").unwrap();
+    /// let date4 = Date::parse_from_str("1401.12.31").unwrap();
+    /// assert_eq!(1, date.days_until(&date2));
+    /// assert_eq!(365, date.days_until(&date3));
+    /// assert_eq!(728, date.days_until(&date4));
+    /// assert_eq!(-728, date4.days_until(&date));
+    /// ```
+    pub fn days_until(&self, other: &Date) -> i32 {
+        other.days() - self.days()
+    }
+
+    /// Return a new date that is the given number of days in the future
+    /// from the current date
+    ///
+    /// ```
+    /// use jomini::common::Date;
+    ///
+    /// let date = Date::parse_from_str("1400.1.2").unwrap();
+    /// let expected = Date::parse_from_str("1400.1.3").unwrap();
+    /// let expected2 = Date::parse_from_str("1400.1.1").unwrap();
+    /// assert_eq!(expected, date.add_days(1));
+    /// assert_eq!(expected2, date.add_days(-1));
+    /// ```
+    pub fn add_days(&self, days: i32) -> Date {
+        let new_days = self.days() + days;
+        let days_since_jan1 = new_days % 365;
+        let year = new_days / 365;
+        let (month, day) = month_day_from_julian(days_since_jan1);
+
+        Date {
+            year: year as u16,
+            month: month as u8,
+            day: day as u8,
+        }
+    }
+
+    /// Decodes a date from a number that had been parsed from binary data
+    pub fn from_binary(mut s: i32) -> Option<Self> {
+        let _hours = s % 24;
+        s /= 24;
+        let days_since_jan1 = s % 365;
+        s /= 365;
+        let year = s.checked_sub(5000).unwrap_or(0);
+        if year < 1 {
+            return None;
+        }
+
+        let (month, day) = month_day_from_julian(days_since_jan1);
+
+        Some(Date {
+            year: year as u16,
+            month: month as u8,
+            day: day as u8,
+        })
+    }
+
+    /// Formats a date in the ISO 8601 format: YYYY-MM-DD
+    ///
+    /// ```
+    /// use jomini::common::Date;
+    /// let date = Date::parse_from_str("1400.1.2").expect("to parse date");
+    /// assert_eq!(date.iso_8601(), String::from("1400-01-02"));
+    /// ```
+    pub fn iso_8601(&self) -> String {
+        format!("{:04}-{:02}-{:02}", self.year, self.month, self.day)
+    }
+
+    /// Formats a date in the game format: Y.M.D
+    ///
+    /// ```
+    /// use jomini::common::Date;
+    /// let date = Date::parse_from_str("1400.1.2").expect("to parse date");
+    /// let end_date = date.add_days(30);
+    /// assert_eq!(end_date.game_fmt(), String::from("1400.2.1"));
+    /// ```
+    pub fn game_fmt(&self) -> String {
+        format!("{}.{}.{}", self.year, self.month, self.day)
+    }
+}
+
+fn month_day_from_julian(days_since_jan1: i32) -> (i32, i32) {
+    // https://landweb.modaps.eosdis.nasa.gov/browse/calendar.html
+    // except we start at 0 instead of 1
+    match days_since_jan1 {
+        0..=30 => (1, days_since_jan1 + 1),
+        31..=58 => (2, days_since_jan1 - 30),
+        59..=89 => (3, days_since_jan1 - 58),
+        90..=119 => (4, days_since_jan1 - 89),
+        120..=150 => (5, days_since_jan1 - 119),
+        151..=180 => (6, days_since_jan1 - 150),
+        181..=211 => (7, days_since_jan1 - 180),
+        212..=242 => (8, days_since_jan1 - 211),
+        243..=272 => (9, days_since_jan1 - 242),
+        273..=303 => (10, days_since_jan1 - 272),
+        304..=333 => (11, days_since_jan1 - 303),
+        334..=364 => (12, days_since_jan1 - 333),
+        _ => unreachable!(),
+    }
+}
+
+#[cfg(feature = "derive")]
+mod datederive {
+    use super::Date;
+    use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+    use std::fmt;
+
+    impl Serialize for Date {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_str(self.iso_8601().as_str())
+        }
+    }
+
+    struct DateVisitor;
+
+    impl<'de> Visitor<'de> for DateVisitor {
+        type Value = Date;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a date")
+        }
+
+        fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Date::from_binary(v)
+                .ok_or_else(|| de::Error::custom(format!("invalid binary date: {}", v)))
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Date::parse_from_str(v).ok_or_else(|| de::Error::custom(format!("invalid date: {}", v)))
+        }
+
+        fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            self.visit_str(v.as_str())
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Date {
+        fn deserialize<D>(deserializer: D) -> Result<Date, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserializer.deserialize_any(DateVisitor)
+        }
+    }
+}
+
+#[cfg(not(feature = "derive"))]
+mod datederive {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_date_roundtrip() {
+        let date = Date::parse_from_str("1400.1.2").unwrap();
+        assert_eq!(date.iso_8601(), String::from("1400-01-02"));
+    }
+
+    #[test]
+    fn test_game_fmt() {
+        let test_cases = [
+            "1400.1.2",
+            "1457.3.5",
+            "1.1.1",
+            "1444.11.11",
+            "1444.11.30",
+            "1444.2.19",
+        ];
+
+        for case in &test_cases {
+            let date = Date::parse_from_str(case).unwrap();
+            assert_eq!(date.game_fmt(), case.to_string());
+        }
+    }
+
+    #[test]
+    fn test_first_bin_date() {
+        let date = Date::from_binary(56379360).unwrap();
+        assert_eq!(date.iso_8601(), String::from("1436-01-01"));
+    }
+
+    #[test]
+    fn test_november_date_regression() {
+        let date = Date::from_binary(56379360).unwrap().add_days(303);
+        assert_eq!(date.iso_8601(), String::from("1436-10-31"));
+        let date = Date::from_binary(56379360).unwrap().add_days(304);
+        assert_eq!(date.iso_8601(), String::from("1436-11-01"));
+        let date = Date::from_binary(56379360).unwrap().add_days(303 - 30);
+        assert_eq!(date.iso_8601(), String::from("1436-10-01"));
+        let date = Date::from_binary(56379360).unwrap().add_days(303 - 31);
+        assert_eq!(date.iso_8601(), String::from("1436-09-30"));
+        let date = Date::from_binary(56379360).unwrap().add_days(303 - 31 - 29);
+        assert_eq!(date.iso_8601(), String::from("1436-09-01"));
+        let date = Date::from_binary(56379360).unwrap().add_days(303 - 31 - 30);
+        assert_eq!(date.iso_8601(), String::from("1436-08-31"));
+    }
+
+    #[test]
+    fn test_past_leap_year_bin_date() {
+        let date = Date::from_binary(59611248).unwrap();
+        assert_eq!(date.iso_8601(), String::from("1804-12-09"));
+    }
+
+    #[test]
+    fn test_early_leap_year_bin_date() {
+        let date = Date::from_binary(57781584).unwrap();
+        assert_eq!(date.iso_8601(), String::from("1596-01-27"));
+    }
+
+    #[test]
+    fn test_non_leap_year_bin_date() {
+        let date = Date::from_binary(57775944).unwrap();
+        assert_eq!(date.iso_8601(), String::from("1595-06-06"));
+    }
+
+    #[test]
+    fn test_early_date() {
+        let date = Date::from_binary(43808760).unwrap();
+        assert_eq!(date.iso_8601(), String::from("0001-01-01"));
+    }
+
+    #[test]
+    fn test_days_until() {
+        let date = Date::parse_from_str("1400.1.2").unwrap();
+        let date2 = Date::parse_from_str("1400.1.3").unwrap();
+        assert_eq!(1, date.days_until(&date2));
+    }
+
+    #[test]
+    fn test_days_until2() {
+        let date = Date::parse_from_str("1400.1.2").unwrap();
+        let date2 = Date::parse_from_str("1401.1.2").unwrap();
+        assert_eq!(365, date.days_until(&date2));
+    }
+
+    #[test]
+    fn test_days_until3() {
+        let date = Date::parse_from_str("1400.1.1").unwrap();
+        let date2 = Date::parse_from_str("1401.12.31").unwrap();
+        assert_eq!(729, date.days_until(&date2));
+    }
+
+    #[test]
+    fn test_days_until4() {
+        let date = Date::parse_from_str("1400.1.2").unwrap();
+        let date2 = Date::parse_from_str("1400.1.2").unwrap();
+        assert_eq!(0, date.days_until(&date2));
+    }
+
+    #[test]
+    fn test_days_until5() {
+        let date = Date::parse_from_str("1400.1.1").unwrap();
+        let date2 = Date::parse_from_str("1401.12.31").unwrap();
+        assert_eq!(-729, date2.days_until(&date));
+    }
+
+    #[test]
+    fn test_add_days() {
+        let date = Date::parse_from_str("1400.1.2").unwrap();
+        let actual = date.add_days(1);
+        let expected = Date::parse_from_str("1400.1.3").unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_add_days2() {
+        let date = Date::parse_from_str("1400.1.2").unwrap();
+        let actual = date.add_days(365);
+        let expected = Date::parse_from_str("1401.1.2").unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_add_days3() {
+        let date = Date::parse_from_str("1400.1.1").unwrap();
+        let actual = date.add_days(729);
+        let expected = Date::parse_from_str("1401.12.31").unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_add_days4() {
+        let date = Date::parse_from_str("1400.1.2").unwrap();
+        let actual = date.add_days(0);
+        let expected = Date::parse_from_str("1400.1.2").unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_all_days() {
+        let start = Date::parse_from_str("1400.1.1").unwrap();
+        for i in 0..364 {
+            let (month, day) = month_day_from_julian(i);
+            let next = Date::parse_from_str(format!("1400.{}.{}", month, day)).unwrap();
+            assert_eq!(start.add_days(i), next);
+            assert_eq!(start.days_until(&next), i);
+        }
+    }
+
+    #[test]
+    fn test_cmp() {
+        let date = Date::parse_from_str("1457.3.5").unwrap();
+        let date2 = Date::parse_from_str("1457.3.4").unwrap();
+        assert!(date2 < date);
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,0 +1,4 @@
+//! Common data structures used across games
+mod date;
+
+pub use date::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,7 @@ features, resulting in a build without dependencies.
 
 pub(crate) mod ascii;
 mod binary;
+pub mod common;
 mod data;
 #[cfg(feature = "derive")]
 pub(crate) mod de;

--- a/tests/meta.rs
+++ b/tests/meta.rs
@@ -9,7 +9,7 @@ struct SaveVersion(pub String);
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 struct Meta {
-    date: eu4save::Eu4Date,
+    date: jomini::common::Date,
     save_game: String,
     player: String,
     displayed_country_name: String,
@@ -120,7 +120,7 @@ fn test_text_deserialization() {
     let data = include_bytes!("./fixtures/meta.txt");
     let actual: Meta =
         jomini::TextDeserializer::from_windows1252_slice(&data["EU4txt".len()..]).unwrap();
-    assert_eq!(actual.date.eu4_fmt(), String::from("1444.11.11"));
+    assert_eq!(actual.date.game_fmt(), String::from("1444.11.11"));
     assert_eq!(actual.savegame_version.0, String::from("1.28.3.0"));
 }
 
@@ -168,7 +168,7 @@ fn test_binary_meta_deserialization() {
     let data = &data["EU4bin".len()..];
     let hash = create_bin_lookup();
     let actual: Meta = jomini::BinaryDeserializer::from_eu4(&data, &hash).unwrap();
-    assert_eq!(actual.date.eu4_fmt(), String::from("1597.1.15"));
+    assert_eq!(actual.date.game_fmt(), String::from("1597.1.15"));
     assert_eq!(actual.savegame_version.0, String::from("1.29.4.0"));
 }
 


### PR DESCRIPTION
Three downstream projects use a common date implementation:

 - eu4
 - ck3
 - imperator

Copying and pasting this code to every project is error prone,
especially when there are bugfixes, features, or performance changes
made in one, it has to be replicated to the rest.

So I decided to create a common module to store data structures that may
be common across games.

It should be noted that HOI4 saves use hours and the binary format
includes hours (this implementation just ignores it), so there is a case
for adding hour data. This commit doesn't as I've yet to decide how to
best to ensure that games that can't represent hours use data structures
that don't have hours. More pondering is necessary.

Closes #30 