### PR TITLE
Add operator text token

### DIFF
--- a/src/binary/tape.rs
+++ b/src/binary/tape.rs
@@ -11,6 +11,9 @@ pub enum BinaryToken<'a> {
     Array(usize),
 
     /// Index of the `BinaryToken::End` that signifies this object's termination
+    ///
+    /// A key's value immediately follows the key. Unlike the text format, the binary
+    /// format is more strict
     Object(usize),
 
     /// Index of the start of this object

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -4,4 +4,4 @@ mod tape;
 
 #[cfg(feature = "derive")]
 pub use self::de::TextDeserializer;
-pub use self::tape::{TextTape, TextToken};
+pub use self::tape::{Operator, TextTape, TextToken};

--- a/tests/tape.rs
+++ b/tests/tape.rs
@@ -1,11 +1,27 @@
+use jomini::{BinaryTape, Operator, Scalar, TextTape, TextToken};
+
 #[test]
 fn reject_bin_obj_in_hidden_obj() {
     let data = include_bytes!("./fixtures/nested-hidden-obj.bin");
-    assert!(jomini::BinaryTape::from_eu4(&data[..]).is_err());
+    assert!(BinaryTape::from_eu4(&data[..]).is_err());
 }
 
 #[test]
 fn reject_txt_obj_in_hidden_obj() {
     let data = include_bytes!("./fixtures/nested-hidden-obj.txt");
-    assert!(jomini::TextTape::from_slice(&data[..]).is_err());
+    assert!(TextTape::from_slice(&data[..]).is_err());
+}
+
+#[test]
+fn test_greater_than_operator() {
+    let data = b"age > 16";
+    let tape = TextTape::from_slice(&data[..]).unwrap();
+    assert_eq!(
+        tape.tokens(),
+        vec![
+            TextToken::Scalar(Scalar::new(b"age")),
+            TextToken::Operator(Operator::GreaterThan),
+            TextToken::Scalar(Scalar::new(b"16")),
+        ]
+    );
 }


### PR DESCRIPTION
This adds supports for parsing non-equal operators from text data:

```
val < 3
val <= 3
val > 3
val >= 3
```

This is done by pushing a `TextToken::Operator` into the tape. Note that
this operator will only appear if an operator is present and is
non-equal. Since equals account for all operators in saves, and saves
have millions of tokens, potentially adding 1/3 more tokens is dangerous
for performance and memory usage for very little gain.

Benchmarks show this change created a low single digit performance
degradation but I find this tradeoff worth it.