### PR TITLE
Expose hidden objects as Text / Binary token

### DIFF
--- a/fuzz/fuzz_targets/fuzz_binary.rs
+++ b/fuzz/fuzz_targets/fuzz_binary.rs
@@ -48,10 +48,11 @@ fuzz_target!(|data: &[u8]| {
             match token {
                 jomini::BinaryToken::Array(ind) |
                 jomini::BinaryToken::Object(ind) |
+                jomini::BinaryToken::HiddenObject(ind) |
                 jomini::BinaryToken::End(ind) if *ind == 0 => {
                     panic!("zero ind encountered");
                 }
-                jomini::BinaryToken::Array(ind) | jomini::BinaryToken::Object(ind) => {
+                jomini::BinaryToken::Array(ind) | jomini::BinaryToken::Object(ind) | jomini::BinaryToken::HiddenObject(ind) => {
                     match tokens[*ind] {
                         jomini::BinaryToken::End(ind2) => {
                             assert_eq!(ind2, i)

--- a/fuzz/fuzz_targets/fuzz_text.rs
+++ b/fuzz/fuzz_targets/fuzz_text.rs
@@ -32,10 +32,11 @@ fuzz_target!(|data: &[u8]| {
                 match token {
                     jomini::TextToken::Array(ind) |
                     jomini::TextToken::Object(ind) |
+                    jomini::TextToken::HiddenObject(ind) |
                     jomini::TextToken::End(ind) if *ind == 0 => {
                         panic!("zero ind encountered");
                     }
-                    jomini::TextToken::Array(ind) | jomini::TextToken::Object(ind) => {
+                    jomini::TextToken::Array(ind) | jomini::TextToken::Object(ind) | jomini::TextToken::HiddenObject(ind) => {
                         match tokens[*ind] {
                             jomini::TextToken::End(ind2) => {
                                 assert_eq!(ind2, i)

--- a/src/text/de.rs
+++ b/src/text/de.rs
@@ -204,8 +204,7 @@ where
                 };
 
                 let next_key = match self.tokens[self.value_ind] {
-                    TextToken::Array(x) => x,
-                    TextToken::Object(x) => x,
+                    TextToken::Array(x) | TextToken::Object(x) | TextToken::HiddenObject(x) => x,
                     TextToken::End(_) => {
                         // this really shouldn't happen but if it does we just
                         // move our sights to the end token and continue on
@@ -564,7 +563,7 @@ where
                 encoding: self.encoding,
             }),
             TextToken::Rgb(x) => visitor.visit_seq(ColorSequence::new(*x)),
-            TextToken::Object(x) => {
+            TextToken::Object(x) | TextToken::HiddenObject(x) => {
                 visitor.visit_map(BinaryMap::new(self.tokens, idx + 1, *x, self.encoding))
             }
             TextToken::End(_x) => Err(DeserializeError {
@@ -756,7 +755,7 @@ where
     {
         let idx = self.value_ind;
         match &self.tokens[idx] {
-            TextToken::Object(x) => {
+            TextToken::Object(x) | TextToken::HiddenObject(x) => {
                 visitor.visit_map(BinaryMap::new(self.tokens, idx + 1, *x, self.encoding))
             }
 
@@ -799,7 +798,7 @@ where
         V: Visitor<'de>,
     {
         match &self.tokens[self.de_idx] {
-            TextToken::Object(x) => visitor.visit_map(BinaryMap::new(
+            TextToken::Object(x) | TextToken::HiddenObject(x) => visitor.visit_map(BinaryMap::new(
                 self.tokens,
                 self.de_idx + 1,
                 *x,
@@ -941,8 +940,7 @@ where
             Ok(None)
         } else {
             let next_key = match self.tokens[self.idx] {
-                TextToken::Array(x) => x,
-                TextToken::Object(x) => x,
+                TextToken::Array(x) | TextToken::Object(x) | TextToken::HiddenObject(x) => x,
                 _ => self.idx,
             };
 


### PR DESCRIPTION
To recap, hidden objects (aka as object headers) look like:

```
a = { 10 0=1 1=2 }
```

It's currently parsed as equivalent to an array of two values (`10` and
an object):

```
a = { 10 { 0=1 1=2 } }
```

The current API doesn't expose to the client if the object they are
looking at has been hidden inside an array. This is important to melters
(binary -> plaintext) as we want to be able to preserve the correct
structure in the conversion.

To fix this, `BinaryToken::HiddenObject` and `TextToken::HiddenObject`
were introduced. They behave exactly like regular objects except that
they denote the object is hidden.