### PR TITLE
Add support for generic token headers

### DIFF
--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -1460,9 +1460,9 @@ mod tests {
 
         #[derive(Debug, PartialEq)]
         struct Color {
-            red: i32,
-            blue: i32,
-            green: i32,
+            red: u8,
+            blue: u8,
+            green: u8,
         }
 
         impl<'de> Deserialize<'de> for Color {
@@ -1483,18 +1483,14 @@ mod tests {
                     where
                         A: de::SeqAccess<'de>,
                     {
-                        let r = seq.next_element::<i32>()?.expect("red to be present");
-                        let g = seq.next_element::<i32>()?.expect("green to be present");
-                        let b = seq.next_element::<i32>()?.expect("blue to be present");
-
-                        if seq.next_element::<de::IgnoredAny>()?.is_some() {
-                            Err(de::Error::custom("unexpected extra rgb value"))
-                        } else {
-                            Ok(Color {
-                                red: r,
-                                blue: b,
-                                green: g,
-                            })
+                        let ty = seq.next_element::<&str>()?.expect("value type");
+                        match ty {
+                            "rgb" => {
+                                let (red, green, blue) =
+                                    seq.next_element::<(u8, u8, u8)>()?.expect("rgb channels");
+                                Ok(Color { red, green, blue })
+                            }
+                            _ => panic!("unexpected color type"),
                         }
                     }
                 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -12,6 +12,55 @@ impl ColorSequence {
     pub(crate) fn new(data: Rgb) -> Self {
         ColorSequence { data, idx: 0 }
     }
+}
+
+impl<'b, 'de, 'r> de::Deserializer<'de> for &'r mut ColorSequence {
+    type Error = DeserializeError;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.idx == 1 {
+            visitor.visit_borrowed_str("rgb")
+        } else {
+            visitor.visit_seq(InnerColorSequence::new(self.data))
+        }
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+impl<'b, 'de> SeqAccess<'de> for ColorSequence {
+    type Error = DeserializeError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        if self.idx >= 2 {
+            Ok(None)
+        } else {
+            self.idx += 1;
+            seed.deserialize(self).map(Some)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct InnerColorSequence {
+    data: Rgb,
+    idx: usize,
+}
+
+impl InnerColorSequence {
+    pub(crate) fn new(data: Rgb) -> Self {
+        InnerColorSequence { data, idx: 0 }
+    }
 
     fn val(&self) -> u32 {
         match self.idx {
@@ -23,7 +72,7 @@ impl ColorSequence {
     }
 }
 
-impl<'b, 'de, 'r> de::Deserializer<'de> for &'r mut ColorSequence {
+impl<'b, 'de, 'r> de::Deserializer<'de> for &'r mut InnerColorSequence {
     type Error = DeserializeError;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -40,7 +89,7 @@ impl<'b, 'de, 'r> de::Deserializer<'de> for &'r mut ColorSequence {
     }
 }
 
-impl<'b, 'de> SeqAccess<'de> for ColorSequence {
+impl<'b, 'de> SeqAccess<'de> for InnerColorSequence {
     type Error = DeserializeError;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ assert_eq!(
 If one will only use `TextTape` and `BinaryTape` then `jomini` can be compiled without default
 features, resulting in a build without dependencies.
 */
-
+#![warn(missing_docs)]
 pub(crate) mod ascii;
 mod binary;
 pub mod common;

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -1,0 +1,82 @@
+#![cfg(feature = "derive")]
+
+use jomini::{BinaryDeserializer, TextDeserializer};
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer,
+};
+use std::collections::HashMap;
+use std::fmt;
+
+#[test]
+fn same_deserializer_for_header_token() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct MyStruct {
+        color: Color,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct Color {
+        red: u8,
+        blue: u8,
+        green: u8,
+    }
+
+    let bin_data = [
+        0x3a, 0x05, 0x01, 0x00, 0x43, 0x02, 0x03, 0x00, 0x14, 0x00, 0x6e, 0x00, 0x00, 0x00, 0x14,
+        0x00, 0x1b, 0x00, 0x00, 0x00, 0x14, 0x00, 0x1b, 0x00, 0x00, 0x00, 0x04, 0x00,
+    ];
+
+    let mut map = HashMap::new();
+    map.insert(0x053a, "color");
+
+    let txt_data = b"color = rgb { 110 27 27 }";
+
+    let bin_out: MyStruct = BinaryDeserializer::from_eu4(&bin_data[..], &map).unwrap();
+    let txt_out: MyStruct = TextDeserializer::from_windows1252_slice(&txt_data[..]).unwrap();
+    assert_eq!(bin_out, txt_out);
+    assert_eq!(
+        bin_out,
+        MyStruct {
+            color: Color {
+                red: 110,
+                blue: 27,
+                green: 27,
+            }
+        }
+    );
+
+    impl<'de> Deserialize<'de> for Color {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct ColorVisitor;
+
+            impl<'de> Visitor<'de> for ColorVisitor {
+                type Value = Color;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("a color")
+                }
+
+                fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                where
+                    A: de::SeqAccess<'de>,
+                {
+                    let ty = seq.next_element::<&str>()?.expect("value type");
+                    match ty {
+                        "rgb" => {
+                            let (red, green, blue) =
+                                seq.next_element::<(u8, u8, u8)>()?.expect("rgb channels");
+                            Ok(Color { red, green, blue })
+                        }
+                        _ => panic!("unexpected color type"),
+                    }
+                }
+            }
+
+            deserializer.deserialize_seq(ColorVisitor)
+        }
+    }
+}


### PR DESCRIPTION
Given the format of

```
<key> = <header> { <data> }
```

This PR introduces the support for arbitrary header values. Previously
only `rgb` was supported for text parsing. This was made generic to
allow for other formats such as:

```
color = hsv { 0.58 1.00 0.72 }
color = rgb { 169 242 27 }
color = hsv360{ 25 75 63 }
position = cylindrical{ 150 3 0 }
color5 = hex { aabbccdd }
mild_winter = LIST { 3700 3701
    # ...
}
```
Since new headers can be introduced whenever, it may not make sense to
hard code in the entire list as then then there would be too many text
tokens related to this syntax. I want to avoid `TextToken::{Rgb, Hsv,
Hsv360, ...}` as that seems like pollution at the lowest level. So
`TextToken::Rgb` was removed in favor of `TextToken::Header("rgb")`. As
can imagine a header token describes the subsequent token in the tape.

The binary parser keeps its Rgb token as that is the only token that has
thus far appeared in binary data.

Another factor that has changed is deserialization. Previously Rgb for
both text and binary would deserialize as a 3 element integer sequence
but with the concept of headers (and the goal that one should be able to
use the same deserializer for both binary and text), this has changed so
that they yield the header as the first element followed by the data
element.