### PR TITLE
Micro-optimize to_u64 for 7% perf gain

### DIFF
--- a/benches/jomini_bench.rs
+++ b/benches/jomini_bench.rs
@@ -69,7 +69,7 @@ pub fn utf8_benchmark(c: &mut Criterion) {
 
 pub fn to_u64_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("to_u64");
-    for input in [&b"1444"[..], &b"20405029"[..]].iter() {
+    for input in [&b"7"[..], &b"1444"[..], &b"20405029"[..]].iter() {
         let data = Scalar::new(input);
         let ins = std::str::from_utf8(input).unwrap();
         group.bench_with_input(BenchmarkId::from_parameter(ins), &data, |b, &data| {


### PR DESCRIPTION
Most integers in PDS files are short:

- 17 (one integer)
- 1.000 (two integers)
- 1444.3.5 (three integers)

The previous implementation had been optimized for throughput on long
numbers. By refocusing the method for shorter lengths, `to_u64` became
2x fast for shorter values.

Long numbers did take a hit in the benchmarks (33% slower) but in a real
world 120MB save, this optimization shaved 7% off total time to parse +
deserialize