### PR TITLE
Introduce a mid-level API

### DIFF
--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -1,10 +1,10 @@
+use super::tape::{array_len, object_len};
 use crate::{
     de::ColorSequence, BinaryFlavor, BinaryTape, BinaryToken, Ck3Flavor, DeserializeError,
     DeserializeErrorKind, Encoding, Error, Eu4Flavor, FailedResolveStrategy, TokenResolver,
 };
 use serde::de::{self, Deserialize, DeserializeSeed, MapAccess, SeqAccess, Visitor};
 use std::borrow::Cow;
-use super::tape::{array_len, object_len};
 
 /// A structure to deserialize binary data into Rust values.
 ///

--- a/src/binary/tape.rs
+++ b/src/binary/tape.rs
@@ -5,7 +5,7 @@ use crate::{
 use crate::{BinaryFlavor, Error, ErrorKind, Eu4Flavor, Rgb, Scalar};
 
 /// Represents any valid binary value
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum BinaryToken<'a> {
     /// Index of the `BinaryToken::End` that signifies this array's termination
     Array(usize),

--- a/src/binary/tape.rs
+++ b/src/binary/tape.rs
@@ -710,7 +710,9 @@ pub(crate) fn object_len(tokens: &[BinaryToken], mut key_idx: usize) -> usize {
 
         let val_ind = key_idx + 1;
         key_idx = match tokens.get(val_ind) {
-            Some(BinaryToken::Array(x)) | Some(BinaryToken::Object(x)) | Some(BinaryToken::HiddenObject(x)) => x + 1,
+            Some(BinaryToken::Array(x))
+            | Some(BinaryToken::Object(x))
+            | Some(BinaryToken::HiddenObject(x)) => x + 1,
             _ => val_ind + 1,
         };
 
@@ -1283,7 +1285,7 @@ mod tests {
             BinaryToken::Token(0x0000),
             BinaryToken::Token(0x0001),
             BinaryToken::Token(0x0002),
-            BinaryToken::Token(0x0003)
+            BinaryToken::Token(0x0003),
         ];
 
         assert_eq!(object_len(&tokens, 0), 2);

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -33,7 +33,7 @@ pub trait Encoding: Sized {
 /// assert_eq!(encoding.decode(b"\xfe\xff\xfe\xff\xfe\xff\xfe\xff\xfe\xff"), "þÿþÿþÿþÿþÿ");
 /// assert_eq!(encoding.decode(b"hi\x81\x8a"), "hi\u{81}Š");
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct Windows1252Encoding;
 
 impl Windows1252Encoding {
@@ -72,7 +72,7 @@ impl<T: Encoding> Encoding for &'_ T {
 /// assert_eq!(encoding.decode(b"J\xc3\xa5hk\xc3\xa5m\xc3\xa5hkke"), "Jåhkåmåhkke");
 /// assert_eq!(encoding.decode("Jåhkåmåhkke".as_bytes()), "Jåhkåmåhkke");
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct Utf8Encoding;
 
 impl Utf8Encoding {

--- a/src/text/de.rs
+++ b/src/text/de.rs
@@ -485,6 +485,10 @@ where
         let _ = std::mem::replace(&mut self.de.readers, old);
         res
     }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.reader.fields_len())
+    }
 }
 
 struct SeqAccess<'a, 'de, 'tokens, E> {
@@ -510,6 +514,10 @@ where
         } else {
             Ok(None)
         }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.reader.values_len())
     }
 }
 

--- a/src/text/de.rs
+++ b/src/text/de.rs
@@ -100,9 +100,7 @@ impl TextDeserializer {
         E: Encoding + Clone,
     {
         let reader = Reader::Object(ObjectReader::new(tape, encoding));
-        let mut root = InternalDeserializer {
-            readers: reader,
-        };
+        let mut root = InternalDeserializer { readers: reader };
         Ok(T::deserialize(&mut root)?)
     }
 }

--- a/src/text/de.rs
+++ b/src/text/de.rs
@@ -149,7 +149,7 @@ where
             Reader::Value(x) => match x.token() {
                 TextToken::Scalar(s) => visit_str!(x.decode(s.view_data()), visitor),
                 TextToken::Header(_) | TextToken::Array(_) => self.deserialize_seq(visitor),
-                TextToken::Object(_) => self.deserialize_map(visitor),
+                TextToken::Object(_) | TextToken::HiddenObject(_) => self.deserialize_map(visitor),
                 _ => Err(DeserializeError {
                     kind: DeserializeErrorKind::Unsupported(String::from(
                         "unsupported value reader token",

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "derive")]
 mod de;
+mod reader;
 mod tape;
 
 #[cfg(feature = "derive")]
 pub use self::de::TextDeserializer;
+pub use self::reader::{ArrayReader, ObjectReader, Reader, ScalarReader, ValueReader};
 pub use self::tape::{Operator, TextTape, TextToken};

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -1,0 +1,330 @@
+use crate::{
+    DeserializeError, DeserializeErrorKind, Encoding, Operator, Scalar, TextTape, TextToken,
+};
+use std::borrow::Cow;
+
+pub type KeyValue<'data, 'tokens, E> = (
+    ScalarReader<'data, E>,
+    Option<Operator>,
+    ValueReader<'data, 'tokens, E>,
+);
+
+fn next_idx_header(tokens: &[TextToken], idx: usize) -> usize {
+    match tokens[idx] {
+        TextToken::Array(x) | TextToken::Object(x) | TextToken::HiddenObject(x) => x + 1,
+        TextToken::Operator(_) => idx + 2,
+        _ => idx + 1,
+    }
+}
+
+fn next_idx(tokens: &[TextToken], idx: usize) -> usize {
+    match tokens[idx] {
+        TextToken::Array(x) | TextToken::Object(x) | TextToken::HiddenObject(x) => x + 1,
+        TextToken::Operator(_) => idx + 2,
+        TextToken::Header(_) => next_idx_header(tokens, idx + 1),
+        _ => idx + 1,
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Reader<'data, 'tokens, E> {
+    Object(ObjectReader<'data, 'tokens, E>),
+    Array(ArrayReader<'data, 'tokens, E>),
+    Scalar(ScalarReader<'data, E>),
+    Value(ValueReader<'data, 'tokens, E>),
+}
+
+impl<'data, 'tokens, E> Reader<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    pub fn read_str(&self) -> Result<Cow<'data, str>, DeserializeError> {
+        match &self {
+            Reader::Scalar(x) => Ok(x.read_str()),
+            Reader::Value(x) => x.read_str(),
+            _ => Err(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+            }),
+        }
+    }
+
+    pub fn read_string(&self) -> Result<String, DeserializeError> {
+        match &self {
+            Reader::Scalar(x) => Ok(x.read_string()),
+            Reader::Value(x) => x.read_string(),
+            _ => Err(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+            }),
+        }
+    }
+
+    pub fn read_scalar(&self) -> Result<Scalar<'data>, DeserializeError> {
+        match &self {
+            Reader::Scalar(x) => Ok(x.read_scalar()),
+            Reader::Value(x) => x.read_scalar(),
+            _ => Err(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ObjectReader<'data, 'tokens, E> {
+    token_ind: usize,
+    end_ind: usize,
+    tokens: &'tokens [TextToken<'data>],
+    encoding: E,
+}
+
+impl<'data, 'tokens, E> ObjectReader<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    pub fn new(tape: &'tokens TextTape<'data>, encoding: E) -> Self {
+        let tokens = tape.tokens();
+        ObjectReader {
+            tokens,
+            end_ind: tokens.len(),
+            token_ind: 0,
+            encoding,
+        }
+    }
+
+    pub fn next_field(&mut self) -> Option<KeyValue<'data, 'tokens, E>> {
+        if self.token_ind < self.end_ind {
+            let key_ind = self.token_ind;
+            let key_scalar = match self.tokens[key_ind] {
+                TextToken::Scalar(x) => x,
+                _ => panic!("AAAA"),
+            };
+            let key_reader = self.new_scalar_reader(key_scalar);
+
+            let (op, value_ind) = match self.tokens[key_ind + 1] {
+                TextToken::Operator(x) => (Some(x), key_ind + 2),
+                _ => (None, key_ind + 1),
+            };
+            let value_reader = self.new_value_reader(value_ind);
+            self.token_ind = next_idx(self.tokens, value_ind);
+            Some((key_reader, op, value_reader))
+        } else {
+            None
+        }
+    }
+
+    fn new_scalar_reader(&self, scalar: Scalar<'data>) -> ScalarReader<'data, E> {
+        ScalarReader {
+            scalar,
+            encoding: self.encoding.clone(),
+        }
+    }
+
+    fn new_value_reader(&self, value_ind: usize) -> ValueReader<'data, 'tokens, E> {
+        ValueReader {
+            value_ind,
+            tokens: self.tokens,
+            encoding: self.encoding.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ScalarReader<'data, E> {
+    scalar: Scalar<'data>,
+    encoding: E,
+}
+
+impl<'data, E> ScalarReader<'data, E>
+where
+    E: Encoding,
+{
+    pub fn read_str(&self) -> Cow<'data, str> {
+        self.encoding.decode(self.scalar.view_data())
+    }
+
+    pub fn read_string(&self) -> String {
+        self.encoding.decode(self.scalar.view_data()).into_owned()
+    }
+
+    pub fn read_scalar(&self) -> Scalar<'data> {
+        self.scalar
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ValueReader<'data, 'tokens, E> {
+    value_ind: usize,
+    tokens: &'tokens [TextToken<'data>],
+    encoding: E,
+}
+
+impl<'data, 'tokens, E> ValueReader<'data, 'tokens, E> {
+    pub fn token(&self) -> &TextToken<'data> {
+        &self.tokens[self.value_ind]
+    }
+}
+
+impl<'data, 'tokens, E> Encoding for ValueReader<'data, 'tokens, E>
+where
+    E: Encoding,
+{
+    fn decode<'a>(&self, data: &'a [u8]) -> Cow<'a, str> {
+        self.encoding.decode(data)
+    }
+}
+
+impl<'data, 'tokens, E> ValueReader<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    pub fn read_str(&self) -> Result<Cow<'data, str>, DeserializeError> {
+        self.tokens[self.value_ind]
+            .as_scalar()
+            .map(|x| self.encoding.decode(x.view_data()))
+            .ok_or_else(|| DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+            })
+    }
+
+    pub fn read_string(&self) -> Result<String, DeserializeError> {
+        self.tokens[self.value_ind]
+            .as_scalar()
+            .map(|x| self.encoding.decode(x.view_data()).into_owned())
+            .ok_or_else(|| DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+            })
+    }
+
+    pub fn read_scalar(&self) -> Result<Scalar<'data>, DeserializeError> {
+        self.tokens[self.value_ind]
+            .as_scalar()
+            .ok_or_else(|| DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+            })
+    }
+
+    pub fn read_object(&self) -> Result<ObjectReader<'data, 'tokens, E>, DeserializeError> {
+        match self.tokens[self.value_ind] {
+            TextToken::Object(ind) => Ok(ObjectReader {
+                tokens: self.tokens,
+                token_ind: self.value_ind + 1,
+                end_ind: ind,
+                encoding: self.encoding.clone(),
+            }),
+
+            // An array can be an object if it is empty
+            TextToken::Array(ind) if ind == self.value_ind + 1 => Ok(ObjectReader {
+                tokens: self.tokens,
+                token_ind: self.value_ind + 1,
+                end_ind: ind,
+                encoding: self.encoding.clone(),
+            }),
+            _ => Err(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not an object")),
+            }),
+        }
+    }
+
+    pub fn read_array(&self) -> Result<ArrayReader<'data, 'tokens, E>, DeserializeError> {
+        match self.tokens[self.value_ind] {
+            TextToken::Array(ind) => Ok(ArrayReader {
+                tokens: self.tokens,
+                token_ind: self.value_ind + 1,
+                end_ind: ind,
+                encoding: self.encoding.clone(),
+            }),
+
+            // A header can be seen as a two element array
+            TextToken::Header(_) => Ok(ArrayReader {
+                tokens: self.tokens,
+                token_ind: self.value_ind,
+                end_ind: next_idx(self.tokens, self.value_ind),
+                encoding: self.encoding.clone(),
+            }),
+
+            _ => Err(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not an array")),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ArrayReader<'data, 'tokens, E> {
+    token_ind: usize,
+    end_ind: usize,
+    tokens: &'tokens [TextToken<'data>],
+    encoding: E,
+}
+
+impl<'data, 'tokens, E> ArrayReader<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    pub fn next_value(&mut self) -> Option<ValueReader<'data, 'tokens, E>> {
+        if self.token_ind < self.end_ind {
+            let value_ind = self.token_ind;
+            self.token_ind = next_idx_header(self.tokens, self.token_ind);
+            Some(ValueReader {
+                value_ind,
+                tokens: self.tokens,
+                encoding: self.encoding.clone(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_text_reader_text() {
+        let data = b"foo=bar";
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+
+        let (key, _op, value) = reader.next_field().unwrap();
+        assert_eq!(key.read_string(), String::from("foo"));
+        assert_eq!(value.read_string().unwrap(), String::from("bar"));
+
+        assert!(reader.next_field().is_none());
+    }
+
+    #[test]
+    fn simple_text_reader_obj() {
+        let data = b"foo={bar=qux}";
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+
+        let (key, _op, value) = reader.next_field().unwrap();
+        assert_eq!(key.read_string(), String::from("foo"));
+
+        let mut nested = value.read_object().unwrap();
+        let (key2, _op, value2) = nested.next_field().unwrap();
+        assert_eq!(key2.read_string(), String::from("bar"));
+        assert_eq!(value2.read_string().unwrap(), String::from("qux"));
+        assert!(nested.next_field().is_none());
+        assert!(reader.next_field().is_none());
+    }
+
+    #[test]
+    fn simple_text_reader_array() {
+        let data = b"foo={bar qux}";
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+
+        let (key, _op, value) = reader.next_field().unwrap();
+        assert_eq!(key.read_string(), String::from("foo"));
+
+        let mut nested = value.read_array().unwrap();
+        let value1 = nested.next_value().unwrap().read_string().unwrap();
+        let value2 = nested.next_value().unwrap().read_string().unwrap();
+
+        assert!(nested.next_value().is_none());
+        assert_eq!(value1, String::from("bar"));
+        assert_eq!(value2, String::from("qux"));
+    }
+}

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -1,12 +1,17 @@
 use crate::{
     DeserializeError, DeserializeErrorKind, Encoding, Operator, Scalar, TextTape, TextToken,
 };
-use std::borrow::Cow;
+use std::{borrow::Cow};
 
 pub type KeyValue<'data, 'tokens, E> = (
     ScalarReader<'data, E>,
     Option<Operator>,
     ValueReader<'data, 'tokens, E>,
+);
+
+pub type KeyValues<'data, 'tokens, E> = (
+    ScalarReader<'data, E>,
+    Vec<ValueReader<'data, 'tokens, E>>,
 );
 
 /// Calculate what index the next value is. This assumes that a header + value
@@ -84,6 +89,8 @@ pub struct ObjectReader<'data, 'tokens, E> {
     end_ind: usize,
     tokens: &'tokens [TextToken<'data>],
     encoding: E,
+    val_ind: usize,
+    seen: Vec<bool>
 }
 
 impl<'data, 'tokens, E> ObjectReader<'data, 'tokens, E>
@@ -96,8 +103,26 @@ where
             tokens,
             end_ind: tokens.len(),
             token_ind: 0,
+            val_ind: 0,
             encoding,
+            seen: Vec::new(),
         }
+    }
+
+    pub fn fields_len(&self) -> usize {
+        let mut ind = self.token_ind;
+        let mut count = 0;
+        while ind < self.end_ind {
+            let key_ind = ind;
+            let value_ind = match self.tokens[key_ind + 1] {
+                TextToken::Operator(_) => key_ind + 2,
+                _ => key_ind + 1,
+            };
+            ind = next_idx(self.tokens, value_ind);
+            count += 1;
+        }
+
+        count
     }
 
     #[inline]
@@ -125,6 +150,65 @@ where
         } else {
             None
         }
+    }
+
+    #[inline]
+    pub fn next_fields(&mut self) -> Option<KeyValues<'data, 'tokens, E>> {
+        if self.val_ind == 0 {
+            self.seen = vec![false; self.fields_len()];
+        }
+
+        let mut values = Vec::new();
+        while self.token_ind < self.end_ind {
+            if !self.seen[self.val_ind] {
+                let key_ind = self.token_ind;
+                let key = &self.tokens[self.token_ind];
+                self.seen[self.val_ind] = true;
+                let key_scalar = if let &TextToken::Scalar(x) = key {
+                    x
+                } else {
+                    // this is a broken invariant, so we safely recover by saying the object
+                    // has no more fields
+                    debug_assert!(false, "All keys should be scalars");
+                    return None;
+                };
+
+                let key_reader = self.new_scalar_reader(key_scalar);
+                let value_ind = match self.tokens[key_ind + 1] {
+                    TextToken::Operator(_) => key_ind + 2,
+                    _ => key_ind + 1,
+                };
+
+                self.token_ind = next_idx(self.tokens, value_ind);
+                let value_reader = self.new_value_reader(value_ind);
+                values.push(value_reader);
+
+                let mut future = self.token_ind;
+                let mut future_ind = self.val_ind + 1;
+                while future < self.end_ind {
+                    if !self.seen[future_ind] && self.tokens[future] == *key {
+                        let value_ind = match self.tokens[future + 1] {
+                            TextToken::Operator(_) => future + 2,
+                            _ => future + 1,
+                        };
+                        self.seen[future_ind] = true;
+                        let value_reader = self.new_value_reader(value_ind);
+                        values.push(value_reader);
+                    }
+                    future_ind += 1;
+                    future = next_idx(self.tokens, future + 1);
+                }
+
+                self.val_ind += 1;
+                dbg!(&self.seen);
+                return Some((key_reader, values));
+            } else {
+                self.val_ind += 1;
+                self.token_ind = next_idx(self.tokens, self.val_ind + 1);
+            }
+        }
+
+        None
     }
 
     #[inline]
@@ -234,7 +318,9 @@ where
             TextToken::Object(ind) | TextToken::HiddenObject(ind) => Ok(ObjectReader {
                 tokens: self.tokens,
                 token_ind: self.value_ind + 1,
+                val_ind: 0,
                 end_ind: ind,
+                seen: Vec::new(),
                 encoding: self.encoding.clone(),
             }),
 
@@ -242,8 +328,10 @@ where
             TextToken::Array(ind) if ind == self.value_ind + 1 => Ok(ObjectReader {
                 tokens: self.tokens,
                 token_ind: self.value_ind + 1,
+                val_ind: 0,
                 end_ind: ind,
                 encoding: self.encoding.clone(),
+                seen: Vec::new(),
             }),
             _ => Err(DeserializeError {
                 kind: DeserializeErrorKind::Unsupported(String::from("not an object")),
@@ -289,6 +377,18 @@ where
     E: Encoding + Clone,
 {
     #[inline]
+    pub fn values_len(&mut self) -> usize {
+        let mut count = 0;
+        let mut ind = self.token_ind;
+        while ind < self.end_ind {
+            ind = next_idx_header(self.tokens, ind);
+            count += 1;
+        } 
+
+        count
+    }
+
+    #[inline]
     pub fn next_value(&mut self) -> Option<ValueReader<'data, 'tokens, E>> {
         if self.token_ind < self.end_ind {
             let value_ind = self.token_ind;
@@ -313,6 +413,7 @@ mod tests {
         let data = b"foo=bar";
         let tape = TextTape::from_slice(data).unwrap();
         let mut reader = tape.windows1252_reader();
+        assert_eq!(reader.fields_len(), 1);
 
         let (key, _op, value) = reader.next_field().unwrap();
         assert_eq!(key.read_string(), String::from("foo"));
@@ -348,6 +449,7 @@ mod tests {
         assert_eq!(key.read_string(), String::from("foo"));
 
         let mut nested = value.read_array().unwrap();
+        assert_eq!(nested.values_len(), 2);
         let value1 = nested.next_value().unwrap().read_string().unwrap();
         let value2 = nested.next_value().unwrap().read_string().unwrap();
 
@@ -362,14 +464,18 @@ mod tests {
         let tape = TextTape::from_slice(data).unwrap();
         let mut reader = tape.windows1252_reader();
 
+        assert_eq!(reader.fields_len(), 1);
         let (key, _op, value) = reader.next_field().unwrap();
         assert_eq!(key.read_string(), String::from("levels"));
 
         let mut nested = value.read_array().unwrap();
+        assert_eq!(nested.values_len(), 2);
+
         let value1 = nested.next_value().unwrap().read_string().unwrap();
         assert_eq!(value1, String::from("10"));
 
         let mut hidden = nested.next_value().unwrap().read_object().unwrap();
+        assert_eq!(hidden.fields_len(), 2);
         let (key, _op, value) = hidden.next_field().unwrap();
         assert_eq!(key.read_string(), String::from("0"));
         assert_eq!(value.read_string().unwrap(), String::from("1"));
@@ -380,5 +486,76 @@ mod tests {
 
         assert!(hidden.next_field().is_none());
         assert!(nested.next_value().is_none());
+    }
+
+    #[test]
+    fn text_reader_read_fields() {
+        let data = b"name=aaa name=bbb core=123 core=456 name=ccc name=ddd";
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+
+        let (key, values) = reader.next_fields().unwrap();
+        assert_eq!(key.read_string(), String::from("name"));
+        assert_eq!(values.len(), 4);
+        assert_eq!(values[0].read_string().unwrap(), String::from("aaa"));
+        assert_eq!(values[1].read_string().unwrap(), String::from("bbb"));
+        assert_eq!(values[2].read_string().unwrap(), String::from("ccc"));
+        assert_eq!(values[3].read_string().unwrap(), String::from("ddd"));
+
+        let (key, values) = reader.next_fields().unwrap();
+        assert_eq!(key.read_string(), String::from("core"));
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0].read_string().unwrap(), String::from("123"));
+        assert_eq!(values[1].read_string().unwrap(), String::from("456"));
+    }
+
+    #[test]
+    fn text_reader_read_fields_nested() {
+        let data = b"army={name=aaa unit={name=bbb} unit={name=ccc}} army={name=ddd unit={name=eee}}";
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+
+        let (key, army_values) = reader.next_fields().unwrap();
+        assert_eq!(key.read_string(), String::from("army"));
+        assert_eq!(army_values.len(), 2);
+
+        let mut aaa = army_values[0].read_object().unwrap();
+        assert_eq!(aaa.fields_len(), 3);
+        
+        let (key, values) = aaa.next_fields().unwrap();
+        assert_eq!(key.read_string(), String::from("name"));
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].read_string().unwrap(), String::from("aaa"));
+        
+        let (key, values) = aaa.next_fields().unwrap();
+        assert_eq!(key.read_string(), String::from("unit"));
+        assert_eq!(values.len(), 2);
+
+        let mut bbb = values[0].read_object().unwrap();
+        let (key, _, value) = bbb.next_field().unwrap();
+        assert_eq!(key.read_string(), String::from("name"));
+        assert_eq!(value.read_string().unwrap(), String::from("bbb"));
+
+        let mut ccc = values[1].read_object().unwrap();
+        let (key, _, value) = ccc.next_field().unwrap();
+        assert_eq!(key.read_string(), String::from("name"));
+        assert_eq!(value.read_string().unwrap(), String::from("ccc"));
+
+        let mut ddd = army_values[1].read_object().unwrap();
+        assert_eq!(ddd.fields_len(), 2);
+        
+        let (key, values) = ddd.next_fields().unwrap();
+        assert_eq!(key.read_string(), String::from("name"));
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].read_string().unwrap(), String::from("ddd"));
+        
+        let (key, values) = ddd.next_fields().unwrap();
+        assert_eq!(key.read_string(), String::from("unit"));
+        assert_eq!(values.len(), 1);
+
+        let mut eee = values[0].read_object().unwrap();
+        let (key, _, value) = eee.next_field().unwrap();
+        assert_eq!(key.read_string(), String::from("name"));
+        assert_eq!(value.read_string().unwrap(), String::from("eee"));
     }
 }

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -1,7 +1,7 @@
 use crate::{
     DeserializeError, DeserializeErrorKind, Encoding, Operator, Scalar, TextTape, TextToken,
 };
-use std::{borrow::Cow};
+use std::borrow::Cow;
 
 pub type KeyValue<'data, 'tokens, E> = (
     ScalarReader<'data, E>,
@@ -11,7 +11,7 @@ pub type KeyValue<'data, 'tokens, E> = (
 
 pub type KeyValues<'data, 'tokens, E> = (
     ScalarReader<'data, E>,
-    Vec<ValueReader<'data, 'tokens, E>>,
+    Vec<(Option<Operator>, ValueReader<'data, 'tokens, E>)>,
 );
 
 /// Calculate what index the next value is. This assumes that a header + value
@@ -90,7 +90,7 @@ pub struct ObjectReader<'data, 'tokens, E> {
     tokens: &'tokens [TextToken<'data>],
     encoding: E,
     val_ind: usize,
-    seen: Vec<bool>
+    seen: Vec<bool>,
 }
 
 impl<'data, 'tokens, E> ObjectReader<'data, 'tokens, E>
@@ -164,7 +164,7 @@ where
                 let key_ind = self.token_ind;
                 let key = &self.tokens[self.token_ind];
                 self.seen[self.val_ind] = true;
-                let key_scalar = if let &TextToken::Scalar(x) = key {
+                let key_scalar = if let TextToken::Scalar(x) = *key {
                     x
                 } else {
                     // this is a broken invariant, so we safely recover by saying the object
@@ -174,37 +174,36 @@ where
                 };
 
                 let key_reader = self.new_scalar_reader(key_scalar);
-                let value_ind = match self.tokens[key_ind + 1] {
-                    TextToken::Operator(_) => key_ind + 2,
-                    _ => key_ind + 1,
+                let (op, value_ind) = match self.tokens[key_ind + 1] {
+                    TextToken::Operator(x) => (Some(x), key_ind + 2),
+                    _ => (None, key_ind + 1),
                 };
 
                 self.token_ind = next_idx(self.tokens, value_ind);
                 let value_reader = self.new_value_reader(value_ind);
-                values.push(value_reader);
+                values.push((op, value_reader));
 
                 let mut future = self.token_ind;
                 let mut future_ind = self.val_ind + 1;
                 while future < self.end_ind {
                     if !self.seen[future_ind] && self.tokens[future] == *key {
-                        let value_ind = match self.tokens[future + 1] {
-                            TextToken::Operator(_) => future + 2,
-                            _ => future + 1,
+                        let (op, value_ind) = match self.tokens[future + 1] {
+                            TextToken::Operator(x) => (Some(x), future + 2),
+                            _ => (None, future + 1),
                         };
                         self.seen[future_ind] = true;
                         let value_reader = self.new_value_reader(value_ind);
-                        values.push(value_reader);
+                        values.push((op, value_reader));
                     }
                     future_ind += 1;
                     future = next_idx(self.tokens, future + 1);
                 }
 
                 self.val_ind += 1;
-                dbg!(&self.seen);
                 return Some((key_reader, values));
             } else {
                 self.val_ind += 1;
-                self.token_ind = next_idx(self.tokens, self.val_ind + 1);
+                self.token_ind = next_idx(self.tokens, self.token_ind + 1);
             }
         }
 
@@ -377,13 +376,13 @@ where
     E: Encoding + Clone,
 {
     #[inline]
-    pub fn values_len(&mut self) -> usize {
+    pub fn values_len(&self) -> usize {
         let mut count = 0;
         let mut ind = self.token_ind;
         while ind < self.end_ind {
             ind = next_idx_header(self.tokens, ind);
             count += 1;
-        } 
+        }
 
         count
     }
@@ -497,21 +496,22 @@ mod tests {
         let (key, values) = reader.next_fields().unwrap();
         assert_eq!(key.read_string(), String::from("name"));
         assert_eq!(values.len(), 4);
-        assert_eq!(values[0].read_string().unwrap(), String::from("aaa"));
-        assert_eq!(values[1].read_string().unwrap(), String::from("bbb"));
-        assert_eq!(values[2].read_string().unwrap(), String::from("ccc"));
-        assert_eq!(values[3].read_string().unwrap(), String::from("ddd"));
+        assert_eq!(values[0].1.read_string().unwrap(), String::from("aaa"));
+        assert_eq!(values[1].1.read_string().unwrap(), String::from("bbb"));
+        assert_eq!(values[2].1.read_string().unwrap(), String::from("ccc"));
+        assert_eq!(values[3].1.read_string().unwrap(), String::from("ddd"));
 
         let (key, values) = reader.next_fields().unwrap();
         assert_eq!(key.read_string(), String::from("core"));
         assert_eq!(values.len(), 2);
-        assert_eq!(values[0].read_string().unwrap(), String::from("123"));
-        assert_eq!(values[1].read_string().unwrap(), String::from("456"));
+        assert_eq!(values[0].1.read_string().unwrap(), String::from("123"));
+        assert_eq!(values[1].1.read_string().unwrap(), String::from("456"));
     }
 
     #[test]
     fn text_reader_read_fields_nested() {
-        let data = b"army={name=aaa unit={name=bbb} unit={name=ccc}} army={name=ddd unit={name=eee}}";
+        let data =
+            b"army={name=aaa unit={name=bbb} unit={name=ccc}} army={name=ddd unit={name=eee}}";
         let tape = TextTape::from_slice(data).unwrap();
         let mut reader = tape.windows1252_reader();
 
@@ -519,43 +519,58 @@ mod tests {
         assert_eq!(key.read_string(), String::from("army"));
         assert_eq!(army_values.len(), 2);
 
-        let mut aaa = army_values[0].read_object().unwrap();
+        let mut aaa = army_values[0].1.read_object().unwrap();
         assert_eq!(aaa.fields_len(), 3);
-        
+
         let (key, values) = aaa.next_fields().unwrap();
         assert_eq!(key.read_string(), String::from("name"));
         assert_eq!(values.len(), 1);
-        assert_eq!(values[0].read_string().unwrap(), String::from("aaa"));
-        
+        assert_eq!(values[0].1.read_string().unwrap(), String::from("aaa"));
+
         let (key, values) = aaa.next_fields().unwrap();
         assert_eq!(key.read_string(), String::from("unit"));
         assert_eq!(values.len(), 2);
 
-        let mut bbb = values[0].read_object().unwrap();
+        let mut bbb = values[0].1.read_object().unwrap();
         let (key, _, value) = bbb.next_field().unwrap();
         assert_eq!(key.read_string(), String::from("name"));
         assert_eq!(value.read_string().unwrap(), String::from("bbb"));
 
-        let mut ccc = values[1].read_object().unwrap();
+        let mut ccc = values[1].1.read_object().unwrap();
         let (key, _, value) = ccc.next_field().unwrap();
         assert_eq!(key.read_string(), String::from("name"));
         assert_eq!(value.read_string().unwrap(), String::from("ccc"));
 
-        let mut ddd = army_values[1].read_object().unwrap();
+        let mut ddd = army_values[1].1.read_object().unwrap();
         assert_eq!(ddd.fields_len(), 2);
-        
+
         let (key, values) = ddd.next_fields().unwrap();
         assert_eq!(key.read_string(), String::from("name"));
         assert_eq!(values.len(), 1);
-        assert_eq!(values[0].read_string().unwrap(), String::from("ddd"));
-        
+        assert_eq!(values[0].1.read_string().unwrap(), String::from("ddd"));
+
         let (key, values) = ddd.next_fields().unwrap();
         assert_eq!(key.read_string(), String::from("unit"));
         assert_eq!(values.len(), 1);
 
-        let mut eee = values[0].read_object().unwrap();
+        let mut eee = values[0].1.read_object().unwrap();
         let (key, _, value) = eee.next_field().unwrap();
         assert_eq!(key.read_string(), String::from("name"));
         assert_eq!(value.read_string().unwrap(), String::from("eee"));
+    }
+
+    #[test]
+    fn text_reader_read_fields_consume() {
+        let data = b"name=aaa name=bbb core=123 name=ccc name=ddd";
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+        let mut count = 0;
+        while let Some((_key, mut entries)) = reader.next_fields() {
+            for (_i, (_op, value)) in entries.drain(..).enumerate() {
+                count += value.read_scalar().map(|_| 1).unwrap_or(0);
+            }
+        }
+
+        assert_eq!(count, 5);
     }
 }

--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -18,7 +18,7 @@ pub enum Operator {
 }
 
 /// Represents a valid text value
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TextToken<'a> {
     /// Index of the `TextToken::End` that signifies this array's termination
     Array(usize),
@@ -1176,8 +1176,6 @@ mod tests {
 
     #[test]
     fn test_mixed_object_array() {
-        // This is something that probably won't have a deserialized test
-        // as ... how should one interpret it?
         let data = br#"brittany_area = { #5
             color = { 118  99  151 }
             169 170 171 172 4384

--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -1,4 +1,4 @@
-use crate::data::is_boundary;
+use crate::{data::is_boundary, ObjectReader, Utf8Encoding, Windows1252Encoding};
 use crate::{Error, ErrorKind, Scalar};
 
 /// An operator token
@@ -64,6 +64,15 @@ pub enum TextToken<'a> {
     Header(Scalar<'a>),
 }
 
+impl<'a> TextToken<'a> {
+    pub fn as_scalar(&self) -> Option<Scalar<'a>> {
+        match self {
+            TextToken::Header(s) | TextToken::Scalar(s) => Some(*s),
+            _ => None,
+        }
+    }
+}
+
 /// Creates a parser that a writes to a text tape
 #[derive(Debug, Default)]
 pub struct TextTapeParser;
@@ -111,6 +120,16 @@ struct ParserState<'a, 'b> {
 #[derive(Debug, Default)]
 pub struct TextTape<'a> {
     token_tape: Vec<TextToken<'a>>,
+}
+
+impl<'a> TextTape<'a> {
+    pub fn windows1252_reader(&self) -> ObjectReader<Windows1252Encoding> {
+        ObjectReader::new(&self, Windows1252Encoding::new())
+    }
+
+    pub fn utf8_reader(&self) -> ObjectReader<Utf8Encoding> {
+        ObjectReader::new(&self, Utf8Encoding::new())
+    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -65,6 +65,14 @@ pub enum TextToken<'a> {
 }
 
 impl<'a> TextToken<'a> {
+    /// Returns the scalar if the token contains a scalar
+    ///
+    /// ```
+    /// use jomini::{Scalar, TextToken};
+    /// assert_eq!(TextToken::Scalar(Scalar::new(b"abc")).as_scalar(), Some(Scalar::new(b"abc")));
+    /// assert_eq!(TextToken::Header(Scalar::new(b"rgb")).as_scalar(), Some(Scalar::new(b"rgb")));
+    /// assert_eq!(TextToken::Object(2).as_scalar(), None);
+    /// ```
     pub fn as_scalar(&self) -> Option<Scalar<'a>> {
         match self {
             TextToken::Header(s) | TextToken::Scalar(s) => Some(*s),
@@ -123,10 +131,12 @@ pub struct TextTape<'a> {
 }
 
 impl<'a> TextTape<'a> {
+    /// Creates a windows 1252 object reader from the parsed tape
     pub fn windows1252_reader(&self) -> ObjectReader<Windows1252Encoding> {
         ObjectReader::new(&self, Windows1252Encoding::new())
     }
 
+    /// Creates a utf-8 object reader from the parsed tape
     pub fn utf8_reader(&self) -> ObjectReader<Utf8Encoding> {
         ObjectReader::new(&self, Utf8Encoding::new())
     }


### PR DESCRIPTION
Working with the low level tape -- well, it can be too low level. And while the high level serde bindings are nice, sometimes it not a good fit. This PR introduces a mid level API that bridges the two extremes.

The best thing about this mid-level API is that it reuses the low level tape and the high level serde api can be implemented on top of the mid-level without a performance penalty (and it drastically makes the serde implementation easier to grok). The other use cases for the mid-level API:

- Simplify the [JS binding](https://github.com/nickbabcock/jomini)
- Simplify the binary melters

Since I had three use cases for a mid-level API, figured it was time it was implemented.

Examples to come.