### PR TITLE
Introduce a mid-level API

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ the binary format, but as a string when in plaintext.
 The plaintext parser is geared towards save file parsing and is not yet general enough to handle
 files that embed operators other than equals.
 
+## The Mid-level API
+
+If the automatic deserialization via `JominiDeserialize` is too high level, there is a mid-level
+api where one can easily iterate through the parsed document and interrogate fields for
+their information. 
+
+```rust
+use jomini::TextTape;
+
+let data = b"name=aaa name=bbb core=123 name=ccc name=ddd";
+let tape = TextTape::from_slice(data).unwrap();
+let mut reader = tape.windows1252_reader();
+
+while let Some((key, _op, value)) = reader.next_field() {
+    println!("{:?}={:?}", key.read_str(), value.read_str().unwrap());
+}
+```
+
 ## One Level Lower
 
 If the automatic deserialization via `JominiDeserialize` is too high level, one can

--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -1,10 +1,10 @@
+use super::tape::{array_len, object_len};
 use crate::{
     de::ColorSequence, BinaryFlavor, BinaryTape, BinaryToken, Ck3Flavor, DeserializeError,
     DeserializeErrorKind, Encoding, Error, Eu4Flavor, FailedResolveStrategy, TokenResolver,
 };
 use serde::de::{self, Deserialize, DeserializeSeed, MapAccess, SeqAccess, Visitor};
 use std::borrow::Cow;
-use super::tape::{array_len, object_len};
 
 /// A structure to deserialize binary data into Rust values.
 ///

--- a/src/binary/tape.rs
+++ b/src/binary/tape.rs
@@ -5,7 +5,7 @@ use crate::{
 use crate::{BinaryFlavor, Error, ErrorKind, Eu4Flavor, Rgb, Scalar};
 
 /// Represents any valid binary value
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum BinaryToken<'a> {
     /// Index of the `BinaryToken::End` that signifies this array's termination
     Array(usize),
@@ -710,7 +710,9 @@ pub(crate) fn object_len(tokens: &[BinaryToken], mut key_idx: usize) -> usize {
 
         let val_ind = key_idx + 1;
         key_idx = match tokens.get(val_ind) {
-            Some(BinaryToken::Array(x)) | Some(BinaryToken::Object(x)) | Some(BinaryToken::HiddenObject(x)) => x + 1,
+            Some(BinaryToken::Array(x))
+            | Some(BinaryToken::Object(x))
+            | Some(BinaryToken::HiddenObject(x)) => x + 1,
             _ => val_ind + 1,
         };
 
@@ -1283,7 +1285,7 @@ mod tests {
             BinaryToken::Token(0x0000),
             BinaryToken::Token(0x0001),
             BinaryToken::Token(0x0002),
-            BinaryToken::Token(0x0003)
+            BinaryToken::Token(0x0003),
         ];
 
         assert_eq!(object_len(&tokens, 0), 2);

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -33,7 +33,7 @@ pub trait Encoding: Sized {
 /// assert_eq!(encoding.decode(b"\xfe\xff\xfe\xff\xfe\xff\xfe\xff\xfe\xff"), "þÿþÿþÿþÿþÿ");
 /// assert_eq!(encoding.decode(b"hi\x81\x8a"), "hi\u{81}Š");
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct Windows1252Encoding;
 
 impl Windows1252Encoding {
@@ -72,7 +72,7 @@ impl<T: Encoding> Encoding for &'_ T {
 /// assert_eq!(encoding.decode(b"J\xc3\xa5hk\xc3\xa5m\xc3\xa5hkke"), "Jåhkåmåhkke");
 /// assert_eq!(encoding.decode("Jåhkåmåhkke".as_bytes()), "Jåhkåmåhkke");
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct Utf8Encoding;
 
 impl Utf8Encoding {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,9 +104,27 @@ the binary format, but as a string when in plaintext.
 The plaintext parser is geared towards save file parsing and is not yet general enough to handle
 files that embed operators other than equals.
 
+## The Mid-level API
+
+If the automatic deserialization via `JominiDeserialize` is too high level, there is a mid-level
+api where one can easily iterate through the parsed document and interrogate fields for
+their information. 
+
+```rust
+use jomini::TextTape;
+
+let data = b"name=aaa name=bbb core=123 name=ccc name=ddd";
+let tape = TextTape::from_slice(data).unwrap();
+let mut reader = tape.windows1252_reader();
+
+while let Some((key, _op, value)) = reader.next_field() {
+    println!("{:?}={:?}", key.read_str(), value.read_str().unwrap());
+}
+```
+
 ## One Level Lower
 
-If the automatic deserialization via `JominiDeserialize` is too high level, one can
+At the very bottom of the API layer, one can
 interact with the raw data directly via `TextTape` and `BinaryTape`.
 
 ```rust

--- a/src/text/de.rs
+++ b/src/text/de.rs
@@ -1,8 +1,8 @@
 use crate::{
-    DeserializeError, DeserializeErrorKind, Encoding, Error, Scalar, TextTape, TextToken,
-    Utf8Encoding, Windows1252Encoding,
+    ArrayReader, DeserializeError, DeserializeErrorKind, Encoding, Error, ObjectReader, Reader,
+    TextTape, TextToken, Utf8Encoding, ValueReader, Windows1252Encoding,
 };
-use serde::de::{self, Deserialize, DeserializeSeed, MapAccess, SeqAccess, Visitor};
+use serde::de::{self, Deserialize, DeserializeSeed, Visitor};
 use std::borrow::Cow;
 
 /// A structure to deserialize text data into Rust values.
@@ -65,7 +65,7 @@ impl TextDeserializer {
     }
 
     /// Deserialize the given text tape assuming quoted strings are windows1252 encoded.
-    pub fn from_windows1252_tape<'b, 'a: 'b, T>(tape: &'b TextTape<'a>) -> Result<T, Error>
+    pub fn from_windows1252_tape<'a, T>(tape: &TextTape<'a>) -> Result<T, Error>
     where
         T: Deserialize<'a>,
     {
@@ -82,7 +82,7 @@ impl TextDeserializer {
     }
 
     /// Deserialize the given text tape assuming quoted strings are utf8 encoded.
-    pub fn from_utf8_tape<'b, 'a: 'b, T>(tape: &'b TextTape<'a>) -> Result<T, Error>
+    pub fn from_utf8_tape<'a, 'b, T>(tape: &'b TextTape<'a>) -> Result<T, Error>
     where
         T: Deserialize<'a>,
     {
@@ -97,49 +97,247 @@ impl TextDeserializer {
     ) -> Result<T, Error>
     where
         T: Deserialize<'a>,
-        E: Encoding,
+        E: Encoding + Clone,
     {
-        let mut root = RootDeserializer {
-            tokens: tape.tokens(),
-            encoding: &encoding,
-        };
+        let reader = Reader::Object(ObjectReader::new(tape, encoding));
+        let mut root = InternalDeserializer { readers: reader };
         Ok(T::deserialize(&mut root)?)
     }
 }
 
 #[derive(Debug)]
-pub struct RootDeserializer<'b, 'a: 'b, E> {
-    tokens: &'b [TextToken<'a>],
-    encoding: &'b E,
+struct InternalDeserializer<'de, 'tokens, E> {
+    readers: Reader<'de, 'tokens, E>,
 }
 
-impl<'b, 'de, 'r, E> de::Deserializer<'de> for &'r mut RootDeserializer<'b, 'de, E>
+impl<'de, 'tokens, E> InternalDeserializer<'de, 'tokens, E>
 where
-    E: Encoding,
+    E: Clone,
+{
+    fn reader(&self) -> Reader<'de, 'tokens, E> {
+        self.readers.clone()
+    }
+
+    fn reader_ref(&self) -> &Reader<'de, 'tokens, E> {
+        &self.readers
+    }
+}
+
+macro_rules! visit_str {
+    ($data: expr, $visitor: expr) => {
+        match $data {
+            Cow::Borrowed(s) => $visitor.visit_borrowed_str(s),
+            Cow::Owned(s) => $visitor.visit_string(s),
+        }
+    };
+}
+
+impl<'a, 'de, 'tokens, E> de::Deserializer<'de> for &'a mut InternalDeserializer<'de, 'tokens, E>
+where
+    E: Encoding + Clone,
 {
     type Error = DeserializeError;
 
-    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        Err(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from(
-                "root deserializer can only work with key value pairs",
-            )),
-        })
+        match &self.readers {
+            Reader::Scalar(x) => visit_str!(x.read_str(), visitor),
+            Reader::Value(x) => match x.token() {
+                TextToken::Scalar(s) => visit_str!(x.decode(s.view_data()), visitor),
+                TextToken::Header(_) | TextToken::Array(_) => self.deserialize_seq(visitor),
+                TextToken::Object(_) | TextToken::HiddenObject(_) => self.deserialize_map(visitor),
+                _ => Err(DeserializeError {
+                    kind: DeserializeErrorKind::Unsupported(String::from(
+                        "unsupported value reader token",
+                    )),
+                }),
+            },
+            Reader::Object(_) => self.deserialize_map(visitor),
+            Reader::Array(_) => self.deserialize_seq(visitor),
+        }
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visit_str!(self.reader_ref().read_str()?, visitor)
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_borrowed_bytes(self.reader_ref().read_scalar()?.view_data())
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_byte_buf(self.reader_ref().read_scalar()?.view_data().to_vec())
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_string(self.reader_ref().read_string()?)
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_bool(self.reader_ref().read_scalar()?.to_bool()?)
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_i64(visitor)
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_i64(visitor)
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_i64(visitor)
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i64(self.reader_ref().read_scalar()?.to_i64()?)
+    }
+
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_i64(visitor)
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_u64(visitor)
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_u64(visitor)
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_u64(visitor)
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u64(self.reader_ref().read_scalar()?.to_u64()?)
+    }
+
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_u64(visitor)
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_f64(self.reader_ref().read_scalar()?.to_f64()?)
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_f64(visitor)
     }
 
     fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_map(BinaryMap::new(
-            &self.tokens,
-            0,
-            self.tokens.len(),
-            self.encoding,
-        ))
+        match self.reader() {
+            Reader::Object(x) => {
+                let map = MapAccess {
+                    de: self,
+                    reader: x,
+                    value: None,
+                };
+                visitor.visit_map(map)
+            }
+            Reader::Value(x) => {
+                let map = MapAccess {
+                    de: self,
+                    reader: x.read_object()?,
+                    value: None,
+                };
+                visitor.visit_map(map)
+            }
+            _ => Err(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from(
+                    "can only deserialize an object as a map",
+                )),
+            }),
+        }
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if let Reader::Value(x) = self.reader() {
+            let map = SeqAccess {
+                de: self,
+                reader: x.read_array()?,
+            };
+            visitor.visit_seq(map)
+        } else {
+            Err(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from(
+                    "unexpected reader for sequence",
+                )),
+            })
+        }
     }
 
     fn deserialize_struct<V>(
@@ -152,173 +350,6 @@ where
         V: Visitor<'de>,
     {
         self.deserialize_map(visitor)
-    }
-
-    serde::forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
-        tuple_struct enum ignored_any identifier
-    }
-}
-
-struct BinaryMap<'a, 'de: 'a, E> {
-    tokens: &'a [TextToken<'de>],
-    tape_idx: usize,
-    end_idx: usize,
-    value_ind: usize,
-    encoding: &'a E,
-}
-
-impl<'a, 'de, E> BinaryMap<'a, 'de, E>
-where
-    E: Encoding,
-{
-    fn new(tokens: &'a [TextToken<'de>], tape_idx: usize, end_idx: usize, encoding: &'a E) -> Self {
-        BinaryMap {
-            tokens,
-            tape_idx,
-            end_idx,
-            value_ind: 0,
-            encoding,
-        }
-    }
-}
-
-impl<'de, 'a, E> MapAccess<'de> for BinaryMap<'a, 'de, E>
-where
-    E: Encoding,
-{
-    type Error = DeserializeError;
-
-    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
-    where
-        K: DeserializeSeed<'de>,
-    {
-        loop {
-            if self.tape_idx < self.end_idx {
-                let current_idx = self.tape_idx;
-
-                self.value_ind = match self.tokens[self.tape_idx + 1] {
-                    TextToken::Operator(_) => self.tape_idx + 2,
-                    _ => self.tape_idx + 1,
-                };
-
-                let next_key = match self.tokens[self.value_ind] {
-                    TextToken::Array(x) | TextToken::Object(x) | TextToken::HiddenObject(x) => x,
-                    TextToken::End(_) => {
-                        // this really shouldn't happen but if it does we just
-                        // move our sights to the end token and continue on
-                        self.tape_idx = self.value_ind;
-                        continue;
-                    }
-                    TextToken::Header(_) => match self.tokens[self.value_ind + 1] {
-                        TextToken::Array(x) | TextToken::Object(x) | TextToken::HiddenObject(x) => {
-                            x
-                        }
-                        _ => self.value_ind + 1,
-                    },
-                    _ => self.value_ind,
-                };
-
-                debug_assert!(next_key + 1 > self.tape_idx);
-                self.tape_idx = next_key + 1;
-
-                return seed
-                    .deserialize(KeyDeserializer {
-                        tape_idx: current_idx,
-                        tokens: self.tokens,
-                        encoding: self.encoding,
-                    })
-                    .map(Some);
-            } else {
-                return Ok(None);
-            }
-        }
-    }
-
-    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
-    where
-        V: DeserializeSeed<'de>,
-    {
-        seed.deserialize(ValueDeserializer {
-            value_ind: self.value_ind,
-            tokens: &self.tokens,
-            encoding: self.encoding,
-        })
-    }
-}
-
-fn ensure_scalar<'a>(s: &TextToken<'a>) -> Result<Scalar<'a>, DeserializeError> {
-    match s {
-        TextToken::Scalar(s) => Ok(*s),
-        TextToken::Header(s) => Ok(*s),
-        x => Err(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(format!("{:?} is not a scalar", x)),
-        }),
-    }
-}
-
-struct KeyDeserializer<'b, 'de: 'b, E> {
-    tokens: &'b [TextToken<'de>],
-    tape_idx: usize,
-    encoding: &'b E,
-}
-
-impl<'b, 'de, E> KeyDeserializer<'b, 'de, E> {
-    fn new(tokens: &'b [TextToken<'de>], tape_idx: usize, encoding: &'b E) -> Self {
-        KeyDeserializer {
-            tokens,
-            tape_idx,
-            encoding,
-        }
-    }
-}
-
-impl<'b, 'de: 'b, E> de::Deserializer<'de> for KeyDeserializer<'b, 'de, E>
-where
-    E: Encoding,
-{
-    type Error = DeserializeError;
-
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_str(visitor)
-    }
-
-    fn deserialize_map<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        Err(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from("can't deserialize map as key")),
-        })
-    }
-
-    fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        Err(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from("can't deserialize seq as key")),
-        })
-    }
-
-    fn deserialize_struct<V>(
-        self,
-        _name: &'static str,
-        _fields: &'static [&'static str],
-        _visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        Err(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from(
-                "can't deserialize struct as key",
-            )),
-        })
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -363,118 +394,6 @@ where
         V: Visitor<'de>,
     {
         visitor.visit_newtype_struct(self)
-    }
-
-    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_str(visitor)
-    }
-
-    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        ensure_scalar(&self.tokens[self.tape_idx])
-            .and_then(|s| visitor.visit_string(self.encoding.decode(s.view_data()).into_owned()))
-    }
-
-    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        ensure_scalar(&self.tokens[self.tape_idx]).and_then(|s| {
-            match self.encoding.decode(s.view_data()) {
-                Cow::Borrowed(s) => visitor.visit_borrowed_str(s),
-                Cow::Owned(s) => visitor.visit_string(s),
-            }
-        })
-    }
-
-    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        ensure_scalar(&self.tokens[self.tape_idx])
-            .and_then(|x| Ok(x.to_bool()?))
-            .and_then(|x| visitor.visit_bool(x))
-    }
-
-    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        ensure_scalar(&self.tokens[self.tape_idx])
-            .and_then(|x| Ok(x.to_u64()?))
-            .and_then(|x| visitor.visit_u64(x))
-    }
-
-    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_u64(visitor)
-    }
-
-    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_u64(visitor)
-    }
-
-    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_u64(visitor)
-    }
-
-    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        ensure_scalar(&self.tokens[self.tape_idx])
-            .and_then(|x| Ok(x.to_i64()?))
-            .and_then(|x| visitor.visit_i64(x))
-    }
-
-    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_i64(visitor)
-    }
-
-    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_i64(visitor)
-    }
-
-    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_i64(visitor)
-    }
-
-    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        ensure_scalar(&self.tokens[self.tape_idx])
-            .and_then(|x| Ok(x.to_f64()?))
-            .and_then(|x| visitor.visit_f64(x))
-    }
-
-    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_f64(visitor)
     }
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -495,459 +414,91 @@ where
         visitor.visit_unit()
     }
 
+    #[inline]
     fn deserialize_enum<V>(
         self,
         _name: &'static str,
         _variants: &'static [&'static str],
-        _visitor: V,
+        visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>,
+        V: de::Visitor<'de>,
     {
-        todo!()
-    }
+        let tmp = match self.reader() {
+            Reader::Value(x) => {
+                if let Ok(x) = x.read_array() {
+                    Ok(x)
+                } else {
+                    Err(DeserializeError {
+                        kind: DeserializeErrorKind::Unsupported(String::from(
+                            "unexpected reader for enum",
+                        )),
+                    })
+                }
+            }
+            _ => Err(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("unexpected reader for enum")),
+            }),
+        }?;
 
-    fn deserialize_i128<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        todo!()
-    }
-
-    fn deserialize_u128<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        todo!()
-    }
-
-    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        todo!()
-    }
-
-    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        todo!()
-    }
-
-    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        todo!()
+        visitor.visit_enum(VariantAccess {
+            reader: tmp,
+            de: self,
+        })
     }
 }
 
-#[derive(Debug)]
-struct ValueDeserializer<'b, 'de: 'b, E> {
-    value_ind: usize,
-    tokens: &'b [TextToken<'de>],
-    encoding: &'b E,
+struct MapAccess<'a, 'de, 'tokens, E> {
+    de: &'a mut InternalDeserializer<'de, 'tokens, E>,
+    reader: ObjectReader<'de, 'tokens, E>,
+    value: Option<ValueReader<'de, 'tokens, E>>,
 }
 
-impl<'b, 'de, E> de::Deserializer<'de> for ValueDeserializer<'b, 'de, E>
+impl<'a, 'de: 'a, 'tokens, E> de::MapAccess<'de> for MapAccess<'a, 'de, 'tokens, E>
 where
-    E: Encoding,
+    E: Encoding + Clone,
 {
     type Error = DeserializeError;
 
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
     where
-        V: Visitor<'de>,
+        K: DeserializeSeed<'de>,
     {
-        let idx = self.value_ind;
-        match &self.tokens[idx] {
-            TextToken::Array(x) => visitor.visit_seq(BinarySequence {
-                tokens: self.tokens,
-                de_idx: 0,
-                idx: idx + 1,
-                end_idx: *x,
-                encoding: self.encoding,
-            }),
-            TextToken::Header(_) => visitor.visit_seq(HeaderSequence {
-                tokens: self.tokens,
-                idx,
-                encoding: self.encoding,
-                state: 0,
-            }),
-            TextToken::Object(x) | TextToken::HiddenObject(x) => {
-                visitor.visit_map(BinaryMap::new(self.tokens, idx + 1, *x, self.encoding))
-            }
-            TextToken::End(_x) => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from(
-                    "encountered end when trying to deserialize",
-                )),
-            }),
-            _ => self.deserialize_str(visitor),
+        if let Some((key, _op, value)) = self.reader.next_field() {
+            self.value = Some(value);
+            let old = std::mem::replace(&mut self.de.readers, Reader::Scalar(key));
+            let res = seed.deserialize(&mut *self.de).map(Some);
+            let _ = std::mem::replace(&mut self.de.readers, old);
+            res
+        } else {
+            Ok(None)
         }
     }
 
-    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>,
+        V: DeserializeSeed<'de>,
     {
-        let idx = self.value_ind;
-        match &self.tokens[idx] {
-            TextToken::Array(x) => visitor.visit_seq(BinarySequence {
-                tokens: self.tokens,
-                de_idx: 0,
-                idx: idx + 1,
-                end_idx: *x,
-                encoding: self.encoding,
-            }),
-            TextToken::Header(_) => visitor.visit_seq(HeaderSequence {
-                tokens: self.tokens,
-                idx,
-                encoding: self.encoding,
-                state: 0,
-            }),
-            TextToken::End(_x) => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from(
-                    "encountered end when trying to deserialize",
-                )),
-            }),
-            _ => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from(
-                    "encountered non-seq when trying to deserialize seq",
-                )),
-            }),
-        }
+        let r = self.value.take().unwrap();
+        let old = std::mem::replace(&mut self.de.readers, Reader::Value(r));
+        let res = seed.deserialize(&mut *self.de);
+        let _ = std::mem::replace(&mut self.de.readers, old);
+        res
     }
 
-    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_some(self)
-    }
-
-    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_seq(visitor)
-    }
-
-    fn deserialize_tuple_struct<V>(
-        self,
-        _name: &'static str,
-        _len: usize,
-        visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_seq(visitor)
-    }
-
-    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_unit()
-    }
-
-    fn deserialize_newtype_struct<V>(
-        self,
-        _name: &'static str,
-        visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_newtype_struct(self)
-    }
-
-    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.value_ind, self.encoding).deserialize_string(visitor)
-    }
-
-    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.value_ind, self.encoding).deserialize_str(visitor)
-    }
-
-    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.value_ind, self.encoding).deserialize_bool(visitor)
-    }
-
-    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.value_ind, self.encoding).deserialize_u64(visitor)
-    }
-
-    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.value_ind, self.encoding).deserialize_u32(visitor)
-    }
-
-    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.value_ind, self.encoding).deserialize_u16(visitor)
-    }
-
-    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.value_ind, self.encoding).deserialize_u8(visitor)
-    }
-
-    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.value_ind, self.encoding).deserialize_i64(visitor)
-    }
-
-    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.value_ind, self.encoding).deserialize_i32(visitor)
-    }
-
-    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.value_ind, self.encoding).deserialize_i16(visitor)
-    }
-
-    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.value_ind, self.encoding).deserialize_i8(visitor)
-    }
-
-    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.value_ind, self.encoding).deserialize_f64(visitor)
-    }
-
-    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.value_ind, self.encoding).deserialize_f32(visitor)
-    }
-
-    fn deserialize_struct<V>(
-        self,
-        _name: &'static str,
-        _fields: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_map(visitor)
-    }
-
-    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        let idx = self.value_ind;
-        match &self.tokens[idx] {
-            TextToken::Object(x) | TextToken::HiddenObject(x) => {
-                visitor.visit_map(BinaryMap::new(self.tokens, idx + 1, *x, self.encoding))
-            }
-
-            // An array is supported if it is empty
-            TextToken::Array(x) => {
-                visitor.visit_map(BinaryMap::new(self.tokens, idx + 1, *x, self.encoding))
-            }
-            _ => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from(
-                    "encountered unexpected token when trying to deserialize map",
-                )),
-            }),
-        }
-    }
-
-    serde::forward_to_deserialize_any! {
-        i128 u128 char
-        bytes byte_buf unit unit_struct identifier
-        enum
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.reader.fields_len())
     }
 }
 
-#[derive(Debug)]
-struct BinarySequence<'b, 'de: 'b, E> {
-    tokens: &'b [TextToken<'de>],
-    idx: usize,
-    de_idx: usize,
-    end_idx: usize,
-    encoding: &'b E,
+struct SeqAccess<'a, 'de, 'tokens, E> {
+    de: &'a mut InternalDeserializer<'de, 'tokens, E>,
+    reader: ArrayReader<'de, 'tokens, E>,
 }
 
-impl<'b, 'de, 'r, E> de::Deserializer<'de> for &'r mut BinarySequence<'b, 'de, E>
+impl<'a, 'de: 'a, 'tokens, E> de::SeqAccess<'de> for SeqAccess<'a, 'de, 'tokens, E>
 where
-    E: Encoding,
-{
-    type Error = DeserializeError;
-
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        match &self.tokens[self.de_idx] {
-            TextToken::Object(x) | TextToken::HiddenObject(x) => visitor.visit_map(BinaryMap::new(
-                self.tokens,
-                self.de_idx + 1,
-                *x,
-                self.encoding,
-            )),
-            TextToken::Array(x) => visitor.visit_seq(BinarySequence {
-                tokens: self.tokens,
-                de_idx: 0,
-                idx: self.de_idx + 1,
-                end_idx: *x,
-                encoding: self.encoding,
-            }),
-            TextToken::Header(_) => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from(
-                    "unable to deserialize header",
-                )),
-            }),
-            TextToken::Scalar(_x) => self.deserialize_str(visitor),
-            TextToken::End(_x) => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from(
-                    "encountered end when trying to deserialize",
-                )),
-            }),
-            TextToken::Operator(_x) => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from(
-                    "encountered operator when trying to deserialize",
-                )),
-            }),
-        }
-    }
-
-    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.de_idx, self.encoding).deserialize_string(visitor)
-    }
-
-    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.de_idx, self.encoding).deserialize_str(visitor)
-    }
-
-    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.de_idx, self.encoding).deserialize_bool(visitor)
-    }
-
-    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.de_idx, self.encoding).deserialize_u64(visitor)
-    }
-
-    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.de_idx, self.encoding).deserialize_u32(visitor)
-    }
-
-    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.de_idx, self.encoding).deserialize_u16(visitor)
-    }
-
-    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.de_idx, self.encoding).deserialize_u8(visitor)
-    }
-
-    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.de_idx, self.encoding).deserialize_i64(visitor)
-    }
-
-    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.de_idx, self.encoding).deserialize_i32(visitor)
-    }
-
-    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.de_idx, self.encoding).deserialize_i16(visitor)
-    }
-
-    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.de_idx, self.encoding).deserialize_i8(visitor)
-    }
-
-    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.de_idx, self.encoding).deserialize_f64(visitor)
-    }
-
-    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.de_idx, self.encoding).deserialize_f32(visitor)
-    }
-
-    serde::forward_to_deserialize_any! {
-        i128 u128 char
-        bytes byte_buf option unit unit_struct newtype_struct tuple
-        tuple_struct map enum ignored_any identifier struct seq
-    }
-}
-
-impl<'b, 'de, E> SeqAccess<'de> for BinarySequence<'b, 'de, E>
-where
-    E: Encoding,
+    E: Encoding + Clone,
 {
     type Error = DeserializeError;
 
@@ -955,304 +506,102 @@ where
     where
         T: DeserializeSeed<'de>,
     {
-        if self.idx >= self.end_idx {
+        if let Some(x) = self.reader.next_value() {
+            let old = std::mem::replace(&mut self.de.readers, Reader::Value(x));
+            let res = seed.deserialize(&mut *self.de).map(Some);
+            let _ = std::mem::replace(&mut self.de.readers, old);
+            res
+        } else {
             Ok(None)
-        } else {
-            let next_key = match self.tokens[self.idx] {
-                TextToken::Array(x) | TextToken::Object(x) | TextToken::HiddenObject(x) => x,
-                TextToken::Header(_) => match self.tokens[self.idx + 1] {
-                    TextToken::Array(x) | TextToken::Object(x) | TextToken::HiddenObject(x) => x,
-                    _ => self.idx + 1,
-                },
-                _ => self.idx,
-            };
-
-            self.de_idx = self.idx;
-            self.idx = next_key + 1;
-            seed.deserialize(self).map(Some)
         }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.reader.values_len())
     }
 }
 
-#[derive(Debug)]
-struct HeaderSequence<'b, 'de: 'b, E> {
-    tokens: &'b [TextToken<'de>],
-    idx: usize,
-    encoding: &'b E,
-    state: usize,
+struct VariantAccess<'a, 'de, 'tokens, E> {
+    de: &'a mut InternalDeserializer<'de, 'tokens, E>,
+    reader: ArrayReader<'de, 'tokens, E>,
 }
 
-impl<'b, 'de: 'b, E> HeaderSequence<'b, 'de, E> {
-    fn val_ind(&self) -> usize {
-        if self.state == 1 {
-            self.idx
+// There probably is a way to type this out, but I'm a bit tired this
+// morning so a macro it is
+macro_rules! enum_access {
+    ($self:expr, $fun:expr) => {
+        if let Some(x) = $self.reader.next_value() {
+            let old = std::mem::replace(&mut $self.de.readers, Reader::Value(x));
+            let val = $fun()?;
+            let _ = std::mem::replace(&mut $self.de.readers, old);
+            Ok(val)
         } else {
-            self.idx + 1
+            Err(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from(
+                    "unexpected value for enum variant seed",
+                )),
+            })
         }
-    }
+    };
 }
 
-impl<'b, 'de, 'r, E> de::Deserializer<'de> for &'r mut HeaderSequence<'b, 'de, E>
+impl<'a, 'de: 'a, 'tokens, E> de::EnumAccess<'de> for VariantAccess<'a, 'de, 'tokens, E>
 where
-    E: Encoding,
+    E: Encoding + Clone,
+{
+    type Error = DeserializeError;
+    type Variant = Self;
+
+    fn variant_seed<V>(mut self, seed: V) -> Result<(V::Value, Self), Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        let val = enum_access!(self, || seed.deserialize(&mut *self.de))?;
+        Ok((val, self))
+    }
+}
+
+impl<'a, 'de: 'a, 'tokens, E> de::VariantAccess<'de> for VariantAccess<'a, 'de, 'tokens, E>
+where
+    E: Encoding + Clone,
 {
     type Error = DeserializeError;
 
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        let idx = self.val_ind();
-        match &self.tokens[idx] {
-            TextToken::Array(x) => visitor.visit_seq(BinarySequence {
-                tokens: self.tokens,
-                de_idx: 0,
-                idx: idx + 1,
-                end_idx: *x,
-                encoding: self.encoding,
-            }),
-            TextToken::Header(_) => visitor.visit_seq(HeaderSequence {
-                tokens: self.tokens,
-                idx,
-                encoding: self.encoding,
-                state: 0,
-            }),
-            TextToken::Object(x) | TextToken::HiddenObject(x) => {
-                visitor.visit_map(BinaryMap::new(self.tokens, idx + 1, *x, self.encoding))
-            }
-            TextToken::End(_x) => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from(
-                    "encountered end when trying to deserialize",
-                )),
-            }),
-            _ => self.deserialize_str(visitor),
-        }
+    fn unit_variant(mut self) -> Result<(), Self::Error> {
+        enum_access!(self, || de::Deserialize::deserialize(&mut *self.de))
     }
 
-    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    fn newtype_variant_seed<T>(mut self, seed: T) -> Result<T::Value, Self::Error>
     where
-        V: Visitor<'de>,
+        T: de::DeserializeSeed<'de>,
     {
-        let idx = self.val_ind();
-        match &self.tokens[idx] {
-            TextToken::Array(x) => visitor.visit_seq(BinarySequence {
-                tokens: self.tokens,
-                de_idx: 0,
-                idx: idx + 1,
-                end_idx: *x,
-                encoding: self.encoding,
-            }),
-            TextToken::Header(_) => visitor.visit_seq(HeaderSequence {
-                tokens: self.tokens,
-                idx,
-                encoding: self.encoding,
-                state: 0,
-            }),
-            TextToken::End(_x) => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from(
-                    "encountered end when trying to deserialize",
-                )),
-            }),
-            _ => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from(
-                    "encountered non-seq when trying to deserialize seq",
-                )),
-            }),
-        }
+        enum_access!(self, || seed.deserialize(&mut *self.de))
     }
 
-    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    fn tuple_variant<V>(mut self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>,
+        V: de::Visitor<'de>,
     {
-        visitor.visit_some(self)
+        enum_access!(self, || de::Deserializer::deserialize_seq(
+            &mut *self.de,
+            visitor
+        ))
     }
 
-    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_seq(visitor)
-    }
-
-    fn deserialize_tuple_struct<V>(
-        self,
-        _name: &'static str,
-        _len: usize,
+    fn struct_variant<V>(
+        mut self,
+        fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>,
+        V: de::Visitor<'de>,
     {
-        self.deserialize_seq(visitor)
-    }
-
-    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_unit()
-    }
-
-    fn deserialize_newtype_struct<V>(
-        self,
-        _name: &'static str,
-        visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_newtype_struct(self)
-    }
-
-    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.val_ind(), self.encoding).deserialize_string(visitor)
-    }
-
-    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.val_ind(), self.encoding).deserialize_str(visitor)
-    }
-
-    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.val_ind(), self.encoding).deserialize_bool(visitor)
-    }
-
-    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.val_ind(), self.encoding).deserialize_u64(visitor)
-    }
-
-    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.val_ind(), self.encoding).deserialize_u32(visitor)
-    }
-
-    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.val_ind(), self.encoding).deserialize_u16(visitor)
-    }
-
-    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.val_ind(), self.encoding).deserialize_u8(visitor)
-    }
-
-    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.val_ind(), self.encoding).deserialize_i64(visitor)
-    }
-
-    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.val_ind(), self.encoding).deserialize_i32(visitor)
-    }
-
-    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.val_ind(), self.encoding).deserialize_i16(visitor)
-    }
-
-    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.val_ind(), self.encoding).deserialize_i8(visitor)
-    }
-
-    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.val_ind(), self.encoding).deserialize_f64(visitor)
-    }
-
-    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        KeyDeserializer::new(self.tokens, self.val_ind(), self.encoding).deserialize_f32(visitor)
-    }
-
-    fn deserialize_struct<V>(
-        self,
-        _name: &'static str,
-        _fields: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_map(visitor)
-    }
-
-    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        let idx = self.val_ind();
-        match &self.tokens[idx] {
-            TextToken::Object(x) | TextToken::HiddenObject(x) => {
-                visitor.visit_map(BinaryMap::new(self.tokens, idx + 1, *x, self.encoding))
-            }
-
-            // An array is supported if it is empty
-            TextToken::Array(x) => {
-                visitor.visit_map(BinaryMap::new(self.tokens, idx + 1, *x, self.encoding))
-            }
-            _ => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from(
-                    "encountered unexpected token when trying to deserialize map",
-                )),
-            }),
-        }
-    }
-
-    serde::forward_to_deserialize_any! {
-        i128 u128 char
-        bytes byte_buf unit unit_struct identifier
-        enum
-    }
-}
-
-impl<'b, 'de, E> SeqAccess<'de> for HeaderSequence<'b, 'de, E>
-where
-    E: Encoding,
-{
-    type Error = DeserializeError;
-
-    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
-    where
-        T: DeserializeSeed<'de>,
-    {
-        if self.state >= 2 {
-            Ok(None)
-        } else {
-            self.state += 1;
-            seed.deserialize(self).map(Some)
-        }
+        enum_access!(self, || de::Deserializer::deserialize_struct(
+            &mut *self.de,
+            "",
+            fields,
+            visitor
+        ))
     }
 }
 
@@ -1874,6 +1223,80 @@ mod tests {
     }
 
     #[test]
+    fn test_deserialize_enum() {
+        let data = b"color = rgb { 10 11 12 }";
+
+        #[derive(Deserialize, Debug, PartialEq)]
+        struct MyStruct {
+            color: MyColor,
+        }
+
+        #[derive(Deserialize, Debug, PartialEq)]
+        enum MyColor {
+            #[serde(rename = "rgb")]
+            Rgb(u8, u8, u8),
+        }
+
+        let actual: MyStruct = from_slice(&data[..]).unwrap();
+        assert_eq!(
+            actual,
+            MyStruct {
+                color: MyColor::Rgb(10, 11, 12),
+            },
+        );
+    }
+
+    #[test]
+    fn test_deserialize_mixed_object() {
+        let data = br#"brittany_area = { #5
+            color = { 118  99  151 }
+            169 170 171 172 4384
+        }"#;
+
+        let actual: MyStruct = from_slice(&data[..]).unwrap();
+        assert_eq!(actual.brittany_area, vec![169, 170, 171, 172, 4384]);
+
+        #[derive(Deserialize, Debug, PartialEq)]
+        struct MyStruct {
+            #[serde(deserialize_with = "deserialize_area_vec")]
+            brittany_area: Vec<u16>,
+        }
+
+        fn deserialize_area_vec<'de, D>(deserializer: D) -> Result<Vec<u16>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct MapVisitor;
+
+            impl<'de> Visitor<'de> for MapVisitor {
+                type Value = Vec<u16>;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("a map area")
+                }
+
+                fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                where
+                    A: de::SeqAccess<'de>,
+                {
+                    let mut result = Vec::new();
+
+                    while let Some(x) = seq.next_element::<&str>()? {
+                        if x == "color" {
+                            let _ = seq.next_element::<de::IgnoredAny>();
+                        } else {
+                            result.push(x.parse::<u16>().unwrap());
+                        }
+                    }
+
+                    Ok(result)
+                }
+            }
+
+            deserializer.deserialize_seq(MapVisitor)
+        }
+    }
+    #[test]
     fn test_deserialize_colors() {
         let data = b"color = rgb { 100 200 150 } color2 = hsv { 0.3 0.2 0.8 }";
 
@@ -1936,7 +1359,7 @@ mod tests {
                         match ty {
                             "rgb" => {
                                 let (red, green, blue) =
-                                    seq.next_element::<(u8, u8, u8)>()?.expect("rgb channels");
+                                    seq.next_element::<(u8, u8, u8)>()?.unwrap();
                                 Ok(MyColor::Rgb { red, green, blue })
                             }
                             "hsv" => {

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "derive")]
 mod de;
+mod reader;
 mod tape;
 
 #[cfg(feature = "derive")]
 pub use self::de::TextDeserializer;
+pub use self::reader::{ArrayReader, ObjectReader, Reader, ScalarReader, ValueReader};
 pub use self::tape::{Operator, TextTape, TextToken};

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -1,0 +1,774 @@
+use crate::{
+    DeserializeError, DeserializeErrorKind, Encoding, Operator, Scalar, TextTape, TextToken,
+};
+use std::borrow::Cow;
+
+pub type KeyValue<'data, 'tokens, E> = (
+    ScalarReader<'data, E>,
+    Option<Operator>,
+    ValueReader<'data, 'tokens, E>,
+);
+
+pub type KeyValues<'data, 'tokens, E> = (
+    ScalarReader<'data, E>,
+    Vec<(Option<Operator>, ValueReader<'data, 'tokens, E>)>,
+);
+
+/// Calculate what index the next value is. This assumes that a header + value
+/// are two separate values
+#[inline]
+fn next_idx_header(tokens: &[TextToken], idx: usize) -> usize {
+    match tokens[idx] {
+        TextToken::Array(x) | TextToken::Object(x) | TextToken::HiddenObject(x) => x + 1,
+        TextToken::Operator(_) => idx + 2,
+        _ => idx + 1,
+    }
+}
+
+/// Calculate what index the next value is. This assumes that a header + value
+/// is one value
+#[inline]
+fn next_idx(tokens: &[TextToken], idx: usize) -> usize {
+    match tokens[idx] {
+        TextToken::Array(x) | TextToken::Object(x) | TextToken::HiddenObject(x) => x + 1,
+        TextToken::Operator(_) => idx + 2,
+        TextToken::Header(_) => next_idx_header(tokens, idx + 1),
+        _ => idx + 1,
+    }
+}
+
+/// All possible text reader variants
+#[derive(Debug, Clone)]
+pub enum Reader<'data, 'tokens, E> {
+    /// object reader
+    Object(ObjectReader<'data, 'tokens, E>),
+
+    /// array reader
+    Array(ArrayReader<'data, 'tokens, E>),
+
+    /// scalar reader
+    Scalar(ScalarReader<'data, E>),
+
+    /// value reader
+    Value(ValueReader<'data, 'tokens, E>),
+}
+
+impl<'data, 'tokens, E> Reader<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    /// Interpret value as a string
+    #[inline]
+    pub fn read_str(&self) -> Result<Cow<'data, str>, DeserializeError> {
+        match &self {
+            Reader::Scalar(x) => Ok(x.read_str()),
+            Reader::Value(x) => x.read_str(),
+            _ => Err(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+            }),
+        }
+    }
+
+    /// Interpret value as a string
+    #[inline]
+    pub fn read_string(&self) -> Result<String, DeserializeError> {
+        match &self {
+            Reader::Scalar(x) => Ok(x.read_string()),
+            Reader::Value(x) => x.read_string(),
+            _ => Err(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+            }),
+        }
+    }
+
+    /// Interpret value as a scalar
+    #[inline]
+    pub fn read_scalar(&self) -> Result<Scalar<'data>, DeserializeError> {
+        match &self {
+            Reader::Scalar(x) => Ok(x.read_scalar()),
+            Reader::Value(x) => x.read_scalar(),
+            _ => Err(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+            }),
+        }
+    }
+}
+
+/// A reader that will advance through an object
+#[derive(Debug, Clone)]
+pub struct ObjectReader<'data, 'tokens, E> {
+    token_ind: usize,
+    end_ind: usize,
+    tokens: &'tokens [TextToken<'data>],
+    encoding: E,
+    val_ind: usize,
+    seen: Vec<bool>,
+}
+
+impl<'data, 'tokens, E> ObjectReader<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    /// Create a new object reader from parsed data with encoded strings
+    pub fn new(tape: &'tokens TextTape<'data>, encoding: E) -> Self {
+        let tokens = tape.tokens();
+        ObjectReader {
+            tokens,
+            end_ind: tokens.len(),
+            token_ind: 0,
+            val_ind: 0,
+            encoding,
+            seen: Vec::new(),
+        }
+    }
+
+    /// Return the number of key value pairs that the object contains
+    pub fn fields_len(&self) -> usize {
+        let mut ind = self.token_ind;
+        let mut count = 0;
+        while ind < self.end_ind {
+            let key_ind = ind;
+            let value_ind = match self.tokens[key_ind + 1] {
+                TextToken::Operator(_) => key_ind + 2,
+                _ => key_ind + 1,
+            };
+            ind = next_idx(self.tokens, value_ind);
+            count += 1;
+        }
+
+        count
+    }
+
+    /// Advance the reader and return the next field
+    #[inline]
+    pub fn next_field(&mut self) -> Option<KeyValue<'data, 'tokens, E>> {
+        if self.token_ind < self.end_ind {
+            let key_ind = self.token_ind;
+            let key_scalar = if let TextToken::Scalar(x) = self.tokens[key_ind] {
+                x
+            } else {
+                // this is a broken invariant, so we safely recover by saying the object
+                // has no more fields
+                debug_assert!(false, "All keys should be scalars");
+                return None;
+            };
+
+            let key_reader = self.new_scalar_reader(key_scalar);
+
+            let (op, value_ind) = match self.tokens[key_ind + 1] {
+                TextToken::Operator(x) => (Some(x), key_ind + 2),
+                _ => (None, key_ind + 1),
+            };
+
+            // When reading an mixed object (a = { b = { c } 10 10 10 })
+            // there is an uneven number of keys and values so we drop the last "field"
+            if value_ind >= self.end_ind {
+                return None;
+            }
+
+            let value_reader = self.new_value_reader(value_ind);
+            self.token_ind = next_idx(self.tokens, value_ind);
+            Some((key_reader, op, value_reader))
+        } else {
+            None
+        }
+    }
+
+    /// Advance the reader and return all fields that share the same key in the object
+    #[inline]
+    pub fn next_fields(&mut self) -> Option<KeyValues<'data, 'tokens, E>> {
+        if self.val_ind == 0 {
+            self.seen = vec![false; self.fields_len()];
+        }
+
+        let mut values = Vec::new();
+        while self.token_ind < self.end_ind {
+            if !self.seen[self.val_ind] {
+                let key_ind = self.token_ind;
+                let key = &self.tokens[self.token_ind];
+                self.seen[self.val_ind] = true;
+                let key_scalar = if let TextToken::Scalar(x) = *key {
+                    x
+                } else {
+                    // this is a broken invariant, so we safely recover by saying the object
+                    // has no more fields
+                    debug_assert!(false, "All keys should be scalars");
+                    return None;
+                };
+
+                let key_reader = self.new_scalar_reader(key_scalar);
+                let (op, value_ind) = match self.tokens[key_ind + 1] {
+                    TextToken::Operator(x) => (Some(x), key_ind + 2),
+                    _ => (None, key_ind + 1),
+                };
+
+                self.token_ind = next_idx(self.tokens, value_ind);
+                let value_reader = self.new_value_reader(value_ind);
+                values.push((op, value_reader));
+
+                let mut future = self.token_ind;
+                let mut future_ind = self.val_ind + 1;
+                while future < self.end_ind {
+                    if !self.seen[future_ind] && self.tokens[future] == *key {
+                        let (op, value_ind) = match self.tokens[future + 1] {
+                            TextToken::Operator(x) => (Some(x), future + 2),
+                            _ => (None, future + 1),
+                        };
+                        self.seen[future_ind] = true;
+                        let value_reader = self.new_value_reader(value_ind);
+                        values.push((op, value_reader));
+                    }
+                    future_ind += 1;
+                    future = next_idx(self.tokens, future + 1);
+                }
+
+                self.val_ind += 1;
+                return Some((key_reader, values));
+            } else {
+                self.val_ind += 1;
+                self.token_ind = next_idx(self.tokens, self.token_ind + 1);
+            }
+        }
+
+        None
+    }
+
+    #[inline]
+    fn new_scalar_reader(&self, scalar: Scalar<'data>) -> ScalarReader<'data, E> {
+        ScalarReader {
+            scalar,
+            encoding: self.encoding.clone(),
+        }
+    }
+
+    #[inline]
+    fn new_value_reader(&self, value_ind: usize) -> ValueReader<'data, 'tokens, E> {
+        ValueReader {
+            value_ind,
+            tokens: self.tokens,
+            encoding: self.encoding.clone(),
+        }
+    }
+}
+
+/// A text reader that wraps an underlying scalar value
+#[derive(Debug, Clone)]
+pub struct ScalarReader<'data, E> {
+    scalar: Scalar<'data>,
+    encoding: E,
+}
+
+impl<'data, E> ScalarReader<'data, E>
+where
+    E: Encoding,
+{
+    /// Decode the data with a given string encoding
+    #[inline]
+    pub fn read_str(&self) -> Cow<'data, str> {
+        self.encoding.decode(self.scalar.view_data())
+    }
+
+    /// Decode the data with a given string encoding
+    #[inline]
+    pub fn read_string(&self) -> String {
+        self.encoding.decode(self.scalar.view_data()).into_owned()
+    }
+
+    /// Return the underlying scalar
+    #[inline]
+    pub fn read_scalar(&self) -> Scalar<'data> {
+        self.scalar
+    }
+}
+
+/// A text reader for a text value
+#[derive(Debug, Clone)]
+pub struct ValueReader<'data, 'tokens, E> {
+    value_ind: usize,
+    tokens: &'tokens [TextToken<'data>],
+    encoding: E,
+}
+
+impl<'data, 'tokens, E> ValueReader<'data, 'tokens, E> {
+    /// Return the token that the reader is abstracting
+    #[inline]
+    pub fn token(&self) -> &TextToken<'data> {
+        &self.tokens[self.value_ind]
+    }
+}
+
+impl<'data, 'tokens, E> Encoding for ValueReader<'data, 'tokens, E>
+where
+    E: Encoding,
+{
+    #[inline]
+    fn decode<'a>(&self, data: &'a [u8]) -> Cow<'a, str> {
+        self.encoding.decode(data)
+    }
+}
+
+impl<'data, 'tokens, E> ValueReader<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    /// Interpret the current value as string
+    #[inline]
+    pub fn read_str(&self) -> Result<Cow<'data, str>, DeserializeError> {
+        self.tokens[self.value_ind]
+            .as_scalar()
+            .map(|x| self.encoding.decode(x.view_data()))
+            .ok_or_else(|| DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+            })
+    }
+
+    /// Interpret the current value as string
+    #[inline]
+    pub fn read_string(&self) -> Result<String, DeserializeError> {
+        self.tokens[self.value_ind]
+            .as_scalar()
+            .map(|x| self.encoding.decode(x.view_data()).into_owned())
+            .ok_or_else(|| DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+            })
+    }
+
+    /// Interpret the current value as a scalar
+    #[inline]
+    pub fn read_scalar(&self) -> Result<Scalar<'data>, DeserializeError> {
+        self.tokens[self.value_ind]
+            .as_scalar()
+            .ok_or_else(|| DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+            })
+    }
+
+    /// Interpret the current value as an object
+    #[inline]
+    pub fn read_object(&self) -> Result<ObjectReader<'data, 'tokens, E>, DeserializeError> {
+        match self.tokens[self.value_ind] {
+            TextToken::Object(ind) | TextToken::HiddenObject(ind) => Ok(ObjectReader {
+                tokens: self.tokens,
+                token_ind: self.value_ind + 1,
+                val_ind: 0,
+                end_ind: ind,
+                seen: Vec::new(),
+                encoding: self.encoding.clone(),
+            }),
+
+            // An array can be an object if it is empty
+            TextToken::Array(ind) if ind == self.value_ind + 1 => Ok(ObjectReader {
+                tokens: self.tokens,
+                token_ind: self.value_ind + 1,
+                val_ind: 0,
+                end_ind: ind,
+                encoding: self.encoding.clone(),
+                seen: Vec::new(),
+            }),
+            _ => Err(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not an object")),
+            }),
+        }
+    }
+
+    /// Interpret the current value as an array
+    #[inline]
+    pub fn read_array(&self) -> Result<ArrayReader<'data, 'tokens, E>, DeserializeError> {
+        match self.tokens[self.value_ind] {
+            TextToken::Array(ind) => Ok(ArrayReader {
+                tokens: self.tokens,
+                token_ind: self.value_ind + 1,
+                end_ind: ind,
+                encoding: self.encoding.clone(),
+            }),
+
+            // An object can be considered an array of alternating keys and values
+            TextToken::Object(ind) => Ok(ArrayReader {
+                tokens: self.tokens,
+                token_ind: self.value_ind + 1,
+                end_ind: ind,
+                encoding: self.encoding.clone(),
+            }),
+
+            // A header can be seen as a two element array
+            TextToken::Header(_) => Ok(ArrayReader {
+                tokens: self.tokens,
+                token_ind: self.value_ind,
+                end_ind: next_idx(self.tokens, self.value_ind + 1),
+                encoding: self.encoding.clone(),
+            }),
+
+            _ => Err(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported(String::from("not an array")),
+            }),
+        }
+    }
+}
+
+/// A text reader that advances through a sequence of values
+#[derive(Debug, Clone)]
+pub struct ArrayReader<'data, 'tokens, E> {
+    token_ind: usize,
+    end_ind: usize,
+    tokens: &'tokens [TextToken<'data>],
+    encoding: E,
+}
+
+impl<'data, 'tokens, E> ArrayReader<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    /// Return the number of values in the array
+    #[inline]
+    pub fn values_len(&self) -> usize {
+        let mut count = 0;
+        let mut ind = self.token_ind;
+        while ind < self.end_ind {
+            ind = next_idx_header(self.tokens, ind);
+            count += 1;
+        }
+
+        count
+    }
+
+    /// Advance the array and return the next value
+    #[inline]
+    pub fn next_value(&mut self) -> Option<ValueReader<'data, 'tokens, E>> {
+        if self.token_ind < self.end_ind {
+            let value_ind = self.token_ind;
+            self.token_ind = next_idx_header(self.tokens, self.token_ind);
+            Some(ValueReader {
+                value_ind,
+                tokens: self.tokens,
+                encoding: self.encoding.clone(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn iterate_array<'data, 'tokens, E>(mut reader: ArrayReader<E>)
+    where
+        E: crate::Encoding + Clone,
+    {
+        while let Some(value) = reader.next_value() {
+            match value.token() {
+                TextToken::Object(_) | TextToken::HiddenObject(_) => {
+                    iterate_object(value.read_object().unwrap());
+                }
+                TextToken::Array(_) => {
+                    iterate_array(value.read_array().unwrap());
+                }
+                TextToken::End(_) => panic!("end!?"),
+                TextToken::Operator(_) => panic!("end!?"),
+                TextToken::Scalar(_) | TextToken::Header(_) => {
+                    let _ = value.read_str().unwrap();
+                }
+            }
+        }
+    }
+
+    fn iterate_object<'data, 'tokens, E>(mut reader: ObjectReader<E>)
+    where
+        E: crate::Encoding + Clone,
+    {
+        while let Some((key, _op, value)) = reader.next_field() {
+            let _ = key.read_str();
+            match value.token() {
+                TextToken::Object(_) | TextToken::HiddenObject(_) => {
+                    iterate_object(value.read_object().unwrap());
+                }
+                TextToken::Array(_) | TextToken::Header(_) => {
+                    iterate_array(value.read_array().unwrap());
+                }
+                TextToken::End(_) => panic!("end!?"),
+                TextToken::Operator(_) => panic!("end!?"),
+                TextToken::Scalar(_) => {
+                    let _ = value.read_str().unwrap();
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn simple_text_reader_text() {
+        let data = b"foo=bar";
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+        assert_eq!(reader.fields_len(), 1);
+
+        let (key, _op, value) = reader.next_field().unwrap();
+        assert_eq!(key.read_string(), String::from("foo"));
+        assert_eq!(value.read_string().unwrap(), String::from("bar"));
+
+        assert!(reader.next_field().is_none());
+    }
+
+    #[test]
+    fn simple_text_reader_obj() {
+        let data = b"foo={bar=qux}";
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+
+        let (key, _op, value) = reader.next_field().unwrap();
+        assert_eq!(key.read_string(), String::from("foo"));
+
+        let mut nested = value.read_object().unwrap();
+        let (key2, _op, value2) = nested.next_field().unwrap();
+        assert_eq!(key2.read_string(), String::from("bar"));
+        assert_eq!(value2.read_string().unwrap(), String::from("qux"));
+        assert!(nested.next_field().is_none());
+        assert!(reader.next_field().is_none());
+    }
+
+    #[test]
+    fn simple_text_reader_array() {
+        let data = b"foo={bar qux}";
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+
+        let (key, _op, value) = reader.next_field().unwrap();
+        assert_eq!(key.read_string(), String::from("foo"));
+
+        let mut nested = value.read_array().unwrap();
+        assert_eq!(nested.values_len(), 2);
+        let value1 = nested.next_value().unwrap().read_string().unwrap();
+        let value2 = nested.next_value().unwrap().read_string().unwrap();
+
+        assert!(nested.next_value().is_none());
+        assert_eq!(value1, String::from("bar"));
+        assert_eq!(value2, String::from("qux"));
+    }
+
+    #[test]
+    fn text_reader_hidden_object() {
+        let data = b"levels={10 0=1 0=2}";
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+
+        assert_eq!(reader.fields_len(), 1);
+        let (key, _op, value) = reader.next_field().unwrap();
+        assert_eq!(key.read_string(), String::from("levels"));
+
+        let mut nested = value.read_array().unwrap();
+        assert_eq!(nested.values_len(), 2);
+
+        let value1 = nested.next_value().unwrap().read_string().unwrap();
+        assert_eq!(value1, String::from("10"));
+
+        let mut hidden = nested.next_value().unwrap().read_object().unwrap();
+        assert_eq!(hidden.fields_len(), 2);
+        let (key, _op, value) = hidden.next_field().unwrap();
+        assert_eq!(key.read_string(), String::from("0"));
+        assert_eq!(value.read_string().unwrap(), String::from("1"));
+
+        let (key, _op, value) = hidden.next_field().unwrap();
+        assert_eq!(key.read_string(), String::from("0"));
+        assert_eq!(value.read_string().unwrap(), String::from("2"));
+
+        assert!(hidden.next_field().is_none());
+        assert!(nested.next_value().is_none());
+    }
+
+    #[test]
+    fn text_reader_read_fields() {
+        let data = b"name=aaa name=bbb core=123 core=456 name=ccc name=ddd";
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+
+        let (key, values) = reader.next_fields().unwrap();
+        assert_eq!(key.read_string(), String::from("name"));
+        assert_eq!(values.len(), 4);
+        assert_eq!(values[0].1.read_string().unwrap(), String::from("aaa"));
+        assert_eq!(values[1].1.read_string().unwrap(), String::from("bbb"));
+        assert_eq!(values[2].1.read_string().unwrap(), String::from("ccc"));
+        assert_eq!(values[3].1.read_string().unwrap(), String::from("ddd"));
+
+        let (key, values) = reader.next_fields().unwrap();
+        assert_eq!(key.read_string(), String::from("core"));
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0].1.read_string().unwrap(), String::from("123"));
+        assert_eq!(values[1].1.read_string().unwrap(), String::from("456"));
+    }
+
+    #[test]
+    fn text_reader_read_fields_nested() {
+        let data =
+            b"army={name=aaa unit={name=bbb} unit={name=ccc}} army={name=ddd unit={name=eee}}";
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+
+        let (key, army_values) = reader.next_fields().unwrap();
+        assert_eq!(key.read_string(), String::from("army"));
+        assert_eq!(army_values.len(), 2);
+
+        let mut aaa = army_values[0].1.read_object().unwrap();
+        assert_eq!(aaa.fields_len(), 3);
+
+        let (key, values) = aaa.next_fields().unwrap();
+        assert_eq!(key.read_string(), String::from("name"));
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].1.read_string().unwrap(), String::from("aaa"));
+
+        let (key, values) = aaa.next_fields().unwrap();
+        assert_eq!(key.read_string(), String::from("unit"));
+        assert_eq!(values.len(), 2);
+
+        let mut bbb = values[0].1.read_object().unwrap();
+        let (key, _, value) = bbb.next_field().unwrap();
+        assert_eq!(key.read_string(), String::from("name"));
+        assert_eq!(value.read_string().unwrap(), String::from("bbb"));
+
+        let mut ccc = values[1].1.read_object().unwrap();
+        let (key, _, value) = ccc.next_field().unwrap();
+        assert_eq!(key.read_string(), String::from("name"));
+        assert_eq!(value.read_string().unwrap(), String::from("ccc"));
+
+        let mut ddd = army_values[1].1.read_object().unwrap();
+        assert_eq!(ddd.fields_len(), 2);
+
+        let (key, values) = ddd.next_fields().unwrap();
+        assert_eq!(key.read_string(), String::from("name"));
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].1.read_string().unwrap(), String::from("ddd"));
+
+        let (key, values) = ddd.next_fields().unwrap();
+        assert_eq!(key.read_string(), String::from("unit"));
+        assert_eq!(values.len(), 1);
+
+        let mut eee = values[0].1.read_object().unwrap();
+        let (key, _, value) = eee.next_field().unwrap();
+        assert_eq!(key.read_string(), String::from("name"));
+        assert_eq!(value.read_string().unwrap(), String::from("eee"));
+    }
+
+    #[test]
+    fn text_reader_read_fields_consume() {
+        let data = b"name=aaa name=bbb core=123 name=ccc name=ddd";
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+        let mut count = 0;
+        while let Some((_key, mut entries)) = reader.next_fields() {
+            for (_i, (_op, value)) in entries.drain(..).enumerate() {
+                count += value.read_scalar().map(|_| 1).unwrap_or(0);
+            }
+        }
+
+        assert_eq!(count, 5);
+    }
+
+    #[test]
+    fn text_reader_mixed_object() {
+        let data = br#"brittany_area = { #5
+            color = { 118  99  151 }
+            169 170 171 172 4384
+        }"#;
+
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+        let (key, _op, value) = reader.next_field().unwrap();
+        assert_eq!(key.read_str(), "brittany_area");
+
+        let mut keys = vec![];
+        let mut brittany = value.read_object().unwrap();
+        while let Some((key, _op, _value)) = brittany.next_field() {
+            keys.push(key.read_str());
+        }
+
+        assert_eq!(
+            keys,
+            vec![
+                String::from("color"),
+                String::from("169"),
+                String::from("171")
+            ]
+        );
+    }
+
+    #[test]
+    fn text_reader_mixed_object_array() {
+        let data = br#"brittany_area = { #5
+            color = { 118  99  151 }
+            169 170 171 172 4384
+        }"#;
+
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+        let (key, _op, value) = reader.next_field().unwrap();
+        assert_eq!(key.read_str(), "brittany_area");
+
+        let mut values = vec![];
+        let mut brittany = value.read_array().unwrap();
+        while let Some(value) = brittany.next_value() {
+            let nv = value.token();
+            values.push((*nv).clone());
+        }
+
+        assert_eq!(
+            values,
+            vec![
+                TextToken::Scalar(Scalar::new(b"color")),
+                TextToken::Array(7),
+                TextToken::Scalar(Scalar::new(b"169")),
+                TextToken::Scalar(Scalar::new(b"170")),
+                TextToken::Scalar(Scalar::new(b"171")),
+                TextToken::Scalar(Scalar::new(b"172")),
+                TextToken::Scalar(Scalar::new(b"4384")),
+            ]
+        );
+    }
+
+    #[test]
+    fn text_reader_header() {
+        let data = b"color = rgb { 10 20 30 }";
+        let tape = TextTape::from_slice(data).unwrap();
+        let mut reader = tape.windows1252_reader();
+        let (key, _op, value) = reader.next_field().unwrap();
+        assert_eq!(key.read_str(), "color");
+
+        let mut header_array = value.read_array().unwrap();
+        let rgb = header_array.next_value().unwrap();
+        assert_eq!(rgb.read_str().unwrap(), "rgb");
+
+        let vals = header_array.next_value().unwrap();
+        let mut s = vals.read_array().unwrap();
+
+        let r = s
+            .next_value()
+            .unwrap()
+            .read_scalar()
+            .unwrap()
+            .to_u64()
+            .unwrap();
+        let g = s
+            .next_value()
+            .unwrap()
+            .read_scalar()
+            .unwrap()
+            .to_u64()
+            .unwrap();
+        let b = s
+            .next_value()
+            .unwrap()
+            .read_scalar()
+            .unwrap()
+            .to_u64()
+            .unwrap();
+
+        assert_eq!(r, 10);
+        assert_eq!(g, 20);
+        assert_eq!(b, 30);
+    }
+
+    #[test]
+    fn reader_crash1() {
+        let data = b"a=r{}";
+        let tape = TextTape::from_slice(data).unwrap();
+        iterate_object(tape.windows1252_reader());
+    }
+}


### PR DESCRIPTION
Working with the low level tape -- well, it can be too low level. And while the
high level serde bindings are nice, sometimes it not a good fit. This PR
introduces a mid level API that bridges the two extremes.

The best thing about this mid-level API is that it reuses the low level tape
and the high level serde api can be implemented on top of the mid-level without
a performance penalty (and it drastically makes the serde implementation easier
to grok). The other use cases for the mid-level API is that it will simplify
the [JS binding](https://github.com/nickbabcock/jomini).

For now only the text format has this intermediate layer as the benefits are
more immediate. The binary format is a bit simpler and adding this intermediate
layer would seem to only complicate things.

There are a couple more benefits that the mid level API helped with:

Enums are deserializable.

```
color1 = rgb { 10 20 30 }
color2 = hsv { 0.3 0.2 0.8 }
color3 = hsv360 { 25 75 63 }
```

Can be deserialized to:

```rust
enum MyColor {
    #[serde(rename = "rgb")]
     Rgb(u8, u8, u8),
    #[serde(rename = "hsv")]
     Hsv(f32, f32, f32),
    #[serde(rename = "hsv360")]
     Hsv360(u8, u8, u8)
}
```

Also values that are both an array and object can be deserialized too:

```
brittany_area = { #5
    color = { 118  99  151 }
    169 170 171 172 4384
}
```

Just make sure the serde deserializer is written to understand the individual values passed to it.

Some sample usage:

```rust
let data = b"name=aaa name=bbb core=123 name=ccc name=ddd";
let tape = TextTape::from_slice(data).unwrap();
let mut reader = tape.windows1252_reader();

while let Some((key, _op, value)) = reader.next_field() {
    println!("{:?}={:?}", key.read_str(), value.read_str().unwrap());
}
```