### PR TITLE
Improve date parsing performance

### DIFF
--- a/src/common/date.rs
+++ b/src/common/date.rs
@@ -127,8 +127,6 @@ impl Date {
                     _ => return None,
                 }
                 start = pos + 1;
-            } else if c > b'9' || (c < b'0' && c != b'-') {
-                return None;
             }
         }
 


### PR DESCRIPTION
The extra conditional introduced by negative dates (#46) caused an 8% increase
in latency. Since numerical input is still checked in `Scalar::to_u64`
we remove the range check as there is an even earlier stage that checks
for out of range characters. This clawed back the performance degradation (and then some).