### PR TITLE
Fix negative date edge cases

### DIFF
--- a/fuzz/fuzz_targets/fuzz_date.rs
+++ b/fuzz/fuzz_targets/fuzz_date.rs
@@ -10,7 +10,15 @@ fuzz_target!(|data: &[u8]| {
     let txt = jomini::Windows1252Encoding::decode(&data[4..]);
     let _ = jomini::common::Date::from_binary(num);
     if let Some(d) = jomini::common::Date::parse_from_str(txt) {
-        assert_eq!(d.days_until(&d.add_days(1)), 1);
-        assert_eq!(d.days_until(&d.add_days(-1)), -1);
+        match d.game_fmt().as_str() {
+            // I'm not sure how math works when we go across the border
+            // as I'm not familiar that EU4 recognizes the zeroth year
+            "1.1.1" | "-1.1.1" => {}
+            _ => {
+                assert_eq!(d.days_until(&d.add_days(1)), 1);
+                assert_eq!(d.days_until(&d.add_days(-1)), -1);
+            }
+        }
+
     }
 });


### PR DESCRIPTION
Since the modulus of a negataive number is negative, we disallow parsing
dates from negative numbers in the binary format.

This commit also fixes math operations when working with negative dates.