### PR TITLE
Differentiate if a scalar is quoted for binary and text tape

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ let data = b"foo=bar";
 assert_eq!(
     TextTape::from_slice(&data[..])?.tokens(),
     &[
-        TextToken::Scalar(Scalar::new(b"foo")),
-        TextToken::Scalar(Scalar::new(b"bar")),
+        TextToken::Unquoted(Scalar::new(b"foo")),
+        TextToken::Unquoted(Scalar::new(b"bar")),
     ]
 );
 ```

--- a/fuzz/fuzz_targets/fuzz_text.rs
+++ b/fuzz/fuzz_targets/fuzz_text.rs
@@ -34,7 +34,7 @@ fn iterate_array<'data, 'tokens, E>(mut reader: ArrayReader<E>) where E: crate::
             TextToken::Array(_)   => { iterate_array(value.read_array().unwrap()); }
             TextToken::End(_) => panic!("end!?"),
             TextToken::Operator(_) => panic!("end!?"),
-            TextToken::Scalar(_) | TextToken::Header(_) => {
+            TextToken::Unquoted(_) | TextToken::Quoted(_) | TextToken::Header(_) => {
                 let _ = value.read_str().unwrap();
             }
         }
@@ -51,7 +51,7 @@ fn iterate_object<'data, 'tokens, E>(mut reader: ObjectReader<E>) where E: crate
             TextToken::Array(_) | TextToken::Header(_)  => { iterate_array(value.read_array().unwrap()); }
             TextToken::End(_) => panic!("end!?"),
             TextToken::Operator(_) => panic!("end!?"),
-            TextToken::Scalar(_) => {
+            TextToken::Unquoted(_) | TextToken::Quoted(_) => {
                 let _ = value.read_str().unwrap();
             }
         }

--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -321,10 +321,12 @@ fn visit_key<'c, 'b: 'c, 'de: 'b, 'res: 'de, RES: TokenResolver, E: Encoding, V:
         BinaryToken::U32(x) => visitor.visit_u32(x),
         BinaryToken::U64(x) => visitor.visit_u64(x),
         BinaryToken::I32(x) => visitor.visit_i32(x),
-        BinaryToken::Text(x) => match config.encoding.decode(x.view_data()) {
-            Cow::Borrowed(s) => visitor.visit_borrowed_str(s),
-            Cow::Owned(s) => visitor.visit_string(s),
-        },
+        BinaryToken::Quoted(x) | BinaryToken::Unquoted(x) => {
+            match config.encoding.decode(x.view_data()) {
+                Cow::Borrowed(s) => visitor.visit_borrowed_str(s),
+                Cow::Owned(s) => visitor.visit_string(s),
+            }
+        }
         BinaryToken::F32_1(x) => visitor.visit_f32(x),
         BinaryToken::F32_2(x) => visitor.visit_f32(x),
         BinaryToken::Token(s) => match config.resolver.resolve(s) {

--- a/src/common/date.rs
+++ b/src/common/date.rs
@@ -244,7 +244,7 @@ impl Date {
     /// Decodes a date from a number that had been parsed from binary data
     pub fn from_binary(mut s: i32) -> Option<Self> {
         if s < 0 {
-            return None
+            return None;
         }
 
         let _hours = s % 24;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,8 +132,8 @@ let data = b"foo=bar";
 assert_eq!(
     TextTape::from_slice(&data[..])?.tokens(),
     &[
-        TextToken::Scalar(Scalar::new(b"foo")),
-        TextToken::Scalar(Scalar::new(b"bar")),
+        TextToken::Unquoted(Scalar::new(b"foo")),
+        TextToken::Unquoted(Scalar::new(b"bar")),
     ]
 );
 # Ok::<(), Box<dyn std::error::Error>>(())

--- a/src/text/de.rs
+++ b/src/text/de.rs
@@ -145,7 +145,9 @@ where
         match &self.readers {
             Reader::Scalar(x) => visit_str!(x.read_str(), visitor),
             Reader::Value(x) => match x.token() {
-                TextToken::Scalar(s) => visit_str!(x.decode(s.view_data()), visitor),
+                TextToken::Quoted(s) | TextToken::Unquoted(s) => {
+                    visit_str!(x.decode(s.view_data()), visitor)
+                }
                 TextToken::Header(_) | TextToken::Array(_) => self.deserialize_seq(visitor),
                 TextToken::Object(_) | TextToken::HiddenObject(_) => self.deserialize_map(visitor),
                 _ => Err(DeserializeError {

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -144,13 +144,14 @@ where
     pub fn next_field(&mut self) -> Option<KeyValue<'data, 'tokens, E>> {
         if self.token_ind < self.end_ind {
             let key_ind = self.token_ind;
-            let key_scalar = if let TextToken::Scalar(x) = self.tokens[key_ind] {
-                x
-            } else {
-                // this is a broken invariant, so we safely recover by saying the object
-                // has no more fields
-                debug_assert!(false, "All keys should be scalars");
-                return None;
+            let key_scalar = match self.tokens[key_ind] {
+                TextToken::Quoted(x) | TextToken::Unquoted(x) => x,
+                _ => {
+                    // this is a broken invariant, so we safely recover by saying the object
+                    // has no more fields
+                    debug_assert!(false, "All keys should be scalars");
+                    return None;
+                }
             };
 
             let key_reader = self.new_scalar_reader(key_scalar);
@@ -187,13 +188,14 @@ where
                 let key_ind = self.token_ind;
                 let key = &self.tokens[self.token_ind];
                 self.seen[self.val_ind] = true;
-                let key_scalar = if let TextToken::Scalar(x) = *key {
-                    x
-                } else {
-                    // this is a broken invariant, so we safely recover by saying the object
-                    // has no more fields
-                    debug_assert!(false, "All keys should be scalars");
-                    return None;
+                let key_scalar = match self.tokens[key_ind] {
+                    TextToken::Quoted(x) | TextToken::Unquoted(x) => x,
+                    _ => {
+                        // this is a broken invariant, so we safely recover by saying the object
+                        // has no more fields
+                        debug_assert!(false, "All keys should be scalars");
+                        return None;
+                    }
                 };
 
                 let key_reader = self.new_scalar_reader(key_scalar);
@@ -466,7 +468,7 @@ mod tests {
                 }
                 TextToken::End(_) => panic!("end!?"),
                 TextToken::Operator(_) => panic!("end!?"),
-                TextToken::Scalar(_) | TextToken::Header(_) => {
+                TextToken::Quoted(_) | TextToken::Unquoted(_) | TextToken::Header(_) => {
                     let _ = value.read_str().unwrap();
                 }
             }
@@ -488,7 +490,7 @@ mod tests {
                 }
                 TextToken::End(_) => panic!("end!?"),
                 TextToken::Operator(_) => panic!("end!?"),
-                TextToken::Scalar(_) => {
+                TextToken::Quoted(_) | TextToken::Unquoted(_) => {
                     let _ = value.read_str().unwrap();
                 }
             }
@@ -712,13 +714,13 @@ mod tests {
         assert_eq!(
             values,
             vec![
-                TextToken::Scalar(Scalar::new(b"color")),
+                TextToken::Unquoted(Scalar::new(b"color")),
                 TextToken::Array(7),
-                TextToken::Scalar(Scalar::new(b"169")),
-                TextToken::Scalar(Scalar::new(b"170")),
-                TextToken::Scalar(Scalar::new(b"171")),
-                TextToken::Scalar(Scalar::new(b"172")),
-                TextToken::Scalar(Scalar::new(b"4384")),
+                TextToken::Unquoted(Scalar::new(b"169")),
+                TextToken::Unquoted(Scalar::new(b"170")),
+                TextToken::Unquoted(Scalar::new(b"171")),
+                TextToken::Unquoted(Scalar::new(b"172")),
+                TextToken::Unquoted(Scalar::new(b"4384")),
             ]
         );
     }

--- a/tests/tape.rs
+++ b/tests/tape.rs
@@ -19,9 +19,9 @@ fn test_greater_than_operator() {
     assert_eq!(
         tape.tokens(),
         vec![
-            TextToken::Scalar(Scalar::new(b"age")),
+            TextToken::Unquoted(Scalar::new(b"age")),
             TextToken::Operator(Operator::GreaterThan),
-            TextToken::Scalar(Scalar::new(b"16")),
+            TextToken::Unquoted(Scalar::new(b"16")),
         ]
     );
 }


### PR DESCRIPTION
Until today I was under the impression that the below shows two equivalent
lines:

```
unit_type=western
unit_type="western"
```

And that games would interpret them the same way. Thus the tape and binary
tokens would consolidate scalars seen under a single discriminant.

Not true. Several reports found that quoting an unquoted value results in save
corruption that isn't shown until a melted save has been laundered (opened in
game, saved, and then reloaded). At first I was incredulous, but I've verified
that these reports. Thank you to all who helped debug this problem.

I do not know why EU4 treats a quoted `unit_type` different than unquoted but
the fix is to not loss this distinction when the data is parsed to a tape.

This commit replaces:

```rust
TextToken::Scalar
```

with

```rust
TextToken::Quoted
TextToken::Unquoted
```

and

```rust
BinaryToken::Text
```

with

```rust
BinaryToken::Quoted
BinaryToken::Unquoted
```

Individual game melters will be updated after this has been released