### PR TITLE
An incomplete object should fail to parse

### DIFF
--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -201,7 +201,7 @@ fn to_f64(d: &[u8]) -> Result<f64, ScalarError> {
                     Ok(result)
                 }
             }
-        },
+        }
     }
 }
 
@@ -368,7 +368,6 @@ mod tests {
         assert_eq!(s.to_u64(), Ok(90071992547409097));
         let fl = s.to_f64().unwrap_err();
         assert_eq!(fl, ScalarError::PrecisionLoss(90071992547409100.0));
-
 
         let s = Scalar::new(b"18446744073709547616");
         assert!(s.to_i64().is_err());


### PR DESCRIPTION
Previously `T&}` was allowed to be parsed into a tape of a single key.
This subsequently broke the reader as every object reader assumes that
there is a value for every key and so would panic on this input.

I believe this possibility of panicing was introduced in 0.9.1 with
the addition of vic2 support which required allowing a trailing brace