### PR TITLE
Fix float parsing inaccuracy for (-1, 0) numbers

### DIFF
--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -702,7 +702,12 @@ impl<'a, 'b> ParserState<'a, 'b> {
                             }
 
                             let ind = self.token_tape.len() - 1;
-                            if array_ind_of_hidden_obj.is_some() || !matches!(self.token_tape[ind], TextToken::Unquoted(_) | TextToken::Quoted(_)) {
+                            if array_ind_of_hidden_obj.is_some()
+                                || !matches!(
+                                    self.token_tape[ind],
+                                    TextToken::Unquoted(_) | TextToken::Quoted(_)
+                                )
+                            {
                                 return Err(Error::new(ErrorKind::InvalidSyntax {
                                     msg: String::from("complex trailers are not supported"),
                                     offset: self.offset(data),
@@ -1357,7 +1362,6 @@ mod tests {
             ]
         );
     }
-
 
     #[test]
     fn test_regression() {


### PR DESCRIPTION
Previously `to_f64` would parse `-0.5` as `0.5` as the implementation
would multiple the sign by the leading value (0 in this case) and 0 * -1
= 0.

The implementation has been switched to something inspired by
https://github.com/lemire/fast_double_parser