### PR TITLE
BinaryFlavor receives arrays instead of slices for arguments

### DIFF
--- a/src/binary/flavor.rs
+++ b/src/binary/flavor.rs
@@ -1,20 +1,20 @@
-use crate::{util::le_f32, util::le_i32, Encoding, Utf8Encoding, Windows1252Encoding};
+use crate::{Encoding, Utf8Encoding, Windows1252Encoding};
 
 /// Trait customizing decoding values from binary data
 pub trait BinaryFlavor: Sized + Encoding {
     /// Decode a f32 from 4 bytes of data
-    fn visit_f32_1(&self, data: &[u8]) -> f32;
+    fn visit_f32_1(&self, data: [u8; 4]) -> f32;
 
     /// Decode a f32 from 8 bytes of data
-    fn visit_f32_2(&self, data: &[u8]) -> f32;
+    fn visit_f32_2(&self, data: [u8; 8]) -> f32;
 }
 
 impl<T: BinaryFlavor> BinaryFlavor for &'_ T {
-    fn visit_f32_1(&self, data: &[u8]) -> f32 {
+    fn visit_f32_1(&self, data: [u8; 4]) -> f32 {
         (**self).visit_f32_1(data)
     }
 
-    fn visit_f32_2(&self, data: &[u8]) -> f32 {
+    fn visit_f32_2(&self, data: [u8; 8]) -> f32 {
         (**self).visit_f32_2(data)
     }
 }
@@ -37,15 +37,15 @@ impl Encoding for Eu4Flavor {
 }
 
 impl BinaryFlavor for Eu4Flavor {
-    fn visit_f32_1(&self, data: &[u8]) -> f32 {
+    fn visit_f32_1(&self, data: [u8; 4]) -> f32 {
         // First encoding is an i32 that has a fixed point offset of 3 decimal digits
-        (le_i32(data) as f32) / 1000.0
+        i32::from_le_bytes(data) as f32 / 1000.0
     }
 
-    fn visit_f32_2(&self, data: &[u8]) -> f32 {
+    fn visit_f32_2(&self, data: [u8; 8]) -> f32 {
         // Second encoding is Q17.15 with 5 fractional digits
         // https://en.wikipedia.org/wiki/Q_(number_format)
-        let val = le_i32(data) as f32 / 32768.0;
+        let val = i64::from_le_bytes(data) as f32 / 32768.0;
         (val * 10_0000.0).floor() / 10_0000.0
     }
 }
@@ -68,11 +68,11 @@ impl Encoding for Ck3Flavor {
 }
 
 impl BinaryFlavor for Ck3Flavor {
-    fn visit_f32_1(&self, data: &[u8]) -> f32 {
-        le_f32(data)
+    fn visit_f32_1(&self, data: [u8; 4]) -> f32 {
+        f32::from_bits(u32::from_le_bytes(data))
     }
 
-    fn visit_f32_2(&self, data: &[u8]) -> f32 {
-        (le_i32(data) as f32) / 1000.0
+    fn visit_f32_2(&self, data: [u8; 8]) -> f32 {
+        i64::from_le_bytes(data) as f32 / 1000.0
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,34 +1,23 @@
-// Allow cast_ptr_alignment issues as we are using them correctly (ie: read_unaligned):
-// https://github.com/rust-lang/rust-clippy/issues/2881
-#![allow(clippy::cast_ptr_alignment)]
+/// A simplified and const generic version of arrayref
+#[inline]
+fn take<const N: usize>(data: &[u8]) -> [u8; N] {
+    debug_assert!(data.len() >= N);
+    unsafe { *(data.as_ptr() as *const [u8; N]) }
+}
 
 #[inline]
-pub(crate) fn le_u16(data: &[u8]) -> u16 {
-    let ptr = data.as_ptr() as *const u8 as *const u16;
-    unsafe { ::std::ptr::read_unaligned(ptr).to_le() }
+pub(crate) fn get<const N: usize>(data: &[u8]) -> Option<[u8; N]> {
+    data.get(..N).map(take)
 }
 
 #[inline]
 pub(crate) fn le_u32(data: &[u8]) -> u32 {
-    let ptr = data.as_ptr() as *const u8 as *const u32;
-    unsafe { ::std::ptr::read_unaligned(ptr).to_le() }
+    u32::from_le_bytes(take::<4>(data))
 }
 
 #[inline]
 pub(crate) fn le_u64(data: &[u8]) -> u64 {
-    let ptr = data.as_ptr() as *const u8 as *const u64;
-    unsafe { ::std::ptr::read_unaligned(ptr).to_le() }
-}
-
-#[inline]
-pub(crate) fn le_i32(data: &[u8]) -> i32 {
-    let ptr = data.as_ptr() as *const u8 as *const i32;
-    unsafe { ::std::ptr::read_unaligned(ptr).to_le() }
-}
-
-#[inline]
-pub(crate) fn le_f32(data: &[u8]) -> f32 {
-    f32::from_bits(le_u32(data))
+    u64::from_le_bytes(take::<8>(data))
 }
 
 #[inline(always)]


### PR DESCRIPTION
This should make it more intuitive what the inputs of the function are
without needing to read documentation. The implementation uses a
simplified and const generic version of arrayref, which helped reduce
the number of unsafe usages significantly.

Benchmarks showed no regression when this was implemented so
preferring arrays to unaligned slice pointer reads was applied across
the code base

Closes #64