### PR TITLE
Rename secondary binary float point encoding to f64

### DIFF
--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -326,8 +326,8 @@ fn visit_key<'c, 'b: 'c, 'de: 'b, 'res: 'de, RES: TokenResolver, E: Encoding, V:
                 Cow::Owned(s) => visitor.visit_string(s),
             }
         }
-        BinaryToken::F32_1(x) => visitor.visit_f32(x),
-        BinaryToken::F32_2(x) => visitor.visit_f32(x),
+        BinaryToken::F32(x) => visitor.visit_f32(x),
+        BinaryToken::F64(x) => visitor.visit_f64(x),
         BinaryToken::Token(s) => match config.resolver.resolve(s) {
             Some(id) => visitor.visit_borrowed_str(id),
             None => match config.failed_resolve_strategy {

--- a/src/binary/flavor.rs
+++ b/src/binary/flavor.rs
@@ -3,19 +3,19 @@ use crate::{Encoding, Utf8Encoding, Windows1252Encoding};
 /// Trait customizing decoding values from binary data
 pub trait BinaryFlavor: Sized + Encoding {
     /// Decode a f32 from 4 bytes of data
-    fn visit_f32_1(&self, data: [u8; 4]) -> f32;
+    fn visit_f32(&self, data: [u8; 4]) -> f32;
 
-    /// Decode a f32 from 8 bytes of data
-    fn visit_f32_2(&self, data: [u8; 8]) -> f32;
+    /// Decode a f64 from 8 bytes of data
+    fn visit_f64(&self, data: [u8; 8]) -> f64;
 }
 
 impl<T: BinaryFlavor> BinaryFlavor for &'_ T {
-    fn visit_f32_1(&self, data: [u8; 4]) -> f32 {
-        (**self).visit_f32_1(data)
+    fn visit_f32(&self, data: [u8; 4]) -> f32 {
+        (**self).visit_f32(data)
     }
 
-    fn visit_f32_2(&self, data: [u8; 8]) -> f32 {
-        (**self).visit_f32_2(data)
+    fn visit_f64(&self, data: [u8; 8]) -> f64 {
+        (**self).visit_f64(data)
     }
 }
 
@@ -37,15 +37,15 @@ impl Encoding for Eu4Flavor {
 }
 
 impl BinaryFlavor for Eu4Flavor {
-    fn visit_f32_1(&self, data: [u8; 4]) -> f32 {
+    fn visit_f32(&self, data: [u8; 4]) -> f32 {
         // First encoding is an i32 that has a fixed point offset of 3 decimal digits
         i32::from_le_bytes(data) as f32 / 1000.0
     }
 
-    fn visit_f32_2(&self, data: [u8; 8]) -> f32 {
+    fn visit_f64(&self, data: [u8; 8]) -> f64 {
         // Second encoding is Q17.15 with 5 fractional digits
         // https://en.wikipedia.org/wiki/Q_(number_format)
-        let val = i64::from_le_bytes(data) as f32 / 32768.0;
+        let val = i64::from_le_bytes(data) as f64 / 32768.0;
         (val * 10_0000.0).floor() / 10_0000.0
     }
 }
@@ -68,11 +68,11 @@ impl Encoding for Ck3Flavor {
 }
 
 impl BinaryFlavor for Ck3Flavor {
-    fn visit_f32_1(&self, data: [u8; 4]) -> f32 {
+    fn visit_f32(&self, data: [u8; 4]) -> f32 {
         f32::from_bits(u32::from_le_bytes(data))
     }
 
-    fn visit_f32_2(&self, data: [u8; 8]) -> f32 {
-        i64::from_le_bytes(data) as f32 / 1000.0
+    fn visit_f64(&self, data: [u8; 8]) -> f64 {
+        i64::from_le_bytes(data) as f64 / 1000.0
     }
 }


### PR DESCRIPTION
There's a bit of an oddity with the binary tokens. There are two
floating point values:

```rust
BinaryToken::F32_1(f32)
BinaryToken::F32_2(f32)
```

The second version actually consumes 8 bytes of data, so a better design
should be:

```rust
BinaryToken::F64(f64)
```

Before #67, only 4 bytes of data was looked at for this second version.
This led to incorrect decoding as seen by the eu4save's burg.eu4 and
cologne2.eu4 which when only 4 bytes were considered the
`total_military_power` field was decoded as negative instead of a large
positive.

Closes #65 