### PR TITLE
Rewrite Scalar methods to take self instead of reference

### DIFF
--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -62,7 +62,7 @@ impl<'a> Scalar<'a> {
     }
 
     /// View the raw data
-    pub fn view_data(&self) -> &'a [u8] {
+    pub fn view_data(self) -> &'a [u8] {
         self.data
     }
 
@@ -77,7 +77,7 @@ impl<'a> Scalar<'a> {
     /// let v2 = Scalar::new(b"-5.67821");
     /// assert_eq!(v2.to_f64(), Ok(-5.67821));
     /// ```
-    pub fn to_f64(&self) -> Result<f64, ScalarError> {
+    pub fn to_f64(self) -> Result<f64, ScalarError> {
         to_f64(self.data)
     }
 
@@ -92,7 +92,7 @@ impl<'a> Scalar<'a> {
     /// let v2 = Scalar::new(b"no");
     /// assert_eq!(v2.to_bool(), Ok(false));
     /// ```
-    pub fn to_bool(&self) -> Result<bool, ScalarError> {
+    pub fn to_bool(self) -> Result<bool, ScalarError> {
         to_bool(self.data)
     }
 
@@ -107,7 +107,7 @@ impl<'a> Scalar<'a> {
     /// let v2 = Scalar::new(b"120");
     /// assert_eq!(v2.to_i64(), Ok(120));
     /// ```
-    pub fn to_i64(&self) -> Result<i64, ScalarError> {
+    pub fn to_i64(self) -> Result<i64, ScalarError> {
         to_i64(self.data)
     }
 
@@ -122,7 +122,7 @@ impl<'a> Scalar<'a> {
     /// let v2 = Scalar::new(b"120");
     /// assert_eq!(v2.to_i64(), Ok(120));
     /// ```
-    pub fn to_u64(&self) -> Result<u64, ScalarError> {
+    pub fn to_u64(self) -> Result<u64, ScalarError> {
         to_u64(self.data)
     }
 
@@ -137,7 +137,7 @@ impl<'a> Scalar<'a> {
     /// let v2 = Scalar::new(&[255][..]);
     /// assert!(!v2.is_ascii());
     /// ```
-    pub fn is_ascii(&self) -> bool {
+    pub fn is_ascii(self) -> bool {
         self.data.is_ascii()
     }
 }


### PR DESCRIPTION
Clippy flagged all the scalar methods as breaking the wrong self
convention: https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

Following the logic from: https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv

> `f64::to_radians()` converts a floating point quantity from degrees to
radians. The input is `f64`. Passing a reference `&f64` is not warranted
because `f64` is cheap to copy. Calling the function `into_radians` would be
misleading because the input is not consumed.

Since scalar is `Copy` it doesn't warrant a `self` reference.

Initially I was considering renaming them to `as_*` but realized that is
inappropriate as the conversion is not free (can cost up to 10 ns to
perform the slowest conversion), and `as_*` methods are considered to be
free.