### PR TITLE
Rename `Scalar::view_data` to `Scalar::as_bytes`

### DIFF
--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -321,7 +321,7 @@ fn visit_key<'c, 'b: 'c, 'de: 'b, 'res: 'de, RES: TokenResolver, E: Encoding, V:
         BinaryToken::U64(x) => visitor.visit_u64(x),
         BinaryToken::I32(x) => visitor.visit_i32(x),
         BinaryToken::Quoted(x) | BinaryToken::Unquoted(x) => {
-            match config.encoding.decode(x.view_data()) {
+            match config.encoding.decode(x.as_bytes()) {
                 Cow::Borrowed(s) => visitor.visit_borrowed_str(s),
                 Cow::Owned(s) => visitor.visit_string(s),
             }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -63,7 +63,7 @@ impl<'a> Scalar<'a> {
 
     /// View the raw data
     #[inline]
-    pub fn view_data(self) -> &'a [u8] {
+    pub fn as_bytes(self) -> &'a [u8] {
         self.data
     }
 

--- a/src/text/de.rs
+++ b/src/text/de.rs
@@ -146,7 +146,7 @@ where
             Reader::Scalar(x) => visit_str!(x.read_str(), visitor),
             Reader::Value(x) => match x.token() {
                 TextToken::Quoted(s) | TextToken::Unquoted(s) => {
-                    visit_str!(x.decode(s.view_data()), visitor)
+                    visit_str!(x.decode(s.as_bytes()), visitor)
                 }
                 TextToken::Header(_) | TextToken::Array(_) => self.deserialize_seq(visitor),
                 TextToken::Object(_) | TextToken::HiddenObject(_) => self.deserialize_map(visitor),
@@ -179,14 +179,14 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_borrowed_bytes(self.reader_ref().read_scalar()?.view_data())
+        visitor.visit_borrowed_bytes(self.reader_ref().read_scalar()?.as_bytes())
     }
 
     fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_byte_buf(self.reader_ref().read_scalar()?.view_data().to_vec())
+        visitor.visit_byte_buf(self.reader_ref().read_scalar()?.as_bytes().to_vec())
     }
 
     fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -328,13 +328,13 @@ where
     /// Decode the data with a given string encoding
     #[inline]
     pub fn read_str(&self) -> Cow<'data, str> {
-        self.encoding.decode(self.scalar.view_data())
+        self.encoding.decode(self.scalar.as_bytes())
     }
 
     /// Decode the data with a given string encoding
     #[inline]
     pub fn read_string(&self) -> String {
-        self.encoding.decode(self.scalar.view_data()).into_owned()
+        self.encoding.decode(self.scalar.as_bytes()).into_owned()
     }
 
     /// Return the underlying scalar
@@ -385,7 +385,7 @@ where
     pub fn read_str(&self) -> Result<Cow<'data, str>, DeserializeError> {
         self.tokens[self.value_ind]
             .as_scalar()
-            .map(|x| self.encoding.decode(x.view_data()))
+            .map(|x| self.encoding.decode(x.as_bytes()))
             .ok_or_else(|| DeserializeError {
                 kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
             })
@@ -396,7 +396,7 @@ where
     pub fn read_string(&self) -> Result<String, DeserializeError> {
         self.tokens[self.value_ind]
             .as_scalar()
-            .map(|x| self.encoding.decode(x.view_data()).into_owned())
+            .map(|x| self.encoding.decode(x.as_bytes()).into_owned())
             .ok_or_else(|| DeserializeError {
                 kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
             })

--- a/src/text/writer.rs
+++ b/src/text/writer.rs
@@ -558,7 +558,7 @@ where
                 TextToken::Parameter(x) => {
                     self.write_preamble()?;
                     write!(self.writer, "[[")?;
-                    self.writer.write_all(x.view_data())?;
+                    self.writer.write_all(x.as_bytes())?;
                     self.writer.write_all(b"]")?;
 
                     if let Ok(obj) = value.read_object() {
@@ -574,7 +574,7 @@ where
                 TextToken::UndefinedParameter(x) => {
                     self.write_preamble()?;
                     write!(self.writer, "[[!")?;
-                    self.writer.write_all(x.view_data())?;
+                    self.writer.write_all(x.as_bytes())?;
                     self.writer.write_all(b"]")?;
 
                     if let Ok(obj) = value.read_object() {
@@ -591,7 +591,7 @@ where
                     // quoted keys really shouldn't happen but when they do
                     // we should make sure to preserve them. This is different
                     // behavior than writing by hand.
-                    self.force_write_quotes(x.view_data())?;
+                    self.force_write_quotes(x.as_bytes())?;
                     if let Some(op) = op {
                         self.write_operator(op)?;
                     }
@@ -599,7 +599,7 @@ where
                     self.write_value(value)?;
                 }
                 _ => {
-                    self.write_unquoted(key.read_scalar().view_data())?;
+                    self.write_unquoted(key.read_scalar().as_bytes())?;
                     if let Some(op) = op {
                         self.write_operator(op)?;
                     }
@@ -636,10 +636,10 @@ where
                 self.write_object_core(obj)?;
             }
             TextToken::Unquoted(x) => {
-                self.write_unquoted(x.view_data())?;
+                self.write_unquoted(x.as_bytes())?;
             }
             TextToken::Quoted(x) => {
-                self.force_write_quotes(x.view_data())?;
+                self.force_write_quotes(x.as_bytes())?;
             }
             TextToken::Parameter(_) => unreachable!(),
             TextToken::UndefinedParameter(_) => unreachable!(),
@@ -647,7 +647,7 @@ where
             TextToken::End(_) => unreachable!(),
             TextToken::Header(x) => {
                 let mut arr = value.read_array().unwrap();
-                self.write_header(x.view_data())?;
+                self.write_header(x.as_bytes())?;
                 arr.next_value().unwrap();
                 let elem = arr.next_value().unwrap();
                 self.write_value(elem)?;


### PR DESCRIPTION
The convention for a cheap, borrowed, and decrease in abstraction method
is to have the function name prefixed with `as_` (C-CONV:
https://rust-lang.github.io/api-guidelines/naming.html#c-conv)

Thus `Scalar::view_data` has been renamed to `Scalar::as_bytes`.

Breaking changes suck but at least it is a mechanical change.