### PR TITLE
Fix missing escape char on terminating quote

### DIFF
--- a/src/text/writer.rs
+++ b/src/text/writer.rs
@@ -782,6 +782,9 @@ fn escape(data: &[u8], mut buffer: Vec<u8>) -> ReuseVec {
 
             if let Some(&last) = data.last() {
                 if last != b'\n' {
+                    if last == b'\\' || last == b'"' {
+                        buffer.push(b'\\');
+                    }
                     buffer.push(last);
                 }
             }
@@ -1221,6 +1224,10 @@ mod tests {
         assert_eq!(b"abc"[..], *actual);
         let actual = escape(b"Joe \"Captain\" Rogers\n", actual.buffer());
         assert_eq!(br#"Joe \"Captain\" Rogers"#[..], *actual);
+        let actual = escape(br#"Project "Eagle""#, actual.buffer());
+        assert_eq!(br#"Project \"Eagle\""#[..], *actual);
+        let actual = escape(br#"Project Eagle""#, actual.buffer());
+        assert_eq!(br#"Project Eagle\""#[..], *actual);
     }
 
     #[test]


### PR DESCRIPTION
The given text:

```
Project "Eagle"
```

Would be written as

```
Project \"Eagle"
```

Notice that the second quote is not escaped.

The bug originates in the final character check, which will skip a
trailing newline (needed for melting EU4 which has quoted entries that
need to be trimmed)

This commit fixes the issue by checking the last character and escaping
it as needed