### PR TITLE
Support decoding numbers with leading plus sign

### DIFF
--- a/src/common/date.rs
+++ b/src/common/date.rs
@@ -1,4 +1,4 @@
-use crate::scalar::{to_i64_t, to_u64, to_u64_t};
+use crate::scalar::{to_i64_t, to_u64_t};
 use crate::DateError;
 use std::cmp::Ordering;
 use std::convert::TryFrom;
@@ -142,10 +142,10 @@ impl ExpandedRawDate {
         }
 
         let (delim3, data) = data.split_first()?;
-        let hour = to_u64(data).ok()?;
+        let (hour, data) = to_u64_t(data, 0).ok()?;
         let hour = u8::try_from(hour).ok()?;
 
-        if hour != 0 && *delim1 == b'.' && *delim2 == b'.' && *delim3 == b'.' {
+        if data.is_empty() && hour != 0 && *delim1 == b'.' && *delim2 == b'.' && *delim3 == b'.' {
             Some(ExpandedRawDate {
                 year,
                 month,

--- a/src/text/de.rs
+++ b/src/text/de.rs
@@ -1568,4 +1568,17 @@ mod tests {
             date: UniformDate,
         }
     }
+
+    #[test]
+    fn test_deserialize_positive_num() {
+        let data = b"pop_happiness = +0.10";
+
+        let actual: MyStruct = from_slice(&data[..]).unwrap();
+        assert_eq!(actual, MyStruct { pop_happiness: 0.1 });
+
+        #[derive(Deserialize, Debug, PartialEq)]
+        struct MyStruct {
+            pop_happiness: f64,
+        }
+    }
 }

--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -2252,6 +2252,18 @@ mod tests {
     }
 
     #[test]
+    fn test_text_number_plus() {
+        let data = b"pop_happiness = +0.10";
+        assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Unquoted(Scalar::new(b"pop_happiness")),
+                TextToken::Unquoted(Scalar::new(b"+0.10")),
+            ]
+        );
+    }
+
+    #[test]
     fn test_parameter_eof() {
         let data = b"[[";
         TextTape::from_slice(data).unwrap_err();


### PR DESCRIPTION
It appears that the game engine allows for explicit positive numbers:

In EU4 golden bulls:

```
yearly_absolutism = +0.5
```

In Stellaris static modifiers:

```
pop_happiness = +0.10
```

Did not find this occurence in HOI4, Imperator, or CK3.

This commits allows a plus sign to be present (and skipped) when
decoding a number from a scalar. Benchmarks show no performance changes.