### PR TITLE
Add `take_last` deserialization attribute

### DIFF
--- a/jomini_derive/tests/11-last.rs
+++ b/jomini_derive/tests/11-last.rs
@@ -1,0 +1,25 @@
+use jomini_derive::JominiDeserialize;
+
+#[derive(JominiDeserialize)]
+pub struct Model {
+    human: bool,
+    #[jomini(take_last)]
+    checksum: String,
+    fourth: u16,
+}
+
+#[test]
+fn test_options() {
+    let data = r#"
+        {
+            "human": true,
+            "checksum": "true",
+            "fourth": 4,
+            "checksum": "false"
+        }"#;
+
+    let m: Model = serde_json::from_str(data).unwrap();
+    assert_eq!(m.checksum, String::from("false"));
+    assert_eq!(m.human, true);
+    assert_eq!(m.fourth, 4);
+}


### PR DESCRIPTION
[Paperman][0] melted saves (ironman to normal) include every checksum
that is part of the original ironman save, even though the combined
format should only have a single checksum. In order to support parsing
paperman melted saves, which is how skanderbeg converts them, this
commit introduces a new attribute that will only take the last instance
of a field instead of throwing a duplicate field error.

```rust
pub struct Model {
    #[jomini(take_last)]
    checksum: String,
}
```

[0]: https://gitgud.io/nixx/paperman