### PR TITLE
Use copyless allocation in binary parsing for minor performance boost

### DIFF
--- a/src/copyless.rs
+++ b/src/copyless.rs
@@ -1,0 +1,39 @@
+///! Trimmed down version of copyless v0.1.5: https://github.com/kvark/copyless
+
+/// A typesafe helper that separates new value construction from
+/// vector growing, allowing LLVM to ideally construct the element in place.
+pub struct VecAllocation<'a, T: 'a> {
+    vec: &'a mut Vec<T>,
+    index: usize,
+}
+
+impl<'a, T> VecAllocation<'a, T> {
+    /// Consumes self and writes the given value into the allocation.
+    // writing is safe because alloc() ensured enough capacity
+    // and `Allocation` holds a mutable borrow to prevent anyone else
+    // from breaking this invariant.
+    #[inline(always)]
+    pub fn init(self, value: T) -> usize {
+        unsafe {
+            std::ptr::write(self.vec.as_mut_ptr().add(self.index), value);
+            self.vec.set_len(self.index + 1);
+        }
+        self.index
+    }
+}
+
+/// Helper trait for a `Vec` type that allocates up-front.
+pub trait VecHelper<T> {
+    /// Grows the vector by a single entry, returning the allocation.
+    fn alloc(&mut self) -> VecAllocation<T>;
+}
+
+impl<T> VecHelper<T> for Vec<T> {
+    fn alloc(&mut self) -> VecAllocation<T> {
+        let index = self.len();
+        if self.capacity() == index {
+            self.reserve(1);
+        }
+        VecAllocation { vec: self, index }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,7 @@ assert_eq!(&out, b"hello=world\nfoo=bar\n");
 #![warn(missing_docs)]
 mod binary;
 pub mod common;
+mod copyless;
 mod data;
 #[cfg(feature = "derive")]
 pub(crate) mod de;


### PR DESCRIPTION
https://github.com/kvark/copyless

2-8% throughput increase to binary parsing. Text parsing was unaffected
and so wasn't adapted.

Used `cargo asm` and `cargo llvm-ir` to find out some interesting
statistics about the main binary parsing function:

```
jomini::binary::tape::BinaryTape::from_eu4
```

asm instructions:
- copyless: 1609
- master: 1719

number of `memcpy` calls:
- copyless: 5
- master: 51