### PR TITLE
Omit terminating newline from written output

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ let tape = TextTape::from_slice(b"hello   = world")?;
 let mut out: Vec<u8> = Vec::new();
 let mut writer = TextWriterBuilder::new().from_writer(&mut out);
 writer.write_tape(&tape)?;
-assert_eq!(&out, b"hello=world\n");
+assert_eq!(&out, b"hello=world");
 ```
 
 The writer normalizes any formatting issues. The writer is not able to
@@ -197,7 +197,7 @@ writer.write_unquoted(b"hello")?;
 writer.write_unquoted(b"world")?;
 writer.write_unquoted(b"foo")?;
 writer.write_unquoted(b"bar")?;
-assert_eq!(&out, b"hello=world\nfoo=bar\n");
+assert_eq!(&out, b"hello=world\nfoo=bar");
 ```
 
 ## Unsupported Syntax

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ let tape = TextTape::from_slice(b"hello   = world")?;
 let mut out: Vec<u8> = Vec::new();
 let mut writer = TextWriterBuilder::new().from_writer(&mut out);
 writer.write_tape(&tape)?;
-assert_eq!(&out, b"hello=world\n");
+assert_eq!(&out, b"hello=world");
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
@@ -203,7 +203,7 @@ writer.write_unquoted(b"hello")?;
 writer.write_unquoted(b"world")?;
 writer.write_unquoted(b"foo")?;
 writer.write_unquoted(b"bar")?;
-assert_eq!(&out, b"hello=world\nfoo=bar\n");
+assert_eq!(&out, b"hello=world\nfoo=bar");
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 */


### PR DESCRIPTION
EU4 is unable to support loading saves that contain a terminating
newline from the in game menu.

Ref: https://forum.paradoxplaza.com/forum/threads/eu-iv-terminating-newline-on-savefile-prevents-loading-from-in-game-menu.1516206/

If downstream users would like it to end in a newline, they can add it
themselves (and typically it is easier to add than to remove).