### PR TITLE
Decouple text readers from iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ use jomini::TextTape;
 
 let data = b"name=aaa name=bbb core=123 name=ccc name=ddd";
 let tape = TextTape::from_slice(data).unwrap();
-let mut reader = tape.windows1252_reader();
+let reader = tape.windows1252_reader();
 
-while let Some((key, _op, value)) = reader.next_field() {
+for (key, _op, value) in reader.fields() {
     println!("{:?}={:?}", key.read_str(), value.read_str().unwrap());
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,9 +140,9 @@ use jomini::TextTape;
 
 let data = b"name=aaa name=bbb core=123 name=ccc name=ddd";
 let tape = TextTape::from_slice(data).unwrap();
-let mut reader = tape.windows1252_reader();
+let reader = tape.windows1252_reader();
 
-while let Some((key, _op, value)) = reader.next_field() {
+for (key, _op, value) in reader.fields() {
     println!("{:?}={:?}", key.read_str(), value.read_str().unwrap());
 }
 ```
@@ -217,7 +217,7 @@ pub(crate) mod de;
 mod encoding;
 mod errors;
 mod scalar;
-mod text;
+pub mod text;
 pub(crate) mod util;
 
 pub use self::binary::*;
@@ -225,7 +225,10 @@ pub use self::data::Rgb;
 pub use self::encoding::*;
 pub use self::errors::*;
 pub use self::scalar::{Scalar, ScalarError};
-pub use self::text::*;
+pub use self::text::{TextTape, TextToken, TextWriter, TextWriterBuilder};
+
+#[cfg(feature = "derive")]
+pub use self::text::TextDeserializer;
 
 #[cfg(feature = "derive")]
 pub use jomini_derive::*;

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -1,11 +1,25 @@
+//! Types for parsing clausewitz plaintext input
+//!
+//! See the top level module documentation for an overview that includes parsing
+//! and deserializing text.
+//!
+//! For more examples of the mid-level DOM-like API, see
+//! [FieldGroupsIter](crate::text::FieldGroupsIter),
+//! [FieldsIter](crate::text::FieldsIter), and
+//! [ValuesIter](crate::text::ValuesIter)
 #[cfg(feature = "derive")]
 mod de;
+mod operator;
 mod reader;
 mod tape;
 mod writer;
 
 #[cfg(feature = "derive")]
 pub use self::de::TextDeserializer;
-pub use self::reader::{ArrayReader, ObjectReader, Reader, ScalarReader, ValueReader};
-pub use self::tape::{Operator, TextTape, TextToken};
+pub use self::operator::*;
+pub use self::reader::{
+    ArrayReader, FieldGroupsIter, FieldsIter, GroupEntry, GroupEntryIter, ObjectReader, Reader,
+    ScalarReader, ValueReader, ValuesIter,
+};
+pub use self::tape::{TextTape, TextTapeParser, TextToken};
 pub use self::writer::*;

--- a/src/text/operator.rs
+++ b/src/text/operator.rs
@@ -1,0 +1,63 @@
+use std::fmt::Display;
+
+/// An operator token
+///
+/// This enum contains only non-equal operators due to their rarity. Including
+/// an equals operator would increase the size of the token list by up to 50%.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum Operator {
+    /// A `<` token
+    LessThan,
+
+    /// A `<=` token
+    LessThanEqual,
+
+    /// A `>` token
+    GreaterThan,
+
+    /// A `>=` token
+    GreaterThanEqual,
+
+    /// A `!=` token
+    NotEqual,
+
+    /// A `==` token
+    Exact,
+}
+
+impl Display for Operator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Operator::LessThan => f.write_str("<"),
+            Operator::GreaterThan => f.write_str(">"),
+            Operator::LessThanEqual => f.write_str("<="),
+            Operator::GreaterThanEqual => f.write_str(">="),
+            Operator::NotEqual => f.write_str("!="),
+            Operator::Exact => f.write_str("=="),
+        }
+    }
+}
+
+impl Operator {
+    /// Returns the name of the operator using only letters
+    ///
+    /// ```
+    /// use jomini::text::Operator;
+    /// assert_eq!(Operator::LessThan.name(), "LESS_THAN");
+    /// assert_eq!(Operator::LessThanEqual.name(), "LESS_THAN_EQUAL");
+    /// assert_eq!(Operator::GreaterThan.name(), "GREATER_THAN");
+    /// assert_eq!(Operator::GreaterThanEqual.name(), "GREATER_THAN_EQUAL");
+    /// assert_eq!(Operator::Exact.name(), "EXACT");
+    /// assert_eq!(Operator::NotEqual.name(), "NOT_EQUAL");
+    /// ```
+    pub fn name(&self) -> &'static str {
+        match self {
+            Operator::LessThan => "LESS_THAN",
+            Operator::LessThanEqual => "LESS_THAN_EQUAL",
+            Operator::GreaterThan => "GREATER_THAN",
+            Operator::GreaterThanEqual => "GREATER_THAN_EQUAL",
+            Operator::Exact => "EXACT",
+            Operator::NotEqual => "NOT_EQUAL",
+        }
+    }
+}

--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -1,41 +1,9 @@
-use crate::{data::is_boundary, ObjectReader, Utf8Encoding, Windows1252Encoding};
+use crate::{
+    data::is_boundary,
+    text::{ObjectReader, Operator},
+    Utf8Encoding, Windows1252Encoding,
+};
 use crate::{Error, ErrorKind, Scalar};
-use std::fmt::Display;
-
-/// An operator token
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub enum Operator {
-    /// A `<` token
-    LessThan,
-
-    /// A `<=` token
-    LessThanEqual,
-
-    /// A `>` token
-    GreaterThan,
-
-    /// A `>=` token
-    GreaterThanEqual,
-
-    /// A `!=` token
-    NotEqual,
-
-    /// A `==` token
-    Exact,
-}
-
-impl Display for Operator {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            Operator::LessThan => f.write_str("<"),
-            Operator::GreaterThan => f.write_str(">"),
-            Operator::LessThanEqual => f.write_str("<="),
-            Operator::GreaterThanEqual => f.write_str(">="),
-            Operator::NotEqual => f.write_str("!="),
-            Operator::Exact => f.write_str("=="),
-        }
-    }
-}
 
 /// Represents a valid text value
 #[derive(Debug, Clone, PartialEq)]

--- a/tests/tape.rs
+++ b/tests/tape.rs
@@ -1,4 +1,4 @@
-use jomini::{BinaryTape, Operator, Scalar, TextTape, TextToken};
+use jomini::{text::Operator, BinaryTape, Scalar, TextTape, TextToken};
 
 #[test]
 fn reject_bin_obj_in_hidden_obj() {


### PR DESCRIPTION
Decoupling text readers that are containers (ie: array and objects) from
iteration is a breaking change. Instead of writing:

```rust
let data = b"name=aaa name=bbb core=123 name=ccc name=ddd";
let tape = TextTape::from_slice(data)?;
let mut reader = tape.windows1252_reader();
while let Some((key, _op, value)) = reader.next_field() {
    println!("{:?}={:?}", key.read_str(), value.read_str()?);
}
```

One will now write:

```rust
let data = b"name=aaa name=bbb core=123 name=ccc name=ddd";
let tape = TextTape::from_slice(data)?;
let reader = tape.windows1252_reader();
for (key, _op, value) in reader.fields() {
    println!("{:?}={:?}", key.read_str(), value.read_str()?);
}
```

The new version is more concise and allows users to iterate over a
fields or values more than once without cloning, which could have been
expensive due to the internal state of `ObjectReader` internally relying
on a lazily allocated vector to keep track of grouped keys. This state
has now been moved to the iterator returned by
`ObjectReader::field_groups()` so that cloning of readers can now always
be done cheaply.

All the `Iterator` trait functions are available to the new iterator
functions.

The API should be more intuitive as now there is zero chance of a user
accidentally interweaving calls to `ObjectReader::next_field()` with
`ObjectReader::next_fields()`.

Previously grouping keys always allocated a vector to hold the
respective values, but the vast majority of the time each group will
contain only a single value, so the group has been optimized such that
each field group is an enum that holds either one (which doesn't require
heap allocation) or many values (which will).

The algorithm for grouping keys has been changed to use a hashmap
instead of a vector which changes the algorithm complexity from (n^2 /
2) to (2n). It remains to be seen what kind of performance benefit this
brings.

This commit also moves several types out of being exported at the root
to avoid polluting the root namespace with highly specific structs (like
the iterator of values from grouped keys) that are better residing in
their own module (in this case `text`).

Benchmarks show that deserialization performance seemed to benefit by a
percent or two