### PR TITLE
Improve text decoding performance

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -277,7 +277,7 @@ pub(crate) const COMMENT: u8 = 8;
 
 #[inline]
 pub(crate) fn is_whitespace(b: u8) -> bool {
-    CHARACTER_CLASS[usize::from(b)] == WHITESPACE
+    b.is_ascii_whitespace()
 }
 
 #[inline]


### PR DESCRIPTION
I was doing some benchmarking and saw the decoding from byte data to
utf-8 consumed a bit too much of the profiling. This PR improves text
decoding throughput by over 50% in some cases (in particular, windows
1252 decoding of ascii input between 8 and 16 bytes).

This was accomplished through several means:

- Move trimming trailing whitespace to the end of the decoding process
when, I presume, the end of the input is already hot. I saw in profiling
that 22% of the L1 data read misses in the json benchmark were from
checking the last character. Moving it to the end should dramatically
drop this percentage (probably to 0).
- Increase the capacity that the string is allocated with when non-ascii
code is encountered with the precaution that the remaining characters
are all 2 bytes. Previously the allocated capacity was too low causing a
guaranteed string reallocation.
- Change `is_whitespace` to a conditional instead of a table lookup