### PR TITLE
Add support for converting text to Json

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,11 +66,13 @@ jobs:
         echo "TARGET=--target ${{ matrix.target }}" >> $GITHUB_ENV
     - name: Build
       run: ${{ env.CARGO }} build --all --verbose $TARGET
-    - name: Run tests
+    - name: Run default features tests
       run: ${{ env.CARGO }} test --all --verbose $TARGET
     - name: Run no-default-feature tests
       run: ${{ env.CARGO }} test --no-default-features --all --verbose $TARGET
-      
+    - name: Run json tests
+      run: ${{ env.CARGO }} test --features json --all --verbose $TARGET
+
     - name: Compile benchmarks
       if: matrix.build == 'stable'
       run: cargo bench --verbose --no-run $TARGET

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,21 @@ description = "Low level, performance oriented parser for save and game files fr
 keywords = ["eu4", "ck3", "ironman", "clausewitz"]
 exclude = ["/.github", "/assets"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [workspace]
 members = ["jomini_derive"]
 
 [dependencies]
 serde = { version = "1", optional = true }
+serde_json = { version = "1", optional = true }
 jomini_derive = { path = "jomini_derive", version = "^0.2.2", optional = true }
 
 [features]
 default = ["derive"]
 derive = ["serde", "jomini_derive"]
+json = ["serde", "serde_json"]
 
 [dev-dependencies]
 encoding_rs = "0.8"
@@ -28,6 +33,10 @@ criterion = "0.3"
 quickcheck = "1"
 quickcheck_macros = "1"
 serde = { version = "1", features = ["derive"] }
+
+[[example]]
+name = "json"
+required-features = ["json"]
 
 [[bench]]
 name = "jomini_bench"

--- a/README.md
+++ b/README.md
@@ -143,6 +143,18 @@ for (key, _op, value) in reader.fields() {
 }
 ```
 
+The mid-level API also provides the excellent utility of converting the
+plaintext Clausewitz format to JSON when the `json` feature is enabled.
+
+```rust
+use jomini::TextTape;
+
+let tape = TextTape::from_slice(b"foo=bar")?;
+let reader = tape.windows1252_reader();
+let actual = reader.json().to_string()?;
+assert_eq!(actual, r#"{"foo":"bar"}"#);
+```
+
 ## One Level Lower
 
 At the lowest layer, one can interact with the raw data directly via `TextTape`

--- a/benches/jomini_bench.rs
+++ b/benches/jomini_bench.rs
@@ -230,6 +230,111 @@ pub fn text_parse_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(not(feature = "json"))]
+pub fn json_benchmark(c: &mut Criterion) {}
+
+#[cfg(feature = "json")]
+pub fn json_benchmark(c: &mut Criterion) {
+    use jomini::json::{DuplicateKeyMode, JsonOptions};
+
+    let data = &METADATA_TXT["EU4txt".len()..];
+    let tape = TextTape::from_slice(data).unwrap();
+
+    let mut group = c.benchmark_group("json");
+
+    let bytes = tape.windows1252_reader().json().to_string().unwrap().len();
+    group.throughput(Throughput::Bytes(bytes as u64));
+    group.bench_function(BenchmarkId::new("preserve", "eu4"), |b| {
+        b.iter(|| tape.windows1252_reader().json().to_string().unwrap())
+    });
+
+    let bytes = tape
+        .windows1252_reader()
+        .json()
+        .with_options(JsonOptions::new().with_duplicate_keys(DuplicateKeyMode::Group))
+        .to_string()
+        .unwrap()
+        .len();
+
+    group.throughput(Throughput::Bytes(bytes as u64));
+    group.bench_function(BenchmarkId::new("group", "eu4"), |b| {
+        b.iter(|| {
+            tape.windows1252_reader()
+                .json()
+                .with_options(JsonOptions::new().with_duplicate_keys(DuplicateKeyMode::Group))
+                .to_string()
+                .unwrap()
+        })
+    });
+
+    let bytes = tape
+        .windows1252_reader()
+        .json()
+        .with_options(JsonOptions::new().with_duplicate_keys(DuplicateKeyMode::KeyValuePairs))
+        .to_string()
+        .unwrap()
+        .len();
+
+    group.throughput(Throughput::Bytes(bytes as u64));
+    group.bench_function(BenchmarkId::new("typed", "eu4"), |b| {
+        b.iter(|| {
+            tape.windows1252_reader()
+                .json()
+                .with_options(JsonOptions::new().with_duplicate_keys(DuplicateKeyMode::KeyValuePairs))
+                .to_string()
+                .unwrap()
+        })
+    });
+
+    let data = &CK3_TXT[..];
+    let tape = TextTape::from_slice(data).unwrap();
+    let bytes = tape.windows1252_reader().json().to_string().unwrap().len();
+    group.throughput(Throughput::Bytes(bytes as u64));
+    group.bench_function(BenchmarkId::new("preserve", "ck3"), |b| {
+        b.iter(|| tape.windows1252_reader().json().to_string().unwrap())
+    });
+
+    let bytes = tape
+        .windows1252_reader()
+        .json()
+        .with_options(JsonOptions::new().with_duplicate_keys(DuplicateKeyMode::Group))
+        .to_string()
+        .unwrap()
+        .len();
+
+    group.throughput(Throughput::Bytes(bytes as u64));
+    group.bench_function(BenchmarkId::new("group", "ck3"), |b| {
+        b.iter(|| {
+            tape.windows1252_reader()
+                .json()
+                .with_options(JsonOptions::new().with_duplicate_keys(DuplicateKeyMode::Group))
+                .to_string()
+                .unwrap()
+        })
+    });
+
+    let bytes = tape
+        .windows1252_reader()
+        .json()
+        .with_options(JsonOptions::new().with_duplicate_keys(DuplicateKeyMode::KeyValuePairs))
+        .to_string()
+        .unwrap()
+        .len();
+
+    group.throughput(Throughput::Bytes(bytes as u64));
+    group.bench_function(BenchmarkId::new("typed", "ck3"), |b| {
+        b.iter(|| {
+            tape.windows1252_reader()
+                .json()
+                .with_options(JsonOptions::new().with_duplicate_keys(DuplicateKeyMode::KeyValuePairs))
+                .to_string()
+                .unwrap()
+        })
+    });
+
+    group.finish();
+}
+
 pub fn date_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("eu4date-parse");
     group.bench_function("valid-date", |b| {
@@ -258,5 +363,6 @@ criterion_group!(
     to_u64_benchmark,
     to_f64_benchmark,
     date_benchmark,
+    json_benchmark,
 );
 criterion_main!(benches);

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,0 +1,22 @@
+use jomini::json::JsonOptions;
+use std::error;
+use std::io::{self, Read};
+
+fn main() -> Result<(), Box<dyn error::Error>> {
+    let mut data = Vec::new();
+    io::stdin().read_to_end(&mut data)?;
+    match jomini::TextTape::from_slice(&data) {
+        Ok(t) => {
+            let out = std::io::stdout();
+            let handle = out.lock();
+            t.windows1252_reader()
+                .json()
+                .with_options(JsonOptions::new().with_prettyprint(true))
+                .to_writer(handle)
+                .unwrap();
+        }
+        Err(e) => println!("errored with {}", e),
+    }
+
+    Ok(())
+}

--- a/examples/tape_text.rs
+++ b/examples/tape_text.rs
@@ -5,7 +5,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let mut data = Vec::new();
     io::stdin().read_to_end(&mut data)?;
     match jomini::TextTape::from_slice(&data) {
-        Ok(t) => println!("{:#?}", t.tokens()),
+        Ok(t) => println!("{:#?}", t.tokens().len()),
         Err(e) => println!("errored with {}", e),
     }
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2018"
 [package.metadata]
 cargo-fuzz = true
 
+[features]
+json = ["jomini/json"]
+
 [dependencies]
 libfuzzer-sys = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/fuzz/fuzz_targets/fuzz_text.rs
+++ b/fuzz/fuzz_targets/fuzz_text.rs
@@ -126,6 +126,9 @@ fuzz_target!(|data: &[u8]| {
             }
         }
 
+        #[cfg(feature = "json")]
+        tape.windows1252_reader().json().to_string().unwrap();
+
         iterate_object(tape.windows1252_reader());
 
         unsafe { GROUPED = true; }

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -1,0 +1,962 @@
+//! Handles conversion of plaintext clausewitz format to JSON
+//!
+//! ```
+//! use jomini::{TextTape, json::{JsonOptions, DuplicateKeyMode}};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let tape = TextTape::from_slice(b"core=a core=b")?;
+//! let reader = tape.windows1252_reader();
+//!
+//! let options = JsonOptions::new()
+//!     .with_prettyprint(false)
+//!     .with_duplicate_keys(DuplicateKeyMode::Preserve);
+//!
+//! // These are the default options
+//! assert_eq!(options, JsonOptions::default());
+//!
+//! let actual = reader.json()
+//!     .with_options(options)
+//!     .to_string()?;
+//! assert_eq!(actual, r#"{"core":"a","core":"b"}"#);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The scope of the JSON can be narrowed to an inner value. This comes in handy
+//! when the parsed document is large but only a small subset of it needs to be
+//! exposed with JSON.
+//!
+//! ```
+//! use jomini::{TextTape};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let tape = TextTape::from_slice(b"nums={1 2 3 4}")?;
+//! let reader = tape.windows1252_reader();
+//! let mut fields = reader.fields();
+//! let (_key, _op, value) = fields.next().unwrap();
+//! let array = value.read_array()?;
+//! let actual = array.json().to_string()?;
+//! let expected = r#"[1,2,3,4]"#;
+//! assert_eq!(&actual, expected);
+//! # Ok(())
+//! # }
+//! ```
+
+use crate::{
+    text::{ArrayReader, GroupEntry, ObjectReader, Operator, ScalarReader, ValueReader},
+    Encoding, TextToken,
+};
+use serde::{
+    ser::{SerializeMap, SerializeSeq},
+    Serialize, Serializer,
+};
+use std::ops::Deref;
+
+/// Customizes the JSON output
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsonOptions {
+    /// Controls if the JSON should be pretty printed
+    pretty: bool,
+
+    /// Controls the how duplicate keys are formatted
+    duplicate_keys: DuplicateKeyMode,
+}
+
+impl JsonOptions {
+    /// Creates the structure with default options
+    pub fn new() -> Self {
+        JsonOptions::default()
+    }
+
+    /// Sets if the JSON should be pretty printed or minified
+    pub fn with_prettyprint(mut self, pretty: bool) -> JsonOptions {
+        self.pretty = pretty;
+        self
+    }
+
+    /// Sets how duplicate keys are formatted
+    pub fn with_duplicate_keys(mut self, duplicate_keys: DuplicateKeyMode) -> JsonOptions {
+        self.duplicate_keys = duplicate_keys;
+        self
+    }
+
+    /// Returns the factor to multiply the token length for a size estimate.
+    ///
+    /// The numbers were found empirically by taking CK3 and EU4 meta data
+    /// from saves and seeing how the JSON output compared with the token length
+    pub(crate) fn output_len_factor(&self) -> usize {
+        match (self.pretty, self.duplicate_keys) {
+            (false, DuplicateKeyMode::Group | DuplicateKeyMode::Preserve) => 10,
+            (true, DuplicateKeyMode::Group | DuplicateKeyMode::Preserve) => 20,
+            (false, DuplicateKeyMode::KeyValuePairs) => 15,
+            (true, DuplicateKeyMode::KeyValuePairs) => 60,
+        }
+    }
+}
+
+impl Default for JsonOptions {
+    fn default() -> Self {
+        Self {
+            pretty: false,
+            duplicate_keys: DuplicateKeyMode::Preserve,
+        }
+    }
+}
+
+/// Controls JSON structure when duplicate keys are encountered
+///
+/// It's debatable whether [duplicate keys is valid
+/// JSON](https://stackoverflow.com/q/21832701), so this allows one to customize
+/// output depending how flexible a downstream client is at handling JSON.
+///
+/// The options are either:
+///
+/// - Group values into an array under a single field
+/// - Preserve the duplicate keys
+/// - Rewrite objects as an array of key value pairs
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DuplicateKeyMode {
+    /// Group values into an array under a single field
+    ///
+    /// ```
+    /// use jomini::{TextTape, json::{JsonOptions, DuplicateKeyMode}};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let tape = TextTape::from_slice(b"a={b=1} c={b=1 b=2}")?;
+    /// let reader = tape.windows1252_reader();
+    ///
+    /// let options = JsonOptions::new()
+    ///     .with_duplicate_keys(DuplicateKeyMode::Group);
+    ///
+    /// let actual = reader.json()
+    ///     .with_options(options)
+    ///     .to_string()?;
+    /// assert_eq!(actual, r#"{"a":{"b":1},"c":{"b":[1,2]}}"#);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// As shown above, downstream clients will need to be flexible enough to
+    /// handle grouped and ungrouped keys, and may prove cumbersome or
+    /// challenging to leverage automatic deserialization logic. Python or
+    /// Javascript clients may like this output due to their more dynamic typing
+    /// nature.
+    ///
+    /// Grouping keys together will have a small but measurable impact on
+    /// performance
+    Group,
+
+    /// Preserve the duplicate keys (the default behavior)
+    ///
+    /// ```
+    /// use jomini::{TextTape, json::{JsonOptions, DuplicateKeyMode}};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let tape = TextTape::from_slice(b"a={b=1} c={b=1 b=2}")?;
+    /// let reader = tape.windows1252_reader();
+    ///
+    /// let actual = reader.json()
+    ///     .with_options(JsonOptions::new())
+    ///     .to_string()?;
+    /// assert_eq!(actual, r#"{"a":{"b":1},"c":{"b":1,"b":2}}"#);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Preserving duplicate keys is the default mode as it represents the most
+    /// concise output and most closely matches the input.
+    ///
+    /// Insertion order of an object's keys are maintained.
+    ///
+    /// Python and Javascript clients may not like this output as their builtin
+    /// JSON modules don't handle duplicate keys well. However, lower level JSON
+    /// parsers like simd-json tend to handle duplicate keys just fine.
+    Preserve,
+
+    /// Rewrite objects as an array of 2 element arrays (the key and the value).
+    ///
+    /// ```
+    /// use jomini::{TextTape, json::{JsonOptions, DuplicateKeyMode}};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let tape = TextTape::from_slice(b"c=0 b={1 2}")?;
+    /// let reader = tape.windows1252_reader();
+    ///
+    /// let options = JsonOptions::new()
+    ///     .with_duplicate_keys(DuplicateKeyMode::KeyValuePairs);
+    ///
+    /// let actual = reader.json()
+    ///     .with_options(options)
+    ///     .to_string()?;
+    /// assert_eq!(actual, r#"{"type":"obj","val":[["c",0],["b",{"type":"array","val":[1,2]}]]}"#);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Objects and arrays are now transformed into adjacently tagged objects
+    /// (to borrow [a term from
+    /// serde](https://serde.rs/enum-representations.html#adjacently-tagged)).
+    /// Objects have a type of `obj` and arrays have a type of `array`. This
+    /// adjacently tagged object is needed to disambiguate between objects and
+    /// arrays if both are going to be represented with JSON arrays.
+    ///
+    /// This output has the largest departure from the input and is the most
+    /// verbose, but it allows one to use inflexible DOM parsers like those seen
+    /// in Python and Javascript and still maintain the positioning of duplicate
+    /// keys. Preserving positioning is important when interpretting an object
+    /// is dependant on the order of the keys and duplicate keys may affect
+    /// subsequent fields.
+    KeyValuePairs,
+}
+
+/// Creates JSON from an object reader
+pub struct JsonObjectBuilder<'data, 'tokens, E> {
+    reader: ObjectReader<'data, 'tokens, E>,
+    options: JsonOptions,
+}
+
+impl<'data, 'tokens, E> JsonObjectBuilder<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    /// Output JSON with the set of options
+    pub fn with_options(mut self, options: JsonOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    /// Output JSON to the given writer
+    pub fn to_writer<W>(self, writer: W) -> Result<(), serde_json::Error>
+    where
+        W: std::io::Write,
+    {
+        let obj = SerObject::new(self.reader, self.options.duplicate_keys);
+        if self.options.pretty {
+            serde_json::to_writer_pretty(writer, &obj)
+        } else {
+            serde_json::to_writer(writer, &obj)
+        }
+    }
+
+    /// Output JSON to vec that contains UTF-8 data
+    pub fn to_vec(self) -> Result<Vec<u8>, serde_json::Error> {
+        let mut out =
+            Vec::with_capacity(self.reader.tokens_len() * self.options.output_len_factor());
+        self.to_writer(&mut out)?;
+        Ok(out)
+    }
+
+    /// Output JSON to a string
+    pub fn to_string(self) -> Result<String, serde_json::Error> {
+        let out = self.to_vec()?;
+
+        // From serde_json source: "we don't generate invalid utf-8"
+        Ok(unsafe { String::from_utf8_unchecked(out) })
+    }
+}
+
+impl<'data, 'tokens, E> ObjectReader<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    /// Converts the object to its JSON representation
+    pub fn json(&self) -> JsonObjectBuilder<'data, 'tokens, E> {
+        JsonObjectBuilder {
+            reader: self.clone(),
+            options: JsonOptions::default(),
+        }
+    }
+}
+
+/// Creates JSON from an array reader
+pub struct JsonArrayBuilder<'data, 'tokens, E> {
+    reader: ArrayReader<'data, 'tokens, E>,
+    options: JsonOptions,
+}
+
+impl<'data, 'tokens, E> JsonArrayBuilder<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    /// Output JSON with the set of options
+    pub fn with_options(mut self, options: JsonOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    /// Output JSON to the given writer
+    pub fn to_writer<W>(self, writer: W) -> Result<(), serde_json::Error>
+    where
+        W: std::io::Write,
+    {
+        let obj = SerArray {
+            reader: self.reader,
+            mode: self.options.duplicate_keys,
+        };
+        if self.options.pretty {
+            serde_json::to_writer_pretty(writer, &obj)
+        } else {
+            serde_json::to_writer(writer, &obj)
+        }
+    }
+
+    /// Output JSON to vec that contains UTF-8 data
+    pub fn to_vec(self) -> Result<Vec<u8>, serde_json::Error> {
+        let mut out =
+            Vec::with_capacity(self.reader.tokens_len() * self.options.output_len_factor());
+        self.to_writer(&mut out)?;
+        Ok(out)
+    }
+
+    /// Output JSON to a string
+    pub fn to_string(self) -> Result<String, serde_json::Error> {
+        let out = self.to_vec()?;
+
+        // From serde_json source: "we don't generate invalid utf-8"
+        Ok(unsafe { String::from_utf8_unchecked(out) })
+    }
+}
+
+impl<'data, 'tokens, E> ArrayReader<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    /// Converts the object to its JSON representation
+    pub fn json(&self) -> JsonArrayBuilder<'data, 'tokens, E> {
+        JsonArrayBuilder {
+            reader: self.clone(),
+            options: JsonOptions::default(),
+        }
+    }
+}
+
+/// Creates JSON from a value reader
+pub struct JsonValueBuilder<'data, 'tokens, E> {
+    reader: ValueReader<'data, 'tokens, E>,
+    options: JsonOptions,
+}
+
+impl<'data, 'tokens, E> JsonValueBuilder<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    /// Output JSON with the set of options
+    pub fn with_options(mut self, options: JsonOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    /// Output JSON to the given writer
+    pub fn to_writer<W>(self, writer: W) -> Result<(), serde_json::Error>
+    where
+        W: std::io::Write,
+    {
+        let obj = SerValue {
+            reader: &self.reader,
+            mode: self.options.duplicate_keys,
+        };
+        if self.options.pretty {
+            serde_json::to_writer_pretty(writer, &obj)
+        } else {
+            serde_json::to_writer(writer, &obj)
+        }
+    }
+
+    /// Output JSON to vec that contains UTF-8 data
+    pub fn to_vec(self) -> Result<Vec<u8>, serde_json::Error> {
+        let mut out =
+            Vec::with_capacity(self.reader.tokens_len() * self.options.output_len_factor());
+        self.to_writer(&mut out)?;
+        Ok(out)
+    }
+
+    /// Output JSON to a string
+    pub fn to_string(self) -> Result<String, serde_json::Error> {
+        let out = self.to_vec()?;
+
+        // From serde_json source: "we don't generate invalid utf-8"
+        Ok(unsafe { String::from_utf8_unchecked(out) })
+    }
+}
+
+impl<'data, 'tokens, E> ValueReader<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    /// Converts the value to its JSON representation
+    pub fn json(&self) -> JsonValueBuilder<'data, 'tokens, E> {
+        JsonValueBuilder {
+            reader: self.clone(),
+            options: JsonOptions::default(),
+        }
+    }
+}
+
+fn serialize_scalar<E, S>(reader: &ValueReader<E>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    E: Encoding + Clone,
+{
+    let scalar = reader.read_scalar().unwrap();
+    if let Ok(x) = scalar.to_bool() {
+        return s.serialize_bool(x);
+    }
+
+    let signed = scalar.to_i64();
+    let unsigned = scalar.to_u64();
+    let float = scalar.to_f64();
+
+    // We only want to serialize numbers that are perfectly representable
+    // with 64 bit floating point, else the value will be stringified
+    match (signed, unsigned, float) {
+        (Ok(x), _, Ok(_)) => s.serialize_i64(x),
+        (_, Ok(x), Ok(_)) => s.serialize_u64(x),
+        (_, _, Ok(f)) => s.serialize_f64(f),
+        _ => s.serialize_str(reader.read_str().unwrap().deref()),
+    }
+}
+
+fn serialize_parameter<S>(body: &str, defined: bool, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut result = String::with_capacity(body.len() + 3);
+    result.push('[');
+
+    if !defined {
+        result.push('!');
+    }
+
+    result.push_str(body.as_ref());
+    result.push(']');
+    s.serialize_str(&result)
+}
+
+pub(crate) struct SerValue<'data, 'tokens, 'reader, E> {
+    reader: &'reader ValueReader<'data, 'tokens, E>,
+    mode: DuplicateKeyMode,
+}
+
+impl<'data, 'tokens, 'reader, E> Serialize for SerValue<'data, 'tokens, 'reader, E>
+where
+    E: Encoding + Clone,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self.reader.token() {
+            TextToken::Quoted(_) | TextToken::Unquoted(_) => {
+                serialize_scalar(self.reader, serializer)
+            }
+            TextToken::Array(_) => {
+                let array_reader = self.reader.read_array().unwrap();
+                let seq = SerArray {
+                    reader: array_reader,
+                    mode: self.mode,
+                };
+                seq.serialize(serializer)
+            }
+            TextToken::Object(_) | TextToken::HiddenObject(_) => {
+                let object_reader = self.reader.read_object().unwrap();
+                let map = SerObject {
+                    reader: object_reader,
+                    mode: self.mode,
+                };
+                map.serialize(serializer)
+            }
+            TextToken::Header(_) => {
+                let arr = self.reader.read_array().unwrap();
+                let mut values = arr.values();
+                let key_reader = values.next().unwrap();
+                let value_reader = values.next().unwrap();
+
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry(
+                    &key_reader.read_str().unwrap(),
+                    &SerValue {
+                        reader: &value_reader,
+                        mode: self.mode,
+                    },
+                )?;
+                map.end()
+            }
+            TextToken::End(_)
+            | TextToken::Operator(_)
+            | TextToken::Parameter(_)
+            | TextToken::UndefinedParameter(_) => serializer.serialize_none(),
+        }
+    }
+}
+
+pub(crate) struct SerObject<'data, 'tokens, E> {
+    reader: ObjectReader<'data, 'tokens, E>,
+    mode: DuplicateKeyMode,
+}
+
+impl<'data, 'tokens, E> SerObject<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    pub fn new(reader: ObjectReader<'data, 'tokens, E>, mode: DuplicateKeyMode) -> Self {
+        SerObject { reader, mode }
+    }
+}
+
+impl<'data, 'tokens, E> Serialize for SerObject<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self.mode {
+            DuplicateKeyMode::Group => {
+                let mut field_groups = self.reader.field_groups();
+                let mut map = serializer.serialize_map(None)?;
+
+                for (key, group) in field_groups.by_ref() {
+                    match group {
+                        GroupEntry::One((op, val)) => {
+                            let v = OperatorValue {
+                                operator: op,
+                                value: val,
+                                mode: self.mode,
+                            };
+                            map.serialize_entry(&KeyScalarWrapper { reader: key }, &v)?;
+                        }
+                        GroupEntry::Multiple(values) => {
+                            let values: Vec<_> = values
+                                .iter()
+                                .map(|(op, val)| OperatorValue {
+                                    operator: *op,
+                                    value: val.clone(),
+                                    mode: self.mode,
+                                })
+                                .collect();
+                            map.serialize_entry(&KeyScalarWrapper { reader: key }, &values)?;
+                        }
+                    }
+                }
+
+                if let Some(trailer) = field_groups.at_trailer() {
+                    let seq = SerArray {
+                        reader: trailer,
+                        mode: self.mode,
+                    };
+                    map.serialize_entry("trailer", &seq)?;
+                }
+
+                map.end()
+            }
+            DuplicateKeyMode::Preserve => {
+                let mut map = serializer.serialize_map(None)?;
+                let mut fields = self.reader.fields();
+                for (key, op, val) in fields.by_ref() {
+                    let v = OperatorValue {
+                        operator: op,
+                        value: val,
+                        mode: self.mode,
+                    };
+                    map.serialize_entry(&KeyScalarWrapper { reader: key }, &v)?;
+                }
+
+                if let Some(trailer) = fields.at_trailer() {
+                    let seq = SerArray {
+                        reader: trailer,
+                        mode: self.mode,
+                    };
+                    map.serialize_entry("trailer", &seq)?;
+                }
+
+                map.end()
+            }
+            DuplicateKeyMode::KeyValuePairs => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "obj")?;
+                map.serialize_entry(
+                    "val",
+                    &SerTapeTyped {
+                        reader: self.reader.clone(),
+                        mode: self.mode,
+                    },
+                )?;
+                map.end()
+            }
+        }
+    }
+}
+
+pub(crate) struct OperatorValue<'data, 'tokens, E> {
+    operator: Option<Operator>,
+    value: ValueReader<'data, 'tokens, E>,
+    mode: DuplicateKeyMode,
+}
+
+impl<'data, 'tokens, E> Serialize for OperatorValue<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if let Some(op) = self.operator {
+            let mut map = serializer.serialize_map(None)?;
+            let reader = &self.value;
+            map.serialize_entry(
+                op.name(),
+                &SerValue {
+                    reader,
+                    mode: self.mode,
+                },
+            )?;
+            map.end()
+        } else {
+            let reader = &self.value;
+            let vs = SerValue {
+                reader,
+                mode: self.mode,
+            };
+            vs.serialize(serializer)
+        }
+    }
+}
+
+pub(crate) struct InnerSerArray<'data, 'tokens, E> {
+    reader: ArrayReader<'data, 'tokens, E>,
+    mode: DuplicateKeyMode,
+}
+
+impl<'data, 'tokens, E> Serialize for InnerSerArray<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(None)?;
+        for value in self.reader.values() {
+            let v = OperatorValue {
+                operator: None,
+                value,
+                mode: self.mode,
+            };
+            seq.serialize_element(&v)?;
+        }
+
+        seq.end()
+    }
+}
+
+pub(crate) struct SerArray<'data, 'tokens, E> {
+    reader: ArrayReader<'data, 'tokens, E>,
+    mode: DuplicateKeyMode,
+}
+
+impl<'data, 'tokens, E> Serialize for SerArray<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let inner = InnerSerArray {
+            reader: self.reader.clone(),
+            mode: self.mode,
+        };
+
+        if self.mode != DuplicateKeyMode::KeyValuePairs {
+            inner.serialize(serializer)
+        } else {
+            let mut map = serializer.serialize_map(None)?;
+            map.serialize_entry("type", "array")?;
+            map.serialize_entry("val", &inner)?;
+            map.end()
+        }
+    }
+}
+
+pub(crate) struct SerTapeTyped<'data, 'tokens, E> {
+    reader: ObjectReader<'data, 'tokens, E>,
+    mode: DuplicateKeyMode,
+}
+
+impl<'data, 'tokens, E> Serialize for SerTapeTyped<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(None)?;
+        let mut fields = self.reader.fields();
+        for (key, op, val) in fields.by_ref() {
+            let v = OperatorValue {
+                operator: op,
+                value: val,
+                mode: self.mode,
+            };
+            seq.serialize_element(&(KeyScalarWrapper { reader: key }, &v))?;
+        }
+
+        if let Some(trailer) = fields.at_trailer() {
+            let trailer_array = InnerSerArray {
+                reader: trailer,
+                mode: self.mode,
+            };
+
+            seq.serialize_element(&trailer_array)?;
+        }
+
+        seq.end()
+    }
+}
+
+pub(crate) struct KeyScalarWrapper<'data, E> {
+    reader: ScalarReader<'data, E>,
+}
+
+impl<'data, E> Serialize for KeyScalarWrapper<'data, E>
+where
+    E: Encoding + Clone,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let body = self.reader.read_str();
+        match self.reader.token() {
+            TextToken::Parameter(_) => serialize_parameter(&body, true, serializer),
+            TextToken::UndefinedParameter(_) => serialize_parameter(&body, false, serializer),
+            _ => serializer.serialize_str(&body),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TextTape;
+
+    fn serialize_with(data: &[u8], options: JsonOptions) -> String {
+        let tape = TextTape::from_slice(data).unwrap();
+        let reader = tape.windows1252_reader();
+        reader.json().with_options(options).to_string().unwrap()
+    }
+
+    fn serialize(data: &[u8]) -> String {
+        serialize_with(data, JsonOptions::default())
+    }
+
+    #[test]
+    fn test_serialize_to_json() {
+        let json = serialize(b"foo=bar");
+        assert_eq!(&json, r#"{"foo":"bar"}"#);
+    }
+
+    #[test]
+    fn test_simple_types() {
+        let json = serialize(b"foo=bar num=1 bool=no bool2=yes pi=3.14");
+        let expected = r#"{"foo":"bar","num":1,"bool":false,"bool2":true,"pi":3.14}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_object() {
+        let json = serialize(b"foo={prop=a bar={num=1}}");
+        let expected = r#"{"foo":{"prop":"a","bar":{"num":1}}}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_array() {
+        let json = serialize(b"nums={1 2 3 4}");
+        let expected = r#"{"nums":[1,2,3,4]}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_duplicate_fields() {
+        let json = serialize(b"core=AAA core=BBB");
+        let expected = r#"{"core":"AAA","core":"BBB"}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_duplicate_fields_grouped() {
+        let json = serialize_with(
+            b"core=AAA core=BBB",
+            JsonOptions {
+                duplicate_keys: DuplicateKeyMode::Group,
+                ..JsonOptions::default()
+            },
+        );
+        let expected = r#"{"core":["AAA","BBB"]}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_duplicate_fields_typed() {
+        let json = serialize_with(
+            b"core=AAA core=BBB",
+            JsonOptions {
+                duplicate_keys: DuplicateKeyMode::KeyValuePairs,
+                ..JsonOptions::default()
+            },
+        );
+        let expected = r#"{"type":"obj","val":[["core","AAA"],["core","BBB"]]}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_header() {
+        let json = serialize(b"color = rgb { 100 200 150 }");
+        let expected = r#"{"color":{"rgb":[100,200,150]}}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_large_numbers() {
+        let json = serialize(b"identity = 18446744073709547616");
+        let expected = r#"{"identity":"18446744073709547616"}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_large_negative_numbers() {
+        let json = serialize(b"identity = -90071992547409097");
+        let expected = r#"{"identity":"-90071992547409097"}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_object_pretty() {
+        let json = serialize_with(
+            b"foo={prop=a bar={num=1}}",
+            JsonOptions {
+                pretty: true,
+                ..JsonOptions::default()
+            },
+        );
+        let expected = r#"{
+  "foo": {
+    "prop": "a",
+    "bar": {
+      "num": 1
+    }
+  }
+}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_array_typed() {
+        let json = serialize_with(
+            b"nums={1 2}",
+            JsonOptions {
+                duplicate_keys: DuplicateKeyMode::KeyValuePairs,
+                ..JsonOptions::default()
+            },
+        );
+        let expected = r#"{"type":"obj","val":[["nums",{"type":"array","val":[1,2]}]]}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_object_trailers() {
+        let json = serialize(b"area = { color = { 10 } 1 2 }");
+        let expected = r#"{"area":{"color":[10],"trailer":[1,2]}}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_object_trailers_group() {
+        let json = serialize_with(
+            b"area = { color = { 10 } 1 2 }",
+            JsonOptions {
+                duplicate_keys: DuplicateKeyMode::Group,
+                ..JsonOptions::default()
+            },
+        );
+        let expected = r#"{"area":{"color":[10],"trailer":[1,2]}}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_object_trailers_typed() {
+        let json = serialize_with(
+            b"area = { color = { 10 } 1 2 }",
+            JsonOptions {
+                duplicate_keys: DuplicateKeyMode::KeyValuePairs,
+                ..JsonOptions::default()
+            },
+        );
+        let expected = r#"{"type":"obj","val":[["area",{"type":"obj","val":[["color",{"type":"array","val":[10]}],[1,2]]}]]}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_parameter_definitions_typed() {
+        let json = serialize_with(
+            b"generate_advisor = { [[scaled_skill] a=b ] [[!scaled_skill] c=d ]  }",
+            JsonOptions {
+                duplicate_keys: DuplicateKeyMode::KeyValuePairs,
+                ..JsonOptions::default()
+            },
+        );
+        let expected = r#"{"type":"obj","val":[["generate_advisor",{"type":"obj","val":[["[scaled_skill]",{"type":"obj","val":[["a","b"]]}],["[!scaled_skill]",{"type":"obj","val":[["c","d"]]}]]}]]}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_parameter_definition_value_typed() {
+        let json = serialize_with(
+            b"foo = { [[add] $add$]}",
+            JsonOptions {
+                duplicate_keys: DuplicateKeyMode::KeyValuePairs,
+                ..JsonOptions::default()
+            },
+        );
+        let expected = r#"{"type":"obj","val":[["foo",{"type":"obj","val":[["[add]","$add$"]]}]]}"#;
+        assert_eq!(&json, expected);
+    }
+
+    #[test]
+    fn test_subobject() {
+        let tape = TextTape::from_slice(b"bar={num=1}").unwrap();
+        let reader = tape.windows1252_reader();
+        let mut fields = reader.fields();
+        let (_key, _op, value) = fields.next().unwrap();
+        let actual = value.json().to_string().unwrap();
+        let expected = r#"{"num":1}"#;
+        assert_eq!(&actual, expected);
+    }
+
+    #[test]
+    fn test_array_direct() {
+        let tape = TextTape::from_slice(b"nums={1 2 3 4}").unwrap();
+        let reader = tape.windows1252_reader();
+        let mut fields = reader.fields();
+        let (_key, _op, value) = fields.next().unwrap();
+        let array = value.read_array().unwrap();
+        let actual = array.json().to_string().unwrap();
+        let expected = r#"[1,2,3,4]"#;
+        assert_eq!(&actual, expected);
+    }
+
+    #[test]
+    fn test_value_direct() {
+        let tape = TextTape::from_slice(b"core=1").unwrap();
+        let reader = tape.windows1252_reader();
+        let mut fields = reader.fields();
+        let (_key, _op, value) = fields.next().unwrap();
+        let actual = value.json().to_string().unwrap();
+        let expected = r#"1"#;
+        assert_eq!(&actual, expected);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,27 @@ for (key, _op, value) in reader.fields() {
 }
 ```
 
+*/
+#![cfg_attr(
+    feature = "json",
+    doc = r##"
+The mid-level API also provides the excellent utility of converting the
+plaintext Clausewitz format to JSON when the `json` feature is enabled.
+
+```rust
+use jomini::TextTape;
+
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let tape = TextTape::from_slice(b"foo=bar")?;
+let reader = tape.windows1252_reader();
+let actual = reader.json().to_string()?;
+assert_eq!(actual, r#"{"foo":"bar"}"#);
+# Ok(())
+# }
+```
+"##
+)]
+/*!
 ## One Level Lower
 
 At the lowest layer, one can interact with the raw data directly via `TextTape`
@@ -216,6 +237,8 @@ mod data;
 pub(crate) mod de;
 mod encoding;
 mod errors;
+#[cfg(feature = "json")]
+pub mod json;
 mod scalar;
 pub mod text;
 pub(crate) mod util;

--- a/src/text/fnv.rs
+++ b/src/text/fnv.rs
@@ -1,0 +1,33 @@
+//! An inlined version of rust-fnv crate
+use std::hash::{BuildHasherDefault, Hasher};
+
+pub struct FnvHasher(u64);
+
+impl Default for FnvHasher {
+    #[inline]
+    fn default() -> FnvHasher {
+        FnvHasher(0xcbf29ce484222325)
+    }
+}
+
+impl Hasher for FnvHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let FnvHasher(mut hash) = *self;
+
+        for byte in bytes.iter() {
+            hash ^= *byte as u64;
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+
+        *self = FnvHasher(hash);
+    }
+}
+
+/// A builder for default FNV hashers.
+pub type FnvBuildHasher = BuildHasherDefault<FnvHasher>;

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -9,6 +9,7 @@
 //! [ValuesIter](crate::text::ValuesIter)
 #[cfg(feature = "derive")]
 mod de;
+mod fnv;
 mod operator;
 mod reader;
 mod tape;


### PR DESCRIPTION
The mid-level API now provides the excellent utility of converting the
plaintext Clausewitz format to JSON when the `json` feature is enabled.

```rust
use jomini::TextTape;

let tape = TextTape::from_slice(b"foo=bar")?;
let reader = tape.windows1252_reader();
let actual = reader.json().to_string()?;
assert_eq!(actual, r#"{"foo":"bar"}"#);
```

The scope of the JSON can be narrowed to an inner value. This comes in handy
when the parsed document is large but only a small subset of it needs to be
exposed with JSON.

```rust
use jomini::{TextTape};

let tape = TextTape::from_slice(b"nums={1 2 3 4}")?;
let reader = tape.windows1252_reader();
let mut fields = reader.fields();
let (_key, _op, value) = fields.next().unwrap();
let array = value.read_array()?;
let actual = array.json().to_string()?;
let expected = r#"[1,2,3,4]"#;
assert_eq!(&actual, expected);
```

It's debatable whether [duplicate keys is valid JSON][0], so this allows one
to customize output depending how flexible a downstream client is at handling
JSON.

The options are either:

- Group values into an array under a single field
- Preserve the duplicate keys
- Rewrite objects as an array of key value pairs

[0]: https://stackoverflow.com/q/21832701