### PR TITLE
Move secondary binary structs behind namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Implementors be warned, not only does each Paradox game have a different binary 
 Below is an example that defines a sample binary format and uses a hashmap token lookup.
 
 ```rust
-use jomini::{BinaryDeserializer, BinaryFlavor, Encoding, JominiDeserialize, Windows1252Encoding};
+use jomini::{BinaryDeserializer, Encoding, JominiDeserialize, Windows1252Encoding};
 use std::{borrow::Cow, collections::HashMap};
 
 #[derive(JominiDeserialize, PartialEq, Debug)]
@@ -84,7 +84,7 @@ struct MyStruct {
 #[derive(Debug, Default)]
 pub struct BinaryTestFlavor;
 
-impl BinaryFlavor for BinaryTestFlavor {
+impl jomini::binary::BinaryFlavor for BinaryTestFlavor {
     fn visit_f32(&self, data: [u8; 4]) -> f32 {
         f32::from_le_bytes(data)
     }

--- a/benches/jomini_bench.rs
+++ b/benches/jomini_bench.rs
@@ -1,7 +1,9 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use jomini::{
-    common::Date, BinaryDeserializer, BinaryFlavor, BinaryTape, BinaryTapeParser, Encoding, Scalar,
-    TextDeserializer, TextTape, Utf8Encoding, Windows1252Encoding,
+    binary::{BinaryFlavor, BinaryTapeParser},
+    common::Date,
+    BinaryDeserializer, BinaryTape, Encoding, Scalar, TextDeserializer, TextTape, Utf8Encoding,
+    Windows1252Encoding,
 };
 use std::{borrow::Cow, collections::HashMap};
 
@@ -280,7 +282,9 @@ pub fn json_benchmark(c: &mut Criterion) {
         b.iter(|| {
             tape.windows1252_reader()
                 .json()
-                .with_options(JsonOptions::new().with_duplicate_keys(DuplicateKeyMode::KeyValuePairs))
+                .with_options(
+                    JsonOptions::new().with_duplicate_keys(DuplicateKeyMode::KeyValuePairs),
+                )
                 .to_string()
                 .unwrap()
         })
@@ -326,7 +330,9 @@ pub fn json_benchmark(c: &mut Criterion) {
         b.iter(|| {
             tape.windows1252_reader()
                 .json()
-                .with_options(JsonOptions::new().with_duplicate_keys(DuplicateKeyMode::KeyValuePairs))
+                .with_options(
+                    JsonOptions::new().with_duplicate_keys(DuplicateKeyMode::KeyValuePairs),
+                )
                 .to_string()
                 .unwrap()
         })

--- a/fuzz/fuzz_targets/fuzz_binary.rs
+++ b/fuzz/fuzz_targets/fuzz_binary.rs
@@ -1,5 +1,5 @@
 #![no_main]
-use jomini::{BinaryFlavor, Encoding, Windows1252Encoding};
+use jomini::{binary::BinaryFlavor, Encoding, Windows1252Encoding};
 use libfuzzer_sys::fuzz_target;
 use serde::Deserialize;
 use std::{borrow::Cow, collections::HashMap};

--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -1,6 +1,7 @@
 use crate::{
-    de::ColorSequence, BinaryFlavor, BinaryTape, BinaryToken, DeserializeError,
-    DeserializeErrorKind, Error, FailedResolveStrategy, TokenResolver,
+    binary::{BinaryFlavor, FailedResolveStrategy, TokenResolver},
+    de::ColorSequence,
+    BinaryTape, BinaryToken, DeserializeError, DeserializeErrorKind, Error,
 };
 use serde::de::{self, Deserialize, DeserializeSeed, MapAccess, SeqAccess, Visitor};
 use std::borrow::Cow;
@@ -13,7 +14,7 @@ use std::borrow::Cow;
 /// The example below demonstrates multiple ways to deserialize data
 ///
 /// ```
-/// use jomini::{BinaryDeserializer, BinaryFlavor, Encoding, JominiDeserialize, Windows1252Encoding};
+/// use jomini::{BinaryDeserializer, Encoding, JominiDeserialize, Windows1252Encoding};
 /// use serde::Deserialize;
 /// use std::{borrow::Cow, collections::HashMap};
 ///
@@ -39,7 +40,7 @@ use std::borrow::Cow;
 /// #[derive(Debug, Default)]
 /// pub struct BinaryTestFlavor;
 ///
-/// impl BinaryFlavor for BinaryTestFlavor {
+/// impl jomini::binary::BinaryFlavor for BinaryTestFlavor {
 ///     fn visit_f32(&self, data: [u8; 4]) -> f32 {
 ///         f32::from_le_bytes(data)
 ///     }

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -1,11 +1,18 @@
+//! Types for parsing clausewitz binary input
+//!
+//! See the top level module documentation for an overview that includes parsing
+//! and deserializing binary data.
+
 #[cfg(feature = "derive")]
 mod de;
 mod flavor;
 mod resolver;
+mod rgb;
 mod tape;
 
 #[cfg(feature = "derive")]
 pub use self::de::{BinaryDeserializer, BinaryDeserializerBuilder};
 pub use self::flavor::BinaryFlavor;
 pub use self::resolver::{FailedResolveStrategy, TokenResolver};
+pub use self::rgb::*;
 pub use self::tape::{BinaryTape, BinaryTapeParser, BinaryToken};

--- a/src/binary/resolver.rs
+++ b/src/binary/resolver.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 ///
 /// ```
 /// use std::collections::HashMap;
-/// use jomini::TokenResolver;
+/// use jomini::binary::TokenResolver;
 ///
 /// let mut map = HashMap::new();
 /// map.insert(0x2d82, String::from("field1"));
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 ///
 /// ```
 /// use std::collections::HashMap;
-/// use jomini::TokenResolver;
+/// use jomini::binary::TokenResolver;
 ///
 /// let mut map = HashMap::new();
 /// map.insert(0x2d82, "field1");

--- a/src/binary/rgb.rs
+++ b/src/binary/rgb.rs
@@ -1,0 +1,15 @@
+/// Extracted color info
+///
+/// This is only for the binary format. RGB values that are in plaintext are
+/// behind a [TextToken::Header](crate::TextToken::Header) of `rgb`
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rgb {
+    /// Red channel
+    pub r: u32,
+
+    /// Green channel
+    pub g: u32,
+
+    /// Blue channel
+    pub b: u32,
+}

--- a/src/binary/tape.rs
+++ b/src/binary/tape.rs
@@ -1,8 +1,9 @@
 use crate::{
+    binary::Rgb,
     copyless::VecHelper,
     util::{get_split, le_u32},
+    Error, ErrorKind, Scalar,
 };
-use crate::{Error, ErrorKind, Rgb, Scalar};
 
 /// Represents any valid binary value
 #[derive(Debug, Clone, PartialEq)]

--- a/src/common/date.rs
+++ b/src/common/date.rs
@@ -1,7 +1,7 @@
 use crate::scalar::{to_i64_t, to_u64_t};
 use std::cmp::Ordering;
 use std::convert::TryFrom;
-use std::fmt::{Debug, Display, self};
+use std::fmt::{self, Debug, Display};
 use std::str::FromStr;
 
 /// A date error.

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,16 +1,3 @@
-/// Extracted color info
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Rgb {
-    /// Red channel
-    pub r: u32,
-
-    /// Green channel
-    pub g: u32,
-
-    /// Blue channel
-    pub b: u32,
-}
-
 pub(crate) static WINDOWS_1252: [char; 256] = [
     0 as char,
     1 as char,

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,4 +1,4 @@
-use crate::{DeserializeError, Rgb};
+use crate::{binary::Rgb, DeserializeError};
 use de::{DeserializeSeed, SeqAccess, Visitor};
 use serde::de;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ Below is an example that defines a sample binary format and uses a hashmap token
 
 ```rust
 # #[cfg(feature = "derive")] {
-use jomini::{BinaryDeserializer, BinaryFlavor, Encoding, JominiDeserialize, Windows1252Encoding};
+use jomini::{BinaryDeserializer, Encoding, JominiDeserialize, Windows1252Encoding};
 use std::{borrow::Cow, collections::HashMap};
 
 #[derive(JominiDeserialize, PartialEq, Debug)]
@@ -86,7 +86,7 @@ struct MyStruct {
 #[derive(Debug, Default)]
 pub struct BinaryTestFlavor;
 
-impl BinaryFlavor for BinaryTestFlavor {
+impl jomini::binary::BinaryFlavor for BinaryTestFlavor {
     fn visit_f32(&self, data: [u8; 4]) -> f32 {
         f32::from_le_bytes(data)
     }
@@ -229,7 +229,7 @@ assert_eq!(&out, b"hello=world\nfoo=bar");
 ```
 */
 #![warn(missing_docs)]
-mod binary;
+pub mod binary;
 pub mod common;
 mod copyless;
 mod data;
@@ -243,8 +243,11 @@ mod scalar;
 pub mod text;
 pub(crate) mod util;
 
-pub use self::binary::*;
-pub use self::data::Rgb;
+pub use self::binary::{BinaryTape, BinaryToken};
+
+#[cfg(feature = "derive")]
+pub use self::binary::BinaryDeserializer;
+
 pub use self::encoding::*;
 pub use self::errors::*;
 pub use self::scalar::{Scalar, ScalarError};

--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -1709,7 +1709,9 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"mult")),
-                TextToken::Unquoted(Scalar::new(b"value:job_weights_research_modifier|JOB|head_researcher|")),
+                TextToken::Unquoted(Scalar::new(
+                    b"value:job_weights_research_modifier|JOB|head_researcher|"
+                )),
             ]
         );
     }

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "derive")]
 
 use jomini::common::PdsDate;
-use jomini::{BinaryDeserializer, BinaryFlavor, Encoding, TextDeserializer, Windows1252Encoding};
+use jomini::{
+    binary::BinaryFlavor, BinaryDeserializer, Encoding, TextDeserializer, Windows1252Encoding,
+};
 use serde::{
     de::{self, Visitor},
     Deserialize, Deserializer,


### PR DESCRIPTION
This continues slimming down the root namespace so there aren't an
overwhelming amount of structures exported