### PR TITLE
Expose io error in json serialization over serde

### DIFF
--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -226,16 +226,18 @@ where
     }
 
     /// Output JSON to the given writer
-    pub fn to_writer<W>(self, writer: W) -> Result<(), serde_json::Error>
+    pub fn to_writer<W>(self, writer: W) -> Result<(), std::io::Error>
     where
         W: std::io::Write,
     {
         let obj = SerObject::new(self.reader, self.options.duplicate_keys);
-        if self.options.pretty {
+        let result = if self.options.pretty {
             serde_json::to_writer_pretty(writer, &obj)
         } else {
             serde_json::to_writer(writer, &obj)
-        }
+        };
+
+        result.map_err(|e| e.into())
     }
 
     /// Output JSON to vec that contains UTF-8 data


### PR DESCRIPTION
The only way the serialization can fail is if the writer fails, so
expose the underlying io error so that we're not coupling the API to
serde_json (in case it's prudent to swap to another JSON writing
library)