### PR TITLE
Pin cross to v0.2.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Use Cross
       if: matrix.target != ''
       run: |
-        cargo install cross
+        cargo install --version 0.2.1 cross
         echo "CARGO=cross" >> $GITHUB_ENV
         echo "TARGET=--target ${{ matrix.target }}" >> $GITHUB_ENV
     - name: Build


### PR DESCRIPTION
I'm anticipating a new release in the next couple days and don't exactly want
to wait for this in order to see greenlights on a release CI run.

CI has been failing due https://github.com/cross-rs/cross/issues/864