### PR TITLE
Unify text array and object containers with mixed mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+assets/saves

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,13 @@ derive = ["serde", "jomini_derive"]
 json = ["serde", "serde_json"]
 
 [dev-dependencies]
+attohttpc = { version = "0.23", features = ["tls-vendored"] }
 encoding_rs = "0.8"
 criterion = "0.3"
 quickcheck = "1"
 quickcheck_macros = "1"
 serde = { version = "1", features = ["derive"] }
+flate2 = "1"
 
 [[bin]]
 name = "json"

--- a/README.md
+++ b/README.md
@@ -214,37 +214,9 @@ assert_eq!(&out, b"hello=world\nfoo=bar");
 
 ## Unsupported Syntax
 
-Due to the nature of Clausewitz being closed source, this library can never guarantee compatibility with Clausewitz. There is no specification of what valid input looks like, and we only have examples that have been [collected in the wild](https://pdx.tools/blog/a-tour-of-pds-clausewitz-syntax). From what we do know, Clausewitz is recklessly flexible: allowing each game object to potentially define its own unique syntax. It is technically possible for us to support these fringe edge cases in search for perfection, but achieving that goal would sacrifice either ergonomics or performance: two pillars that are a must for save game parsing. Until a suitable solution is presented, a workaround would be to preprocess the unique syntax into a more recognizable format.
+Due to the nature of Clausewitz being closed source, this library can never guarantee compatibility with Clausewitz. There is no specification of what valid input looks like, and we only have examples that have been [collected in the wild](https://pdx.tools/blog/a-tour-of-pds-clausewitz-syntax). From what we do know, Clausewitz is recklessly flexible: allowing each game object to potentially define its own unique syntax.
 
-The good news is that unsupported syntax is typically isolated in a handful of game files.
-
-Known unsupported syntax:
-
-- ```
-    simple_cross_flag = {
-        pattern = list "christian_emblems_list"
-        color1 = list "normal_colors"
-    }
-  ```
-
-  Above is an example of an unmarked list found in CK3. Typically lists are use brackets (`{`, `}`) but those are conspicuously missing here.
-
-- ```
-    on_actions = {
-        faith_holy_order_land_acquisition_pulse
-        delay = { days = { 5 10 }}
-        faith_heresy_events_pulse
-        delay = { days = { 15 20 }}
-        faith_fervor_events_pulse
-    }
-  ```
-
-  Alternating value and key value pairs. Makes one wish they used a bit more of a self describing format. We can parse objects or lists that occur at the end of a container, but are unable to repeatedly switch between the two formats.
-
-- ```
-  pride_of_the_fleet = yes definition definition = heavy_cruiser
-  ```
-  In this instance, the first `definition` should be skipped, but skipping an unrecognized or duplicate field is not consistent across game objects, as we can see from the previous examples where one shouldn't skip fields like this.
+We can only do our best and add support for new syntax as it is encountered.
 
 ## Benchmarks
 

--- a/fuzz/fuzz_targets/fuzz_binary.rs
+++ b/fuzz/fuzz_targets/fuzz_binary.rs
@@ -68,20 +68,21 @@ fuzz_target!(|data: &[u8]| {
             match token {
                 jomini::BinaryToken::Array(ind)
                 | jomini::BinaryToken::Object(ind)
-                | jomini::BinaryToken::HiddenObject(ind)
                 | jomini::BinaryToken::End(ind)
                     if *ind == 0 =>
                 {
                     panic!("zero ind encountered");
                 }
-                jomini::BinaryToken::Array(ind)
-                | jomini::BinaryToken::Object(ind)
-                | jomini::BinaryToken::HiddenObject(ind) => match tokens[*ind] {
-                    jomini::BinaryToken::End(ind2) => {
-                        assert_eq!(ind2, i)
+                jomini::BinaryToken::MixedContainer => {}
+                jomini::BinaryToken::Equal => {}
+                jomini::BinaryToken::Array(ind) | jomini::BinaryToken::Object(ind) => {
+                    match tokens[*ind] {
+                        jomini::BinaryToken::End(ind2) => {
+                            assert_eq!(ind2, i)
+                        }
+                        _ => panic!("expected end"),
                     }
-                    _ => panic!("expected end"),
-                },
+                }
                 _ => {}
             }
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,6 +10,8 @@ impl Error {
         Error(Box::new(kind))
     }
 
+    #[inline(never)]
+    #[cold]
     pub(crate) fn eof() -> Error {
         Self::new(ErrorKind::Eof)
     }

--- a/src/text/operator.rs
+++ b/src/text/operator.rs
@@ -23,22 +23,42 @@ pub enum Operator {
 
     /// A `==` token
     Exact,
+
+    /// A `=` token
+    Equal,
 }
 
 impl Display for Operator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            Operator::LessThan => f.write_str("<"),
-            Operator::GreaterThan => f.write_str(">"),
-            Operator::LessThanEqual => f.write_str("<="),
-            Operator::GreaterThanEqual => f.write_str(">="),
-            Operator::NotEqual => f.write_str("!="),
-            Operator::Exact => f.write_str("=="),
-        }
+        f.write_str(self.symbol())
     }
 }
 
 impl Operator {
+    /// Returns the name of the operator using only letters
+    ///
+    /// ```
+    /// use jomini::text::Operator;
+    /// assert_eq!(Operator::LessThan.symbol(), "<");
+    /// assert_eq!(Operator::LessThanEqual.symbol(), "<=");
+    /// assert_eq!(Operator::GreaterThan.symbol(), ">");
+    /// assert_eq!(Operator::GreaterThanEqual.symbol(), ">=");
+    /// assert_eq!(Operator::Exact.symbol(), "==");
+    /// assert_eq!(Operator::NotEqual.symbol(), "!=");
+    /// assert_eq!(Operator::Equal.symbol(), "=");
+    /// ```
+    pub fn symbol(&self) -> &'static str {
+        match self {
+            Operator::LessThan => "<",
+            Operator::LessThanEqual => "<=",
+            Operator::GreaterThan => ">",
+            Operator::GreaterThanEqual => ">=",
+            Operator::Exact => "==",
+            Operator::Equal => "=",
+            Operator::NotEqual => "!=",
+        }
+    }
+
     /// Returns the name of the operator using only letters
     ///
     /// ```
@@ -49,6 +69,7 @@ impl Operator {
     /// assert_eq!(Operator::GreaterThanEqual.name(), "GREATER_THAN_EQUAL");
     /// assert_eq!(Operator::Exact.name(), "EXACT");
     /// assert_eq!(Operator::NotEqual.name(), "NOT_EQUAL");
+    /// assert_eq!(Operator::Equal.name(), "EQUAL");
     /// ```
     pub fn name(&self) -> &'static str {
         match self {
@@ -57,6 +78,7 @@ impl Operator {
             Operator::GreaterThan => "GREATER_THAN",
             Operator::GreaterThanEqual => "GREATER_THAN_EQUAL",
             Operator::Exact => "EXACT",
+            Operator::Equal => "EQUAL",
             Operator::NotEqual => "NOT_EQUAL",
         }
     }

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -1,3 +1,4 @@
+use super::fnv::FnvBuildHasher;
 use crate::{
     text::Operator, DeserializeError, DeserializeErrorKind, Encoding, Scalar, TextTape, TextToken,
 };
@@ -5,8 +6,6 @@ use std::{
     borrow::Cow,
     collections::{hash_map::Entry, HashMap},
 };
-
-use super::fnv::FnvBuildHasher;
 
 pub type KeyValue<'data, 'tokens, E> = (
     ScalarReader<'data, E>,
@@ -21,8 +20,8 @@ pub type KeyValues<'data, 'tokens, E> = (ScalarReader<'data, E>, GroupEntry<'dat
 #[inline]
 fn next_idx_header(tokens: &[TextToken], idx: usize) -> usize {
     match tokens[idx] {
-        TextToken::Array(x) | TextToken::Object(x) | TextToken::HiddenObject(x) => x + 1,
-        TextToken::Operator(_) => idx + 2,
+        TextToken::Array { end, .. } | TextToken::Object { end, .. } => end + 1,
+        TextToken::Operator(_) | TextToken::MixedContainer => idx + 2,
         _ => idx + 1,
     }
 }
@@ -32,9 +31,17 @@ fn next_idx_header(tokens: &[TextToken], idx: usize) -> usize {
 #[inline]
 fn next_idx(tokens: &[TextToken], idx: usize) -> usize {
     match tokens[idx] {
-        TextToken::Array(x) | TextToken::Object(x) | TextToken::HiddenObject(x) => x + 1,
+        TextToken::Array { end, .. } | TextToken::Object { end, .. } => end + 1,
         TextToken::Operator(_) => next_idx(tokens, idx + 1),
         TextToken::Header(_) => next_idx_header(tokens, idx + 1),
+        _ => idx + 1,
+    }
+}
+
+#[inline]
+fn next_idx_values(tokens: &[TextToken], idx: usize) -> usize {
+    match tokens[idx] {
+        TextToken::Array { end, .. } | TextToken::Object { end, .. } => end + 1,
         _ => idx + 1,
     }
 }
@@ -45,7 +52,7 @@ fn fields_len(tokens: &[TextToken], start_ind: usize, end_ind: usize) -> usize {
     let mut count = 0;
     while ind < end_ind {
         let key_ind = ind;
-        if let TextToken::Array(_) = tokens[key_ind] {
+        if tokens[key_ind] == TextToken::MixedContainer {
             return count;
         }
 
@@ -65,38 +72,11 @@ pub fn values_len(tokens: &[TextToken], start_ind: usize, end_ind: usize) -> usi
     let mut count = 0;
     let mut ind = start_ind;
     while ind < end_ind {
-        ind = next_idx_header(tokens, ind);
+        ind = next_idx_values(tokens, ind);
         count += 1;
     }
 
     count
-}
-
-#[inline]
-fn at_trailer<'data, 'tokens, E>(
-    tokens: &'tokens [TextToken<'data>],
-    encoding: &E,
-    token_ind: usize,
-) -> Option<ArrayReader<'data, 'tokens, E>>
-where
-    E: Encoding + Clone,
-{
-    if let Some(TextToken::Array(ind)) = tokens.get(token_ind) {
-        // trailers must be at least one element in length, else we're just reading
-        // an object as an array
-        if *ind != token_ind + 1 {
-            Some(ArrayReader {
-                tokens,
-                start_ind: token_ind + 1,
-                end_ind: *ind,
-                encoding: encoding.clone(),
-            })
-        } else {
-            None
-        }
-    } else {
-        None
-    }
 }
 
 type OpValue<'data, 'tokens, E> = (Option<Operator>, ValueReader<'data, 'tokens, E>);
@@ -364,9 +344,9 @@ where
         }
     }
 
-    /// See [the other `at_trailer` documentation](crate::text::FieldsIter::at_trailer)
-    pub fn at_trailer(&self) -> Option<ArrayReader<'data, 'tokens, E>> {
-        self.fields.at_trailer()
+    /// See [the other `remainder` documentation](crate::text::FieldsIter::remainder)
+    pub fn remainder(&self) -> ArrayReader<'data, 'tokens, E> {
+        self.fields.remainder()
     }
 }
 
@@ -460,35 +440,31 @@ where
         }
     }
 
-    /// Exposes the object trailer at the end of the object if it exists. It is
-    /// the responsibility of the caller to make sure they have exhausted the
-    /// iterator before calling this method, as the any trailer would be at the
-    /// end of the object. An object trailer is looks like:
-    ///
-    /// ```
-    /// use jomini::TextTape;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let data = b"brittany_area = { color = { 10 10 10 } 100 200 300 }";
-    /// let tape = TextTape::from_slice(data)?;
-    /// let reader = tape.windows1252_reader();
-    /// let mut root_fields = reader.fields();
-    /// let (_brittany, _op, brittany_val) = root_fields.next().unwrap();
-    /// let mut brittany_fields = brittany_val.read_object()?.fields();
-    ///
-    /// // consume iterator
-    /// brittany_fields.by_ref().for_each(drop);
-    ///
-    /// let trailer = brittany_fields.at_trailer().map(|array| {
-    ///     array.values()
-    ///         .filter_map(|value| value.read_str().ok())
-    ///         .collect()
-    /// });
-    /// assert_eq!(trailer, Some(vec!["100".into(), "200".into(), "300".into()]));
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn at_trailer(&self) -> Option<ArrayReader<'data, 'tokens, E>> {
-        at_trailer(self.tokens, &self.encoding, self.token_ind)
+    /// Returns the remaining values from an object if the container is an
+    /// object that transitions into an array.
+    pub fn remainder(&self) -> ArrayReader<'data, 'tokens, E> {
+        let start = self
+            .tokens
+            .get(self.token_ind)
+            .map(|x| match x {
+                TextToken::MixedContainer => self.token_ind + 1,
+                TextToken::End(y) => {
+                    if let Some(TextToken::Array { .. }) = self.tokens.get(*y) {
+                        *y + 1
+                    } else {
+                        self.token_ind
+                    }
+                }
+                _ => self.token_ind,
+            })
+            .unwrap_or(self.end_ind);
+
+        ArrayReader {
+            start_ind: start,
+            end_ind: self.end_ind,
+            encoding: self.encoding.clone(),
+            tokens: self.tokens,
+        }
     }
 }
 
@@ -510,13 +486,13 @@ where
             | TextToken::Unquoted(x)
             | TextToken::Parameter(x)
             | TextToken::UndefinedParameter(x) => x,
-            TextToken::Array(_) => {
+            TextToken::MixedContainer => {
                 return None;
             }
             _ => {
                 // this is a broken invariant, so we safely recover by saying the object
                 // has no more fields
-                debug_assert!(false, "All keys should be scalars or have a trailer");
+                debug_assert!(false, "All keys should be scalars, not {:?}", &token);
                 return None;
             }
         };
@@ -531,12 +507,6 @@ where
             TextToken::Operator(x) => (Some(x), key_ind + 2),
             _ => (None, key_ind + 1),
         };
-
-        // When reading an mixed object (a = { b = { c } 10 10 10 })
-        // there is an uneven number of keys and values so we drop the last "field"
-        if value_ind >= self.end_ind {
-            return None;
-        }
 
         let value_reader = ValueReader {
             value_ind,
@@ -594,7 +564,6 @@ where
     }
 
     /// Return the number of key value pairs that the object contains.
-    /// Does not count the object trailer if present
     pub fn fields_len(&self) -> usize {
         fields_len(self.tokens, self.start_ind, self.end_ind)
     }
@@ -688,25 +657,33 @@ impl<'data, 'tokens, E> ValueReader<'data, 'tokens, E>
 where
     E: Encoding + Clone,
 {
+    fn raw_str(&self) -> Option<Cow<'data, str>> {
+        match self.tokens[self.value_ind] {
+            TextToken::Header(s)
+            | TextToken::Unquoted(s)
+            | TextToken::Quoted(s)
+            | TextToken::Parameter(s)
+            | TextToken::UndefinedParameter(s) => Some(self.encoding.decode(s.as_bytes())),
+            TextToken::Operator(s) => Some(Cow::Borrowed(s.symbol())),
+            _ => None,
+        }
+    }
+
     /// Interpret the current value as string
     #[inline]
     pub fn read_str(&self) -> Result<Cow<'data, str>, DeserializeError> {
-        self.tokens[self.value_ind]
-            .as_scalar()
-            .map(|x| self.encoding.decode(x.as_bytes()))
-            .ok_or_else(|| DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
-            })
+        self.raw_str().ok_or_else(|| DeserializeError {
+            kind: DeserializeErrorKind::Unsupported(String::from("not a string")),
+        })
     }
 
     /// Interpret the current value as string
     #[inline]
     pub fn read_string(&self) -> Result<String, DeserializeError> {
-        self.tokens[self.value_ind]
-            .as_scalar()
-            .map(|x| self.encoding.decode(x.as_bytes()).into_owned())
+        self.raw_str()
+            .map(String::from)
             .ok_or_else(|| DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+                kind: DeserializeErrorKind::Unsupported(String::from("not a string")),
             })
     }
 
@@ -724,20 +701,20 @@ where
     #[inline]
     pub fn read_object(&self) -> Result<ObjectReader<'data, 'tokens, E>, DeserializeError> {
         match self.tokens[self.value_ind] {
-            TextToken::Object(ind) | TextToken::HiddenObject(ind) => Ok(ObjectReader {
+            TextToken::Object { end, .. } => Ok(ObjectReader {
                 tokens: self.tokens,
                 start_ind: self.value_ind + 1,
-                end_ind: ind,
+                end_ind: end,
                 encoding: self.encoding.clone(),
             }),
 
-            // An array can be an object if it is empty or interpreted as an object with only a trailer
-            TextToken::Array(ind) => Ok(ObjectReader {
+            TextToken::Array { end, .. } => Ok(ObjectReader {
                 tokens: self.tokens,
-                start_ind: self.value_ind,
-                end_ind: ind,
+                start_ind: end,
+                end_ind: end,
                 encoding: self.encoding.clone(),
             }),
+
             _ => Err(DeserializeError {
                 kind: DeserializeErrorKind::Unsupported(String::from("not an object")),
             }),
@@ -748,25 +725,25 @@ where
     #[inline]
     pub fn read_array(&self) -> Result<ArrayReader<'data, 'tokens, E>, DeserializeError> {
         match self.tokens[self.value_ind] {
-            TextToken::Array(ind) => Ok(ArrayReader {
+            TextToken::Object { end, mixed: true } => {
+                let mut start_ind = self.value_ind + 1;
+                while self.tokens.get(start_ind) != Some(&TextToken::MixedContainer) {
+                    start_ind = next_idx(self.tokens, start_ind);
+                }
+
+                Ok(ArrayReader {
+                    tokens: self.tokens,
+                    start_ind: start_ind + 1,
+                    end_ind: end,
+                    encoding: self.encoding.clone(),
+                })
+            }
+            TextToken::Array { end, .. } | TextToken::Object { end, .. } => Ok(ArrayReader {
                 tokens: self.tokens,
                 start_ind: self.value_ind + 1,
-                end_ind: ind,
+                end_ind: end,
                 encoding: self.encoding.clone(),
             }),
-
-            // An object can be an array when it has a trailer at the end
-            TextToken::Object(_) => {
-                let obj = self.read_object().unwrap();
-                let mut fields = obj.fields();
-                fields.by_ref().for_each(drop);
-                Ok(fields.at_trailer().unwrap_or_else(|| ArrayReader {
-                    tokens: self.tokens,
-                    start_ind: 0,
-                    end_ind: 0,
-                    encoding: self.encoding.clone(),
-                }))
-            }
 
             // A header can be seen as a two element array
             TextToken::Header(_) => Ok(ArrayReader {
@@ -799,7 +776,7 @@ where
     #[inline]
     pub fn tokens_len(&self) -> usize {
         match self.tokens[self.value_ind] {
-            TextToken::Array(end) | TextToken::Object(end) | TextToken::HiddenObject(end) => {
+            TextToken::Array { end, .. } | TextToken::Object { end, .. } => {
                 end - self.value_ind - 1
             }
             _ => 1,
@@ -859,7 +836,7 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         if self.token_ind < self.end_ind {
             let value_ind = self.token_ind;
-            self.token_ind = next_idx_header(self.tokens, self.token_ind);
+            self.token_ind = next_idx_values(self.tokens, self.token_ind);
             Some(ValueReader {
                 value_ind,
                 tokens: self.tokens,
@@ -938,14 +915,17 @@ mod tests {
         E: crate::Encoding + Clone,
     {
         match value.token() {
-            TextToken::Object(_) | TextToken::HiddenObject(_) => {
+            TextToken::Object { .. } => {
                 iterate_object(value.read_object().unwrap());
+                iterate_array(value.read_array().unwrap());
             }
-            TextToken::Array(_) => {
+            TextToken::Array { .. } => {
+                iterate_object(value.read_object().unwrap());
                 iterate_array(value.read_array().unwrap());
             }
             TextToken::End(_) => panic!("end!?"),
-            TextToken::Operator(_) => panic!("end!?"),
+            TextToken::Operator(_) => {}
+            TextToken::MixedContainer => {}
             TextToken::Unquoted(_)
             | TextToken::Quoted(_)
             | TextToken::Header(_)
@@ -979,10 +959,6 @@ mod tests {
         for (key, _op, value) in fields.by_ref() {
             let _ = key.read_str();
             read_value(value);
-        }
-
-        if let Some(trailer) = fields.at_trailer() {
-            iterate_array(trailer);
         }
     }
 
@@ -1039,39 +1015,6 @@ mod tests {
         assert!(values.next().is_none());
         assert_eq!(value1, String::from("bar"));
         assert_eq!(value2, String::from("qux"));
-    }
-
-    #[test]
-    fn text_reader_hidden_object() {
-        let data = b"levels={10 0=1 0=2}";
-        let tape = TextTape::from_slice(data).unwrap();
-        let reader = tape.windows1252_reader();
-
-        assert_eq!(reader.fields_len(), 1);
-        let mut iter = reader.fields();
-        let (key, _op, value) = iter.next().unwrap();
-        assert_eq!(key.read_string(), String::from("levels"));
-
-        let nested = value.read_array().unwrap();
-        assert_eq!(nested.len(), 2);
-
-        let mut values = nested.values();
-        let value1 = values.next().unwrap().read_string().unwrap();
-        assert_eq!(value1, String::from("10"));
-
-        let hidden = values.next().unwrap().read_object().unwrap();
-        assert_eq!(hidden.fields_len(), 2);
-        let mut hidden_iter = hidden.fields();
-        let (key, _op, value) = hidden_iter.next().unwrap();
-        assert_eq!(key.read_string(), String::from("0"));
-        assert_eq!(value.read_string().unwrap(), String::from("1"));
-
-        let (key, _op, value) = hidden_iter.next().unwrap();
-        assert_eq!(key.read_string(), String::from("0"));
-        assert_eq!(value.read_string().unwrap(), String::from("2"));
-
-        assert!(hidden_iter.next().is_none());
-        assert!(values.next().is_none());
     }
 
     #[test]
@@ -1180,7 +1123,50 @@ mod tests {
     }
 
     #[test]
-    fn text_reader_mixed_object() {
+    fn text_reader_mixed_object_1() {
+        let data = b"levels={10 0=1 0=2}";
+        let tape = TextTape::from_slice(data).unwrap();
+        let reader = tape.windows1252_reader();
+
+        assert_eq!(reader.fields_len(), 1);
+        let mut iter = reader.fields();
+        let (key, _op, value) = iter.next().unwrap();
+        assert_eq!(key.read_string(), String::from("levels"));
+
+        let nested = value.read_array().unwrap();
+        assert_eq!(nested.len(), 8);
+
+        assert_eq!(
+            nested.values().nth(3).unwrap().token(),
+            &TextToken::Operator(Operator::Equal)
+        );
+        assert_eq!(
+            nested.values().nth(6).unwrap().token(),
+            &TextToken::Operator(Operator::Equal)
+        );
+
+        let values = nested
+            .values()
+            .filter(|x| x.token() != &TextToken::MixedContainer)
+            .map(|x| x.read_string().unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            values.as_slice(),
+            &[
+                String::from("10"),
+                String::from("0"),
+                String::from("="),
+                String::from("1"),
+                String::from("0"),
+                String::from("="),
+                String::from("2"),
+            ]
+        );
+    }
+
+    #[test]
+    fn text_reader_mixed_object_2() {
         let data = br#"brittany_area = { #5
             color = { 118  99  151 }
             169 170 171 172 4384
@@ -1199,66 +1185,40 @@ mod tests {
             keys.push(key.read_str())
         }
 
-        assert_eq!(keys, vec![String::from("color"),]);
+        assert_eq!(keys, vec![String::from("color")]);
+        let trailer = fields.remainder();
+        assert_eq!(trailer.len(), 5);
+        assert_eq!(trailer.values().next().unwrap().read_str().unwrap(), "169");
 
-        let mut values = vec![];
-        let trailer = fields.at_trailer().unwrap();
-        for value in trailer.values() {
-            let nv = value.token();
-            values.push((*nv).clone());
-        }
+        let nested = value.read_array().unwrap();
+        assert_eq!(nested.len(), 5);
 
+        let mut values = nested.values();
         assert_eq!(
-            values,
-            vec![
-                TextToken::Unquoted(Scalar::new(b"169")),
-                TextToken::Unquoted(Scalar::new(b"170")),
-                TextToken::Unquoted(Scalar::new(b"171")),
-                TextToken::Unquoted(Scalar::new(b"172")),
-                TextToken::Unquoted(Scalar::new(b"4384")),
-            ]
+            values.next().unwrap().token(),
+            &TextToken::Unquoted(Scalar::new(b"169"))
         );
+        assert_eq!(
+            values.next().unwrap().token(),
+            &TextToken::Unquoted(Scalar::new(b"170"))
+        );
+        assert_eq!(
+            values.next().unwrap().token(),
+            &TextToken::Unquoted(Scalar::new(b"171"))
+        );
+        assert_eq!(
+            values.next().unwrap().token(),
+            &TextToken::Unquoted(Scalar::new(b"172"))
+        );
+        assert_eq!(
+            values.next().unwrap().token(),
+            &TextToken::Unquoted(Scalar::new(b"4384"))
+        );
+        assert!(values.next().is_none());
     }
 
     #[test]
-    fn text_reader_mixed_object_fields() {
-        let data = br#"brittany_area = { #5
-            color = { 118  99  151 }
-            169 170 171 172 4384
-        }"#;
-
-        let tape = TextTape::from_slice(data).unwrap();
-        let reader = tape.windows1252_reader();
-        let mut iter = reader.fields();
-        let (key, _op, value) = iter.next().unwrap();
-        assert_eq!(key.read_str(), "brittany_area");
-
-        let brittany = value.read_object().unwrap();
-        let mut field_groups = brittany.field_groups();
-        field_groups.next().unwrap();
-        assert!(field_groups.next().is_none());
-
-        let mut values = vec![];
-        let trailer = field_groups.at_trailer().unwrap();
-        for value in trailer.values() {
-            let nv = value.token();
-            values.push((*nv).clone());
-        }
-
-        assert_eq!(
-            values,
-            vec![
-                TextToken::Unquoted(Scalar::new(b"169")),
-                TextToken::Unquoted(Scalar::new(b"170")),
-                TextToken::Unquoted(Scalar::new(b"171")),
-                TextToken::Unquoted(Scalar::new(b"172")),
-                TextToken::Unquoted(Scalar::new(b"4384")),
-            ]
-        );
-    }
-
-    #[test]
-    fn text_trailer_size_hints() {
+    fn text_reader_mixed_object_3() {
         let data = br#"brittany_area = { #5
             color = { 118  99  151 }
             color = { 118  99  151 }
@@ -1293,6 +1253,89 @@ mod tests {
     }
 
     #[test]
+    fn text_reader_mixed_object_4() {
+        let data = br#"levels={a=b 10 c=d 20}"#;
+
+        let tape = TextTape::from_slice(data).unwrap();
+        let reader = tape.windows1252_reader();
+
+        assert_eq!(reader.fields_len(), 1);
+        let mut iter = reader.fields();
+        let (key, _op, value) = iter.next().unwrap();
+        assert_eq!(key.read_string(), String::from("levels"));
+
+        let nested = value.read_array().unwrap();
+        assert_eq!(nested.len(), 5);
+
+        let mut values = nested.values();
+        assert_eq!(
+            values.next().unwrap().token(),
+            &TextToken::Unquoted(Scalar::new(b"10"))
+        );
+        assert_eq!(
+            values.next().unwrap().token(),
+            &TextToken::Unquoted(Scalar::new(b"c"))
+        );
+        assert_eq!(
+            values.next().unwrap().token(),
+            &TextToken::Operator(Operator::Equal)
+        );
+        assert_eq!(
+            values.next().unwrap().token(),
+            &TextToken::Unquoted(Scalar::new(b"d"))
+        );
+        assert_eq!(
+            values.next().unwrap().token(),
+            &TextToken::Unquoted(Scalar::new(b"20"))
+        );
+        assert!(values.next().is_none());
+    }
+
+    #[test]
+    fn text_reader_mixed_object_5() {
+        let data = br#"brittany_area = { #5
+            color = { 118  99  151 }
+            169 170 171 172 4384
+        }"#;
+
+        let tape = TextTape::from_slice(data).unwrap();
+        let reader = tape.windows1252_reader();
+        let mut iter = reader.fields();
+        let (key, _op, value) = iter.next().unwrap();
+        assert_eq!(key.read_str(), "brittany_area");
+
+        let brittany = value.read_object().unwrap();
+        let mut field_groups = brittany.field_groups();
+        field_groups.next().unwrap();
+        assert!(field_groups.next().is_none());
+
+        let trailer = field_groups.remainder();
+
+        let mut values = trailer.values();
+        assert_eq!(
+            values.next().unwrap().token(),
+            &TextToken::Unquoted(Scalar::new(b"169"))
+        );
+        assert_eq!(
+            values.next().unwrap().token(),
+            &TextToken::Unquoted(Scalar::new(b"170"))
+        );
+        assert_eq!(
+            values.next().unwrap().token(),
+            &TextToken::Unquoted(Scalar::new(b"171"))
+        );
+        assert_eq!(
+            values.next().unwrap().token(),
+            &TextToken::Unquoted(Scalar::new(b"172"))
+        );
+        assert_eq!(
+            values.next().unwrap().token(),
+            &TextToken::Unquoted(Scalar::new(b"4384"))
+        );
+        assert!(values.next().is_none());
+    }
+
+    #[test]
     fn text_reader_empty_container() {
         let data = b"active_idea_groups={ }";
         let tape = TextTape::from_slice(data).unwrap();
@@ -1309,7 +1352,6 @@ mod tests {
         let mut empty_object_iter = empty_object.fields();
         assert_eq!(0, empty_object.fields_len());
         assert!(empty_object_iter.next().is_none());
-        assert!(empty_object_iter.at_trailer().is_none());
     }
 
     #[test]
@@ -1390,13 +1432,38 @@ mod tests {
         }
     }
 
-    // Investigate why this test case is so slow
+    #[test]
+    fn text_reader_regression() {
+        let data = b"a={b{}=2}";
+        if let Ok(tape) = TextTape::from_slice(data) {
+            let reader = tape.windows1252_reader();
+            iterate_object(reader);
+        }
+    }
+
+    #[test]
+    fn text_reader_regression2() {
+        let data = b"r={c=d=@{y=u}";
+        if let Ok(tape) = TextTape::from_slice(data) {
+            let reader = tape.windows1252_reader();
+            iterate_object(reader);
+        }
+    }
+
+    #[test]
+    fn text_reader_regression3() {
+        let data = b"a={{t c=d = b}}";
+        if let Ok(tape) = TextTape::from_slice(data) {
+            let reader = tape.windows1252_reader();
+            iterate_object(reader);
+        }
+    }
+
     // #[test]
-    // fn text_reader_oom() {
-    //     let data = b"w{w={w={w={a={w={w={.=w={W={={w={w={a={w={w={.=w={W={w={w={b=}.{B{6={b={w={w={.b=}}}ws!=}}}}={=b}}=}}}}={w=}}}}}w={w={b=}.{B{6={b={w={w={.b=}}}ws!=}}}}={=b}}=}}}}={w=}}}}}";
+    // fn text_reader_regression4() {
+    //     let data = include_bytes!("/home/nick/projects/jomini/fuzz/artifacts/fuzz_text/crash-a14643c9a89c0f4ab665815c99a07b15de3544a5");
+    //     // let data = b"a={{ b c == == = d e=f}}";
     //     if let Ok(tape) = TextTape::from_slice(data) {
-    //         dbg!(&tape);
-    //         assert!(false);
     //         let reader = tape.windows1252_reader();
     //         iterate_object(reader);
     //     }

--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -8,30 +8,35 @@ use crate::{Error, ErrorKind, Scalar};
 /// Represents a valid text value
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TextToken<'a> {
-    /// Index of the `TextToken::End` that signifies this array's termination
-    Array(usize),
+    /// Start of an array
+    Array {
+        /// The index of the `TextToken::End` for this array
+        end: usize,
 
-    /// Index of the `TextToken::End` that signifies this objects's termination
+        /// If this array contains a `MixedContainer` token
+        mixed: bool,
+    },
+
+    /// Start of an object
     ///
-    /// Typically in the tape the value immediately follows a key token. However,
+    /// The value of a property typically immediately follows a key token. However,
     /// this is not guaranteed so always check if the end has been reached before
     /// trying to decode a value. There are two main situations where this is not
     /// guaranteed:
     ///
     /// - A non-equal operator (eg: `a > b` will be parsed to 3 instead of 2 tokens)
-    /// - Array trailers (eg: `a = {10} 0 1 2`)
-    Object(usize),
+    /// - If an object switches to a mixed container that is both an array and object
+    Object {
+        /// Index of the `TextToken::End` that signifies this objects's termination
+        end: usize,
 
-    /// Index of the `TextToken::End` that signifies this objects's termination
-    ///
-    /// A hidden object occurs where the first element is part of an array:
-    ///
-    /// ```ignore
-    /// a = { 10 a=b c=d}
-    /// ```
-    ///
-    /// In the above example, a and c would be part of the hidden object
-    HiddenObject(usize),
+        /// If this object contains a `MixedContainer` token
+        mixed: bool,
+    },
+
+    /// Denotes the start of where a homogenous object or array becomes
+    /// heterogenous.
+    MixedContainer,
 
     /// Extracted unquoted scalar value
     Unquoted(Scalar<'a>),
@@ -85,7 +90,7 @@ impl<'a> TextToken<'a> {
     /// assert_eq!(TextToken::Unquoted(Scalar::new(b"abc")).as_scalar(), Some(Scalar::new(b"abc")));
     /// assert_eq!(TextToken::Quoted(Scalar::new(b"abc")).as_scalar(), Some(Scalar::new(b"abc")));
     /// assert_eq!(TextToken::Header(Scalar::new(b"rgb")).as_scalar(), Some(Scalar::new(b"rgb")));
-    /// assert_eq!(TextToken::Object(2).as_scalar(), None);
+    /// assert_eq!((TextToken::Object { end: 2, mixed: false }).as_scalar(), None);
     /// ```
     pub fn as_scalar(&self) -> Option<Scalar<'a>> {
         match self {
@@ -172,7 +177,6 @@ enum ParseState {
     ObjectValue,
     ArrayValue,
     ParseOpen,
-    FirstValue,
 }
 
 /// I'm not smart enough to figure out the behavior of handling escape sequences when
@@ -498,75 +502,6 @@ impl<'a, 'b> ParserState<'a, 'b> {
         rest
     }
 
-    #[inline]
-    fn parse_key_value_separator(&mut self, d: &'a [u8]) -> &'a [u8] {
-        // Most key values are separated by an equal sign but there are some fields like
-        // map_area_data that does not have a separator.
-        //
-        // ```
-        // map_area_data{
-        //   brittany_area={
-        //   # ...
-        // ```
-        //
-        // Additionally it's possible for there to be heterogenus objects:
-        //
-        // ```
-        // brittany_area = { color = { 10 10 10 } 100 200 300 }
-        // ```
-        //
-        // These are especially tricky, but essentially this function's job is to skip the equal
-        // token (the 99.9% typical case) if possible.
-        let range = d.as_ptr_range();
-        let mut cur = range.start;
-        if unsafe { *cur } != b'=' {
-            return self.parse_key_value_separator_unlikely(d);
-        }
-
-        cur = unsafe { cur.add(1) };
-        if cur == range.end {
-            self.parse_key_value_separator_unlikely(d)
-        } else if unsafe { *cur } != b'=' {
-            &d[1..]
-        } else {
-            self.parse_key_value_separator_unlikely(d)
-        }
-    }
-
-    #[inline(never)]
-    fn parse_key_value_separator_unlikely(&mut self, d: &'a [u8]) -> &'a [u8] {
-        if d[0] == b'<' {
-            if d.get(1).map_or(false, |c| *c == b'=') {
-                self.token_tape
-                    .push(TextToken::Operator(Operator::LessThanEqual));
-                &d[2..]
-            } else {
-                self.token_tape
-                    .push(TextToken::Operator(Operator::LessThan));
-                &d[1..]
-            }
-        } else if d[0] == b'>' {
-            if d.get(1).map_or(false, |c| *c == b'=') {
-                self.token_tape
-                    .push(TextToken::Operator(Operator::GreaterThanEqual));
-                &d[2..]
-            } else {
-                self.token_tape
-                    .push(TextToken::Operator(Operator::GreaterThan));
-                &d[1..]
-            }
-        } else if d[0] == b'!' && d.get(1).map_or(false, |c| *c == b'=') {
-            self.token_tape
-                .push(TextToken::Operator(Operator::NotEqual));
-            &d[2..]
-        } else if d[0] == b'=' && d.get(1).map_or(false, |c| *c == b'=') {
-            self.token_tape.push(TextToken::Operator(Operator::Exact));
-            &d[2..]
-        } else {
-            d
-        }
-    }
-
     /// Clear previously parsed data and parse the given data
     #[inline]
     pub fn parse(&mut self) -> Result<(), Error> {
@@ -578,20 +513,7 @@ impl<'a, 'b> ParserState<'a, 'b> {
             data = &data[3..];
         }
 
-        // This variable keeps track of outer array when we're parsing a hidden object.
-        // A hidden object textually looks like:
-        //     levels={ 10 0=2 1=2 }
-        // which we will translate into
-        //     levels={ 10 { 0=2 1=2 } }
-        // with the help of this variable. As when we'll only see one END token to signify
-        // both the end of the array and object, but we'll produce two TextToken::End.
-        let mut array_ind_of_hidden_obj = None;
-
-        // Records if an object key does not have an operator for detecting objecty trailers:
-        // brittany_area = { color = { 10 10 10 } 100 200 300 }
-        let mut lack_operator = false;
-        let mut in_trailer = false;
-
+        let mut mixed_mode = false;
         let mut parent_ind = 0;
         loop {
             let d = match self.skip_ws_t(data) {
@@ -606,15 +528,15 @@ impl<'a, 'b> ParserState<'a, 'b> {
                     } else {
                         // Support for files that don't have enough closing brackets (ugh)
                         let grand_ind = match self.token_tape.get(parent_ind) {
-                            Some(TextToken::Array(x)) => *x,
-                            Some(TextToken::Object(x)) => *x,
+                            Some(TextToken::Array { end, .. }) => *end,
+                            Some(TextToken::Object { end, .. }) => *end,
                             _ => 0,
                         };
 
                         if grand_ind == 0 {
-                            let end_idx = self.token_tape.len();
+                            let end = self.token_tape.len();
                             self.token_tape.push(TextToken::End(parent_ind));
-                            self.token_tape[parent_ind] = TextToken::Object(end_idx);
+                            self.token_tape[parent_ind] = TextToken::Object { end, mixed: false };
                             return Ok(());
                         } else {
                             return Err(Error::eof());
@@ -628,16 +550,30 @@ impl<'a, 'b> ParserState<'a, 'b> {
                 ParseState::Key => {
                     match data[0] {
                         b'}' | b']' => {
+                            let saved_mixed = mixed_mode;
                             let grand_ind = match self.token_tape.get(parent_ind) {
-                                Some(TextToken::Array(x)) => *x,
-                                Some(TextToken::Object(x)) => *x,
+                                Some(TextToken::Array { end, .. }) => *end,
+                                Some(TextToken::Object { end, .. }) => *end,
                                 _ => 0,
                             };
 
-                            state = match self.token_tape.get(grand_ind) {
-                                Some(TextToken::Array(_x)) => ParseState::ArrayValue,
-                                Some(TextToken::Object(_x)) => ParseState::Key,
-                                _ => ParseState::Key,
+                            match self.token_tape.get(grand_ind) {
+                                Some(TextToken::Array { mixed, .. }) => {
+                                    mixed_mode = *mixed;
+                                    state = ParseState::ArrayValue;
+                                }
+                                Some(TextToken::Object { mixed, .. }) => {
+                                    mixed_mode = *mixed;
+                                    state = if mixed_mode {
+                                        ParseState::ArrayValue
+                                    } else {
+                                        ParseState::Key
+                                    }
+                                }
+                                _ => {
+                                    mixed_mode = false;
+                                    state = ParseState::Key;
+                                }
                             };
 
                             let end_idx = self.token_tape.len();
@@ -648,39 +584,11 @@ impl<'a, 'b> ParserState<'a, 'b> {
                             }
 
                             self.token_tape.push(TextToken::End(parent_ind));
-                            if let Some(array_ind) = array_ind_of_hidden_obj.take() {
-                                self.token_tape[parent_ind] = TextToken::HiddenObject(end_idx);
-
-                                let end_idx = self.token_tape.len();
-                                self.token_tape.push(TextToken::End(array_ind));
-
-                                // Grab the grand parent from the outer array. Even though the logic should
-                                // be more strict (ie: throwing an error when if the parent array index doesn't exist,
-                                // or if the parent doesn't exist), but since hidden objects are such a rather rare
-                                // occurrence, it's better to be flexible
-                                let grand_ind =
-                                    if let Some(parent) = self.token_tape.get_mut(array_ind) {
-                                        let grand_ind = match parent {
-                                            TextToken::Array(x) => *x,
-                                            _ => 0,
-                                        };
-                                        *parent = TextToken::Array(end_idx);
-                                        grand_ind
-                                    } else {
-                                        0
-                                    };
-
-                                state = match self.token_tape.get(grand_ind) {
-                                    Some(TextToken::Array(_x)) => ParseState::ArrayValue,
-                                    Some(TextToken::Object(_x)) => ParseState::Key,
-                                    _ => ParseState::Key,
-                                };
-                                parent_ind = grand_ind;
-                            } else {
-                                self.token_tape[parent_ind] = TextToken::Object(end_idx);
-                                parent_ind = grand_ind;
-                            }
-
+                            self.token_tape[parent_ind] = TextToken::Object {
+                                end: end_idx,
+                                mixed: saved_mixed,
+                            };
+                            parent_ind = grand_ind;
                             data = &data[1..];
                         }
 
@@ -694,12 +602,13 @@ impl<'a, 'b> ParserState<'a, 'b> {
 
                             if let Some(last) = self.token_tape.last_mut() {
                                 if let TextToken::Unquoted(header) = last {
-                                    if array_ind_of_hidden_obj.is_none() {
-                                        *last = TextToken::Header(*header);
-                                        self.token_tape.push(TextToken::Array(0));
-                                        state = ParseState::ParseOpen;
-                                        continue;
-                                    }
+                                    *last = TextToken::Header(*header);
+                                    self.token_tape.push(TextToken::Array {
+                                        end: 0,
+                                        mixed: false,
+                                    });
+                                    state = ParseState::ParseOpen;
+                                    continue;
                                 }
                             }
 
@@ -715,7 +624,6 @@ impl<'a, 'b> ParserState<'a, 'b> {
                                 &mut parent_ind,
                                 &mut state,
                                 false,
-                                array_ind_of_hidden_obj.is_some(),
                             )?;
                         }
 
@@ -735,245 +643,268 @@ impl<'a, 'b> ParserState<'a, 'b> {
                         }
                     }
                 }
-                ParseState::KeyValueSeparator => {
-                    let new_data = self.parse_key_value_separator(data);
-                    lack_operator = new_data.len() == data.len();
-                    data = new_data;
-                    state = ParseState::ObjectValue;
-                }
-                ParseState::ObjectValue => {
-                    match data[0] {
-                        b'{' => {
-                            if let Some(array_ind) = array_ind_of_hidden_obj.take() {
-                                // before we error, we should check if we previously parsed an empty array
-                                // `history={{} 1444.11.11={core=AAA}}`
-                                // so we're going to go back up the stack until we see our parent object
-                                // and ensure that everything along the way is an empty array
-
-                                let mut start = self.token_tape.len() - 3;
-                                while start > array_ind {
-                                    match self.token_tape[start] {
-                                        TextToken::End(x) if x == start - 1 => {
-                                            start -= 2;
-                                        }
-                                        _ => {
-                                            return Err(Error::new(ErrorKind::InvalidSyntax {
-                                                offset: self.offset(data) - 2,
-                                                msg: String::from(
-                                                    "header values inside a hidden object are unsupported",
-                                                ),
-                                            }));
-                                        }
-                                    }
-                                }
-
-                                let empty_objects_to_remove = self.token_tape.len() - 2 - array_ind;
-
-                                let grand_ind = match self.token_tape[array_ind] {
-                                    TextToken::Array(x) => x,
-                                    _ => 0,
-                                };
-
-                                for _ in 0..empty_objects_to_remove {
-                                    self.token_tape.remove(self.token_tape.len() - 3);
-                                }
-
-                                parent_ind = array_ind;
-                                self.token_tape[parent_ind] = TextToken::Object(grand_ind);
-                            }
-
-                            self.token_tape.push(TextToken::Array(0));
-                            state = ParseState::ParseOpen;
-                            data = &data[1..];
-                        }
-
-                        b'}' => {
-                            // Encountering a `}` for an object value has never been encountered in the wild
-                            // but it makes sense to interpret it as an array trailer of one element long.
-                            if parent_ind == 0 {
-                                return Err(Error::new(ErrorKind::StackEmpty {
-                                    offset: self.offset(data),
-                                }));
-                            }
-
-                            let ind = self.token_tape.len() - 1;
-                            if array_ind_of_hidden_obj.is_some()
-                                || !matches!(
-                                    self.token_tape[ind],
-                                    TextToken::Unquoted(_) | TextToken::Quoted(_)
-                                )
-                            {
-                                return Err(Error::new(ErrorKind::InvalidSyntax {
-                                    msg: String::from("complex trailers are not supported"),
-                                    offset: self.offset(data),
-                                }));
-                            }
-
-                            self.token_tape.insert(ind, TextToken::Array(parent_ind));
-                            parent_ind = ind;
-                            state = ParseState::ArrayValue;
-                            in_trailer = true;
-                        }
-
-                        b'"' => {
-                            data = self.parse_quote_scalar(data)?;
-                            state = ParseState::Key;
-                        }
-                        b'@' => {
-                            data = self.parse_variable(data)?;
-                            state = ParseState::Key;
-                        }
-                        _ => {
-                            if lack_operator && parent_ind != 0 {
-                                if array_ind_of_hidden_obj.is_some() {
-                                    return Err(Error::new(ErrorKind::InvalidSyntax {
-                                        msg: String::from("complex trailers are not supported"),
-                                        offset: self.offset(data),
-                                    }));
-                                }
-
-                                let ind = self.token_tape.len() - 1;
-                                self.token_tape.insert(ind, TextToken::Array(parent_ind));
-                                parent_ind = ind;
-                                state = ParseState::ArrayValue;
-                                in_trailer = true;
-                            } else {
-                                data = self.parse_scalar(data);
-                                state = ParseState::Key;
-                            }
-                        }
+                ParseState::KeyValueSeparator => match data {
+                    [b'<', b'=', ..] => {
+                        self.token_tape
+                            .push(TextToken::Operator(Operator::LessThanEqual));
+                        data = &data[2..];
+                        state = ParseState::ObjectValue;
                     }
-                    lack_operator = false;
-                }
+                    [b'<', ..] => {
+                        self.token_tape
+                            .push(TextToken::Operator(Operator::LessThan));
+                        data = &data[1..];
+                        state = ParseState::ObjectValue;
+                    }
+                    [b'>', b'=', ..] => {
+                        self.token_tape
+                            .push(TextToken::Operator(Operator::GreaterThanEqual));
+                        data = &data[2..];
+                        state = ParseState::ObjectValue;
+                    }
+                    [b'>', ..] => {
+                        self.token_tape
+                            .push(TextToken::Operator(Operator::GreaterThan));
+                        data = &data[1..];
+                        state = ParseState::ObjectValue;
+                    }
+                    [b'!', b'=', ..] => {
+                        self.token_tape
+                            .push(TextToken::Operator(Operator::NotEqual));
+                        data = &data[2..];
+                        state = ParseState::ObjectValue;
+                    }
+                    [b'=', b'=', ..] => {
+                        self.token_tape.push(TextToken::Operator(Operator::Exact));
+                        data = &data[2..];
+                        state = ParseState::ObjectValue;
+                    }
+                    [b'=', ..] if mixed_mode => {
+                        self.token_tape.push(TextToken::Operator(Operator::Equal));
+                        data = &data[1..];
+                    }
+                    [b'=', ..] => {
+                        data = &data[1..];
+                        state = ParseState::ObjectValue;
+                    }
+                    [b'{', ..] => {
+                        state = ParseState::ObjectValue;
+                    }
+                    [b'}', ..] => {
+                        self.token_tape
+                            .insert(self.token_tape.len() - 1, TextToken::MixedContainer);
+                        state = ParseState::ArrayValue;
+                        mixed_mode = true;
+                    }
+                    _ => {
+                        self.token_tape
+                            .insert(self.token_tape.len() - 1, TextToken::MixedContainer);
+                        state = ParseState::ArrayValue;
+                        mixed_mode = true;
+                    }
+                },
+                ParseState::ObjectValue => match data[0] {
+                    b'{' => {
+                        self.token_tape.push(TextToken::Array {
+                            end: 0,
+                            mixed: false,
+                        });
+                        state = ParseState::ParseOpen;
+                        data = &data[1..];
+                    }
+
+                    b'}' => {
+                        return Err(Error::new(ErrorKind::InvalidSyntax {
+                            msg: String::from("encountered '}' for object value"),
+                            offset: self.offset(data),
+                        }));
+                    }
+
+                    b'"' => {
+                        data = self.parse_quote_scalar(data)?;
+                        state = ParseState::Key;
+                    }
+                    b'@' => {
+                        data = self.parse_variable(data)?;
+                        state = ParseState::Key;
+                    }
+                    _ => {
+                        data = self.parse_scalar(data);
+                        state = ParseState::Key;
+                    }
+                },
                 ParseState::ParseOpen => {
                     match data[0] {
                         // Empty array
                         b'}' => {
                             let ind = self.token_tape.len() - 1;
-                            state = match self.token_tape.get(parent_ind) {
-                                Some(TextToken::Array(_x)) => ParseState::ArrayValue,
-                                Some(TextToken::Object(_x)) => ParseState::Key,
-                                _ => ParseState::Key,
+
+                            match self.token_tape.get(parent_ind) {
+                                Some(TextToken::Array { mixed, .. }) => {
+                                    mixed_mode = *mixed;
+                                    state = ParseState::ArrayValue;
+                                }
+                                Some(TextToken::Object { mixed, .. }) => {
+                                    mixed_mode = *mixed;
+                                    state = if mixed_mode {
+                                        ParseState::ArrayValue
+                                    } else {
+                                        ParseState::Key
+                                    }
+                                }
+                                _ => {
+                                    mixed_mode = false;
+                                    state = ParseState::Key;
+                                }
                             };
 
-                            self.token_tape[ind] = TextToken::Array(ind + 1);
+                            self.token_tape[ind] = TextToken::Array {
+                                end: ind + 1,
+                                mixed: false,
+                            };
                             self.token_tape.push(TextToken::End(ind));
                             data = &data[1..];
+                            continue;
                         }
 
                         // start of a parameter definition
                         b'[' => {
+                            if mixed_mode {
+                                return Err(Error::new(ErrorKind::InvalidSyntax {
+                                    msg: String::from(
+                                        "mixed object and array container not expected",
+                                    ),
+                                    offset: self.offset(data),
+                                }));
+                            }
+
                             data = self.parse_parameter_definition(
                                 data,
                                 &mut parent_ind,
                                 &mut state,
                                 true,
-                                array_ind_of_hidden_obj.is_some(),
                             )?;
+                            continue;
                         }
 
-                        // array of objects or another array
+                        // array of objects, another array
                         b'{' => {
+                            let scratch = self.skip_ws_t(&data[1..]).ok_or_else(Error::eof)?;
+                            if scratch[0] == b'}' {
+                                data = &scratch[1..];
+                                continue;
+                            }
+
+                            mixed_mode = false;
                             let ind = self.token_tape.len() - 1;
-                            self.token_tape[ind] = TextToken::Array(parent_ind);
+                            self.token_tape[ind] = TextToken::Array {
+                                end: parent_ind,
+                                mixed: mixed_mode,
+                            };
                             parent_ind = ind;
                             state = ParseState::ArrayValue;
+                            continue;
                         }
                         b'"' => {
                             data = self.parse_quote_scalar(data)?;
-                            state = ParseState::FirstValue;
                         }
                         b'@' => {
                             data = self.parse_variable(data)?;
-                            state = ParseState::FirstValue;
                         }
                         _ => {
                             data = self.parse_scalar(data);
-                            state = ParseState::FirstValue;
+                        }
+                    }
+
+                    if mixed_mode {
+                        if let Some(
+                            TextToken::Array { mixed, .. } | TextToken::Object { mixed, .. },
+                        ) = self.token_tape.get_mut(parent_ind)
+                        {
+                            *mixed = mixed_mode;
+                        }
+                    }
+
+                    mixed_mode = false;
+                    data = self.skip_ws_t(data).ok_or_else(Error::eof)?;
+                    match data[0] {
+                        b'=' | b'>' | b'<' => {
+                            let ind = self.token_tape.len() - 2;
+                            self.token_tape[ind] = TextToken::Object {
+                                end: parent_ind,
+                                mixed: mixed_mode,
+                            };
+                            parent_ind = ind;
+                            state = ParseState::KeyValueSeparator;
+                        }
+                        _ => {
+                            let ind = self.token_tape.len() - 2;
+                            self.token_tape[ind] = TextToken::Array {
+                                end: parent_ind,
+                                mixed: mixed_mode,
+                            };
+                            parent_ind = ind;
+                            state = ParseState::ArrayValue;
                         }
                     }
                 }
-                ParseState::FirstValue => match data[0] {
-                    b'=' | b'>' | b'<' => {
-                        let ind = self.token_tape.len() - 2;
-                        self.token_tape[ind] = TextToken::Object(parent_ind);
-                        parent_ind = ind;
-                        state = ParseState::KeyValueSeparator;
-                    }
-                    _ => {
-                        let ind = self.token_tape.len() - 2;
-                        self.token_tape[ind] = TextToken::Array(parent_ind);
-                        parent_ind = ind;
-                        state = ParseState::ArrayValue;
-                    }
-                },
                 ParseState::ArrayValue => match data[0] {
                     b'{' => {
-                        if in_trailer {
-                            return Err(Error::new(ErrorKind::InvalidSyntax {
-                                msg: String::from("complex trailers are not supported"),
-                                offset: self.offset(data) - 1,
-                            }));
-                        }
-
-                        self.token_tape.push(TextToken::Array(0));
+                        self.token_tape.push(TextToken::Array {
+                            end: 0,
+                            mixed: false,
+                        });
                         state = ParseState::ParseOpen;
                         data = &data[1..];
                     }
                     b'}' => {
-                        if in_trailer {
-                            let parent_obj_ind = if let Some(TextToken::Array(x)) =
-                                self.token_tape.get(parent_ind)
-                            {
-                                *x
-                            } else {
-                                panic!("expected array");
-                            };
+                        let saved_mixed_mode = mixed_mode;
+                        let (grand_ind, is_array) = match self.token_tape.get(parent_ind) {
+                            Some(TextToken::Array { end, .. }) => (*end, true),
+                            Some(TextToken::Object { end, .. }) => (*end, false),
+                            _ => (0, false),
+                        };
 
-                            let grand_ind = match self.token_tape.get(parent_obj_ind) {
-                                Some(TextToken::Array(x)) => *x,
-                                Some(TextToken::Object(x)) => *x,
-                                _ => 0,
-                            };
-
-                            state = match self.token_tape.get(grand_ind) {
-                                Some(TextToken::Array(_x)) => ParseState::ArrayValue,
-                                Some(TextToken::Object(_x)) => ParseState::Key,
-                                _ => ParseState::Key,
-                            };
-
-                            let end_idx = self.token_tape.len();
-                            self.token_tape[parent_ind] = TextToken::Array(end_idx);
-                            self.token_tape[parent_obj_ind] = TextToken::Object(end_idx + 1);
-                            self.token_tape.push(TextToken::End(parent_ind));
-                            self.token_tape.push(TextToken::End(parent_obj_ind));
-                            parent_ind = grand_ind;
-                            in_trailer = false;
-                        } else {
-                            let grand_ind = match self.token_tape.get(parent_ind) {
-                                Some(TextToken::Array(x)) => *x,
-                                Some(TextToken::Object(x)) => *x,
-                                _ => 0,
-                            };
-
-                            state = match self.token_tape.get(grand_ind) {
-                                Some(TextToken::Array(_x)) => ParseState::ArrayValue,
-                                Some(TextToken::Object(_x)) => ParseState::Key,
-                                _ => ParseState::Key,
-                            };
-
-                            if parent_ind == 0 && grand_ind == 0 {
-                                return Err(Error::new(ErrorKind::StackEmpty {
-                                    offset: self.offset(data),
-                                }));
+                        match self.token_tape.get(grand_ind) {
+                            Some(TextToken::Array { mixed, .. }) => {
+                                mixed_mode = *mixed;
+                                state = ParseState::ArrayValue;
                             }
+                            Some(TextToken::Object { mixed, .. }) => {
+                                mixed_mode = *mixed;
+                                state = if mixed_mode {
+                                    ParseState::ArrayValue
+                                } else {
+                                    ParseState::Key
+                                }
+                            }
+                            _ => {
+                                mixed_mode = false;
+                                state = ParseState::Key;
+                            }
+                        };
 
-                            let end_idx = self.token_tape.len();
-                            self.token_tape[parent_ind] = TextToken::Array(end_idx);
-                            self.token_tape.push(TextToken::End(parent_ind));
-                            parent_ind = grand_ind;
+                        if parent_ind == 0 && grand_ind == 0 {
+                            return Err(Error::new(ErrorKind::StackEmpty {
+                                offset: self.offset(data),
+                            }));
                         }
 
+                        let end_idx = self.token_tape.len();
+                        self.token_tape[parent_ind] = if is_array {
+                            TextToken::Array {
+                                end: end_idx,
+                                mixed: saved_mixed_mode,
+                            }
+                        } else {
+                            TextToken::Object {
+                                end: end_idx,
+                                mixed: saved_mixed_mode,
+                            }
+                        };
+
+                        self.token_tape.push(TextToken::End(parent_ind));
+                        parent_ind = grand_ind;
                         data = &data[1..];
                     }
                     b'"' => {
@@ -984,30 +915,61 @@ impl<'a, 'b> ParserState<'a, 'b> {
                         data = self.parse_variable(data)?;
                         state = ParseState::ArrayValue;
                     }
-                    b'=' => {
-                        // CK3 introduced hidden object inside lists so we work around it by trying to
-                        // make the object explicit, but we first check to see if we have any prior
-                        // array values
-                        if self.token_tape.len() - parent_ind <= 1
-                            || matches!(
-                                self.token_tape[self.token_tape.len() - 1],
-                                TextToken::End(_)
-                            )
-                            || in_trailer
-                        {
-                            return Err(Error::new(ErrorKind::InvalidSyntax {
-                                msg: String::from("hidden object must start with a key"),
-                                offset: self.offset(data) - 1,
-                            }));
+                    b'<' | b'>' | b'!' | b'=' => {
+                        if !mixed_mode {
+                            if self.token_tape.last().and_then(|x| x.as_scalar()).is_some() {
+                                self.token_tape
+                                    .insert(self.token_tape.len() - 1, TextToken::MixedContainer);
+                                mixed_mode = true;
+                            } else {
+                                return Err(Error::new(ErrorKind::InvalidSyntax {
+                                    msg: String::from("expected a scalar to precede an operator"),
+                                    offset: self.offset(data) - 1,
+                                }));
+                            }
                         }
 
-                        let hidden_object = TextToken::Object(parent_ind);
-                        array_ind_of_hidden_obj = Some(parent_ind);
-                        parent_ind = self.token_tape.len() - 1;
-                        self.token_tape
-                            .insert(self.token_tape.len() - 1, hidden_object);
-                        state = ParseState::ObjectValue;
-                        data = &data[1..];
+                        match data {
+                            [b'<', b'=', ..] => {
+                                self.token_tape
+                                    .push(TextToken::Operator(Operator::LessThanEqual));
+                                data = &data[2..];
+                            }
+                            [b'<', ..] => {
+                                self.token_tape
+                                    .push(TextToken::Operator(Operator::LessThan));
+                                data = &data[1..];
+                            }
+                            [b'>', b'=', ..] => {
+                                self.token_tape
+                                    .push(TextToken::Operator(Operator::GreaterThanEqual));
+                                data = &data[2..];
+                            }
+                            [b'>', ..] => {
+                                self.token_tape
+                                    .push(TextToken::Operator(Operator::GreaterThan));
+                                data = &data[1..];
+                            }
+                            [b'!', b'=', ..] => {
+                                self.token_tape
+                                    .push(TextToken::Operator(Operator::NotEqual));
+                                data = &data[2..];
+                            }
+                            [b'=', b'=', ..] => {
+                                self.token_tape.push(TextToken::Operator(Operator::Exact));
+                                data = &data[2..];
+                            }
+                            [b'=', ..] => {
+                                self.token_tape.push(TextToken::Operator(Operator::Equal));
+                                data = &data[1..];
+                            }
+                            _ => {
+                                return Err(Error::new(ErrorKind::InvalidSyntax {
+                                    msg: String::from("unrecognized operator"),
+                                    offset: self.offset(data) - 1,
+                                }));
+                            }
+                        }
                     }
                     _ => {
                         data = self.parse_scalar(data);
@@ -1024,15 +986,7 @@ impl<'a, 'b> ParserState<'a, 'b> {
         parent_ind: &mut usize,
         state: &mut ParseState,
         initial: bool,
-        inside_hidden_object: bool,
     ) -> Result<&'a [u8], Error> {
-        if inside_hidden_object {
-            return Err(Error::new(ErrorKind::InvalidSyntax {
-                offset: self.offset(data),
-                msg: String::from("parameter definitions inside hidden objects are not allowed"),
-            }));
-        }
-
         if !matches!(data.get(1), Some(&x) if x == b'[') {
             return Err(Error::new(ErrorKind::InvalidSyntax {
                 offset: self.offset(data),
@@ -1044,7 +998,10 @@ impl<'a, 'b> ParserState<'a, 'b> {
         // definition means an object as parameters should be uniquely named
         if initial {
             let ind = self.token_tape.len() - 1;
-            self.token_tape[ind] = TextToken::Object(*parent_ind);
+            self.token_tape[ind] = TextToken::Object {
+                end: *parent_ind,
+                mixed: false,
+            };
             *parent_ind = ind;
         }
 
@@ -1088,7 +1045,10 @@ impl<'a, 'b> ParserState<'a, 'b> {
         } else {
             let grand_ind = *parent_ind;
             *parent_ind = self.token_tape.len();
-            self.token_tape.push(TextToken::Object(grand_ind));
+            self.token_tape.push(TextToken::Object {
+                end: grand_ind,
+                mixed: false,
+            });
             self.token_tape.push(TextToken::Unquoted(key_or_value));
             *state = ParseState::KeyValueSeparator;
             Ok(data)
@@ -1270,7 +1230,10 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"foo")),
-                TextToken::Object(4),
+                TextToken::Object {
+                    end: 4,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"bar")),
                 TextToken::Unquoted(Scalar::new(b"qux")),
                 TextToken::End(1),
@@ -1286,7 +1249,10 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"foo")),
-                TextToken::Object(6),
+                TextToken::Object {
+                    end: 6,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"bar")),
                 TextToken::Unquoted(Scalar::new(b"1")),
                 TextToken::Unquoted(Scalar::new(b"qux")),
@@ -1309,7 +1275,10 @@ mod tests {
             tape.tokens(),
             vec![
                 TextToken::Unquoted(Scalar::new(b"foo")),
-                TextToken::Object(6),
+                TextToken::Object {
+                    end: 6,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"bar")),
                 TextToken::Unquoted(Scalar::new(b"1")),
                 TextToken::Unquoted(Scalar::new(b"qux")),
@@ -1327,7 +1296,10 @@ mod tests {
             tape.tokens(),
             vec![
                 TextToken::Unquoted(Scalar::new(b"foo2")),
-                TextToken::Object(6),
+                TextToken::Object {
+                    end: 6,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"bar2")),
                 TextToken::Unquoted(Scalar::new(b"3")),
                 TextToken::Unquoted(Scalar::new(b"qux2")),
@@ -1345,7 +1317,10 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"versions")),
-                TextToken::Array(3),
+                TextToken::Array {
+                    end: 3,
+                    mixed: false
+                },
                 TextToken::Quoted(Scalar::new(b"1.28.3.0")),
                 TextToken::End(1),
             ]
@@ -1360,7 +1335,10 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"versions")),
-                TextToken::Array(4),
+                TextToken::Array {
+                    end: 4,
+                    mixed: false
+                },
                 TextToken::Quoted(Scalar::new(b"1.28.3.0")),
                 TextToken::Unquoted(Scalar::new(b"foo")),
                 TextToken::End(1),
@@ -1376,7 +1354,10 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"foo")),
-                TextToken::Object(4),
+                TextToken::Object {
+                    end: 4,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"bar")),
                 TextToken::Unquoted(Scalar::new(b"qux")),
                 TextToken::End(1),
@@ -1400,22 +1381,32 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"dlc002")),
-                TextToken::Object(17),
+                TextToken::Object {
+                    end: 21,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"name")),
                 TextToken::Quoted(Scalar::new(b"Arachnoid Portrait Pack")),
                 TextToken::Unquoted(Scalar::new(b"steam_id")),
                 TextToken::Quoted(Scalar::new(b"447680")),
                 TextToken::Unquoted(Scalar::new(b"gog_store_id")),
                 TextToken::Quoted(Scalar::new(b"")),
+                TextToken::MixedContainer,
                 TextToken::Unquoted(Scalar::new(b"paradoxplaza_store_url")),
                 TextToken::Quoted(Scalar::new(b"")),
                 TextToken::Unquoted(Scalar::new(b"category")),
+                TextToken::Operator(Operator::Equal),
                 TextToken::Quoted(Scalar::new(b"content_pack")),
                 TextToken::Unquoted(Scalar::new(b"show")),
+                TextToken::Operator(Operator::Equal),
                 TextToken::Unquoted(Scalar::new(b"no")),
                 TextToken::Unquoted(Scalar::new(b"recommendations")),
-                TextToken::Array(16),
-                TextToken::End(15),
+                TextToken::Operator(Operator::Equal),
+                TextToken::Array {
+                    end: 20,
+                    mixed: false
+                },
+                TextToken::End(19),
                 TextToken::End(1),
             ]
         );
@@ -1429,7 +1420,10 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"discovered_by")),
-                TextToken::Array(2),
+                TextToken::Array {
+                    end: 2,
+                    mixed: false
+                },
                 TextToken::End(1),
             ]
         );
@@ -1443,14 +1437,23 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"stats")),
-                TextToken::Array(14),
-                TextToken::Object(7),
+                TextToken::Array {
+                    end: 14,
+                    mixed: false
+                },
+                TextToken::Object {
+                    end: 7,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"id")),
                 TextToken::Unquoted(Scalar::new(b"0")),
                 TextToken::Unquoted(Scalar::new(b"type")),
                 TextToken::Unquoted(Scalar::new(b"general")),
                 TextToken::End(2),
-                TextToken::Object(13),
+                TextToken::Object {
+                    end: 13,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"id")),
                 TextToken::Unquoted(Scalar::new(b"1")),
                 TextToken::Unquoted(Scalar::new(b"type")),
@@ -1469,9 +1472,15 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"history")),
-                TextToken::Object(7),
+                TextToken::Object {
+                    end: 7,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"1629.11.10")),
-                TextToken::Object(6),
+                TextToken::Object {
+                    end: 6,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"core")),
                 TextToken::Unquoted(Scalar::new(b"AAA")),
                 TextToken::End(3),
@@ -1488,9 +1497,15 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"history")),
-                TextToken::Object(7),
+                TextToken::Object {
+                    end: 7,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"1629.11.10")),
-                TextToken::Object(6),
+                TextToken::Object {
+                    end: 6,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"core")),
                 TextToken::Unquoted(Scalar::new(b"AAA")),
                 TextToken::End(3),
@@ -1507,7 +1522,10 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"foo")),
-                TextToken::Object(4),
+                TextToken::Object {
+                    end: 4,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"bar")),
                 TextToken::Unquoted(Scalar::new(b"val")),
                 TextToken::End(1),
@@ -1525,7 +1543,10 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"foo")),
-                TextToken::Object(6),
+                TextToken::Object {
+                    end: 6,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"bar")),
                 TextToken::Unquoted(Scalar::new(b"val")),
                 TextToken::Unquoted(Scalar::new(b"a")),
@@ -1545,71 +1566,21 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"army")),
-                TextToken::Object(4),
+                TextToken::Object {
+                    end: 4,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"name")),
                 TextToken::Unquoted(Scalar::new(b"abc")),
                 TextToken::End(1),
                 TextToken::Unquoted(Scalar::new(b"army")),
-                TextToken::Object(9),
+                TextToken::Object {
+                    end: 9,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"name")),
                 TextToken::Unquoted(Scalar::new(b"def")),
                 TextToken::End(6),
-            ]
-        );
-    }
-
-    #[test]
-    fn test_object_array_trailer() {
-        let data = br#"brittany_area = { #5
-            color = { 118  99  151 }
-            169 170 171 172 4384
-        }"#;
-
-        assert_eq!(
-            parse(&data[..]).unwrap().token_tape,
-            vec![
-                TextToken::Unquoted(Scalar::new(b"brittany_area")),
-                TextToken::Object(15),
-                TextToken::Unquoted(Scalar::new(b"color")),
-                TextToken::Array(7),
-                TextToken::Unquoted(Scalar::new(b"118")),
-                TextToken::Unquoted(Scalar::new(b"99")),
-                TextToken::Unquoted(Scalar::new(b"151")),
-                TextToken::End(3),
-                TextToken::Array(14),
-                TextToken::Unquoted(Scalar::new(b"169")),
-                TextToken::Unquoted(Scalar::new(b"170")),
-                TextToken::Unquoted(Scalar::new(b"171")),
-                TextToken::Unquoted(Scalar::new(b"172")),
-                TextToken::Unquoted(Scalar::new(b"4384")),
-                TextToken::End(8),
-                TextToken::End(1),
-            ]
-        );
-    }
-
-    #[test]
-    fn test_object_array_trailer_single_element() {
-        let data = br#"brittany_area = { #5
-            color = { 118  99  151 }
-            169
-        }"#;
-
-        assert_eq!(
-            parse(&data[..]).unwrap().token_tape,
-            vec![
-                TextToken::Unquoted(Scalar::new(b"brittany_area")),
-                TextToken::Object(11),
-                TextToken::Unquoted(Scalar::new(b"color")),
-                TextToken::Array(7),
-                TextToken::Unquoted(Scalar::new(b"118")),
-                TextToken::Unquoted(Scalar::new(b"99")),
-                TextToken::Unquoted(Scalar::new(b"151")),
-                TextToken::End(3),
-                TextToken::Array(10),
-                TextToken::Unquoted(Scalar::new(b"169")),
-                TextToken::End(8),
-                TextToken::End(1),
             ]
         );
     }
@@ -1736,7 +1707,10 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"position")),
-                TextToken::Array(4),
+                TextToken::Array {
+                    end: 4,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"@[1-leopard_x]")),
                 TextToken::Unquoted(Scalar::new(b"@leopard_y")),
                 TextToken::End(1),
@@ -1851,7 +1825,10 @@ mod tests {
             vec![
                 TextToken::Unquoted(Scalar::new(b"color")),
                 TextToken::Header(Scalar::new(b"rgb")),
-                TextToken::Array(6),
+                TextToken::Array {
+                    end: 6,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"100")),
                 TextToken::Unquoted(Scalar::new(b"200")),
                 TextToken::Unquoted(Scalar::new(b"150")),
@@ -1910,7 +1887,10 @@ mod tests {
             vec![
                 TextToken::Unquoted(Scalar::new(b"color")),
                 TextToken::Header(Scalar::new(b"hsv")),
-                TextToken::Array(6),
+                TextToken::Array {
+                    end: 6,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"0.43")),
                 TextToken::Unquoted(Scalar::new(b"0.86")),
                 TextToken::Unquoted(Scalar::new(b"0.61")),
@@ -1928,7 +1908,10 @@ mod tests {
             vec![
                 TextToken::Unquoted(Scalar::new(b"color")),
                 TextToken::Header(Scalar::new(b"hsv360")),
-                TextToken::Array(6),
+                TextToken::Array {
+                    end: 6,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"25")),
                 TextToken::Unquoted(Scalar::new(b"75")),
                 TextToken::Unquoted(Scalar::new(b"63")),
@@ -1946,7 +1929,10 @@ mod tests {
             vec![
                 TextToken::Unquoted(Scalar::new(b"color")),
                 TextToken::Header(Scalar::new(b"cylindrical")),
-                TextToken::Array(6),
+                TextToken::Array {
+                    end: 6,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"150")),
                 TextToken::Unquoted(Scalar::new(b"3")),
                 TextToken::Unquoted(Scalar::new(b"0")),
@@ -1964,7 +1950,10 @@ mod tests {
             vec![
                 TextToken::Unquoted(Scalar::new(b"color")),
                 TextToken::Header(Scalar::new(b"hex")),
-                TextToken::Array(4),
+                TextToken::Array {
+                    end: 4,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"aabbccdd")),
                 TextToken::End(2),
             ]
@@ -1980,7 +1969,10 @@ mod tests {
             vec![
                 TextToken::Unquoted(Scalar::new(b"mild_winter")),
                 TextToken::Header(Scalar::new(b"LIST")),
-                TextToken::Array(5),
+                TextToken::Array {
+                    end: 5,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"3700")),
                 TextToken::Unquoted(Scalar::new(b"3701")),
                 TextToken::End(2),
@@ -1988,70 +1980,27 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_heterogenous_list() {
-        let data = b"levels={ 10 0=2 1=2 } foo={bar=qux}";
-        assert_eq!(
-            parse(&data[..]).unwrap().token_tape,
-            vec![
-                TextToken::Unquoted(Scalar::new(b"levels")),
-                TextToken::Array(9),
-                TextToken::Unquoted(Scalar::new(b"10")),
-                TextToken::HiddenObject(8),
-                TextToken::Unquoted(Scalar::new(b"0")),
-                TextToken::Unquoted(Scalar::new(b"2")),
-                TextToken::Unquoted(Scalar::new(b"1")),
-                TextToken::Unquoted(Scalar::new(b"2")),
-                TextToken::End(3),
-                TextToken::End(1),
-                TextToken::Unquoted(Scalar::new(b"foo")),
-                TextToken::Object(14),
-                TextToken::Unquoted(Scalar::new(b"bar")),
-                TextToken::Unquoted(Scalar::new(b"qux")),
-                TextToken::End(11),
-            ]
-        );
-    }
+    // #[test]
+    // fn test_hidden_object_needs_key() {
+    //     let data = b"a{{}=}";
+    //     assert!(parse(&data[..]).is_err());
+    // }
+
+    // #[test]
+    // fn test_objects_in_hidden_objects_not_supported() {
+    //     let data = b"u{1 a={0=1}";
+    //     assert!(parse(&data[..]).is_err());
+    // }
+
+    // #[test]
+    // fn test_hidden_objects_with_headers_not_supported() {
+    //     let data = b"s{{c d=a{b=}}";
+    //     assert!(TextTape::from_slice(&data[..]).is_err());
+    // }
 
     #[test]
-    fn test_hidden_object() {
-        let data = b"16778374={ levels={ 10 0=2 1=2 } }";
-
-        assert_eq!(
-            parse(&data[..]).unwrap().token_tape,
-            vec![
-                TextToken::Unquoted(Scalar::new(b"16778374")),
-                TextToken::Object(12),
-                TextToken::Unquoted(Scalar::new(b"levels")),
-                TextToken::Array(11),
-                TextToken::Unquoted(Scalar::new(b"10")),
-                TextToken::HiddenObject(10),
-                TextToken::Unquoted(Scalar::new(b"0")),
-                TextToken::Unquoted(Scalar::new(b"2")),
-                TextToken::Unquoted(Scalar::new(b"1")),
-                TextToken::Unquoted(Scalar::new(b"2")),
-                TextToken::End(5),
-                TextToken::End(3),
-                TextToken::End(1),
-            ]
-        );
-    }
-
-    #[test]
-    fn test_hidden_object_needs_key() {
-        let data = b"a{{}=}";
-        assert!(parse(&data[..]).is_err());
-    }
-
-    #[test]
-    fn test_objects_in_hidden_objects_not_supported() {
-        let data = b"u{1 a={0=1}";
-        assert!(parse(&data[..]).is_err());
-    }
-
-    #[test]
-    fn test_hidden_objects_with_headers_not_supported() {
-        let data = b"s{{c d=a{b=}}";
+    fn test_operator_early_eof() {
+        let data = b"a{b=}";
         assert!(TextTape::from_slice(&data[..]).is_err());
     }
 
@@ -2140,7 +2089,10 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"value")),
-                TextToken::Object(7),
+                TextToken::Object {
+                    end: 7,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"date")),
                 TextToken::Operator(Operator::LessThan),
                 TextToken::Unquoted(Scalar::new(b"1941.7.7")),
@@ -2159,7 +2111,10 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"foo")),
-                TextToken::Array(3),
+                TextToken::Array {
+                    end: 3,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"bar")),
                 TextToken::End(1),
             ]
@@ -2168,12 +2123,15 @@ mod tests {
 
     #[test]
     fn test_extraneous_closing_bracket2() {
-        let data = b"a{} b r}";
+        let data = b"a{} b=r}";
         assert_eq!(
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"a")),
-                TextToken::Array(2),
+                TextToken::Array {
+                    end: 2,
+                    mixed: false
+                },
                 TextToken::End(1),
                 TextToken::Unquoted(Scalar::new(b"b")),
                 TextToken::Unquoted(Scalar::new(b"r")),
@@ -2183,7 +2141,7 @@ mod tests {
 
     #[test]
     fn test_extraneous_closing_bracket3() {
-        let data = b"a c}}";
+        let data = b"a=c}}";
         assert_eq!(
             parse(&data[..]).unwrap().token_tape,
             vec![
@@ -2202,13 +2160,19 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"color")),
-                TextToken::Array(5),
+                TextToken::Array {
+                    end: 5,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"121")),
                 TextToken::Unquoted(Scalar::new(b"163")),
                 TextToken::Unquoted(Scalar::new(b"114")),
                 TextToken::End(1),
                 TextToken::Unquoted(Scalar::new(b"army_names")),
-                TextToken::Array(9),
+                TextToken::Array {
+                    end: 9,
+                    mixed: false
+                },
                 TextToken::Quoted(Scalar::new(b"Armata di $PROVINCE$")),
                 TextToken::End(7),
             ]
@@ -2222,11 +2186,20 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"BRA_GAR_01")),
-                TextToken::Object(9),
+                TextToken::Object {
+                    end: 9,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"ordered")),
-                TextToken::Object(8),
+                TextToken::Object {
+                    end: 8,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"1")),
-                TextToken::Array(7),
+                TextToken::Array {
+                    end: 7,
+                    mixed: false
+                },
                 TextToken::Quoted(Scalar::new(b"%da Divisao de Infantaria")),
                 TextToken::End(5),
                 TextToken::End(3),
@@ -2250,34 +2223,16 @@ mod tests {
     }
 
     #[test]
-    fn test_trailer_in_object_array() {
-        let data = b"a {{b=c d c}}";
-        assert_eq!(
-            parse(&data[..]).unwrap().token_tape,
-            vec![
-                TextToken::Unquoted(Scalar::new(b"a")),
-                TextToken::Array(10),
-                TextToken::Object(9),
-                TextToken::Unquoted(Scalar::new(b"b")),
-                TextToken::Unquoted(Scalar::new(b"c")),
-                TextToken::Array(8),
-                TextToken::Unquoted(Scalar::new(b"d")),
-                TextToken::Unquoted(Scalar::new(b"c")),
-                TextToken::End(5),
-                TextToken::End(2),
-                TextToken::End(1)
-            ]
-        );
-    }
-
-    #[test]
     fn test_parameter_value() {
         let data = b"generate_advisor = { [[effect] $effect$ ] }";
         assert_eq!(
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"generate_advisor")),
-                TextToken::Object(4),
+                TextToken::Object {
+                    end: 4,
+                    mixed: false
+                },
                 TextToken::Parameter(Scalar::new(b"effect")),
                 TextToken::Unquoted(Scalar::new(b"$effect$")),
                 TextToken::End(1),
@@ -2292,9 +2247,15 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"generate_advisor")),
-                TextToken::Object(7),
+                TextToken::Object {
+                    end: 7,
+                    mixed: false
+                },
                 TextToken::Parameter(Scalar::new(b"scaled_skill")),
-                TextToken::Object(6),
+                TextToken::Object {
+                    end: 6,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"a")),
                 TextToken::Unquoted(Scalar::new(b"b")),
                 TextToken::End(3),
@@ -2310,11 +2271,20 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"generate_advisor")),
-                TextToken::Object(10),
+                TextToken::Object {
+                    end: 10,
+                    mixed: false
+                },
                 TextToken::Parameter(Scalar::new(b"add")),
-                TextToken::Object(9),
+                TextToken::Object {
+                    end: 9,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"if")),
-                TextToken::Object(8),
+                TextToken::Object {
+                    end: 8,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"a")),
                 TextToken::Unquoted(Scalar::new(b"b")),
                 TextToken::End(5),
@@ -2331,19 +2301,34 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"generate_advisor")),
-                TextToken::Object(18),
+                TextToken::Object {
+                    end: 18,
+                    mixed: false
+                },
                 TextToken::Parameter(Scalar::new(b"add")),
-                TextToken::Object(9),
+                TextToken::Object {
+                    end: 9,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"if")),
-                TextToken::Object(8),
+                TextToken::Object {
+                    end: 8,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"a")),
                 TextToken::Unquoted(Scalar::new(b"b")),
                 TextToken::End(5),
                 TextToken::End(3),
                 TextToken::Parameter(Scalar::new(b"remove")),
-                TextToken::Object(17),
+                TextToken::Object {
+                    end: 17,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"if")),
-                TextToken::Object(16),
+                TextToken::Object {
+                    end: 16,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"c")),
                 TextToken::Unquoted(Scalar::new(b"d")),
                 TextToken::End(13),
@@ -2360,9 +2345,15 @@ mod tests {
             parse(&data[..]).unwrap().token_tape,
             vec![
                 TextToken::Unquoted(Scalar::new(b"generate_advisor")),
-                TextToken::Object(7),
+                TextToken::Object {
+                    end: 7,
+                    mixed: false
+                },
                 TextToken::UndefinedParameter(Scalar::new(b"scaled_skill")),
-                TextToken::Object(6),
+                TextToken::Object {
+                    end: 6,
+                    mixed: false
+                },
                 TextToken::Unquoted(Scalar::new(b"a")),
                 TextToken::Unquoted(Scalar::new(b"b")),
                 TextToken::End(3),
@@ -2398,45 +2389,333 @@ mod tests {
     }
 
     #[test]
+    fn test_mixed_container_1() {
+        let data = b"levels={a=b 10}";
+        assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Unquoted(Scalar::new(b"levels")),
+                TextToken::Object {
+                    end: 6,
+                    mixed: true
+                },
+                TextToken::Unquoted(Scalar::new(b"a")),
+                TextToken::Unquoted(Scalar::new(b"b")),
+                TextToken::MixedContainer,
+                TextToken::Unquoted(Scalar::new(b"10")),
+                TextToken::End(1),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_mixed_container_2() {
+        let data = b"levels={a=b 10 20}";
+        assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Unquoted(Scalar::new(b"levels")),
+                TextToken::Object {
+                    end: 7,
+                    mixed: true
+                },
+                TextToken::Unquoted(Scalar::new(b"a")),
+                TextToken::Unquoted(Scalar::new(b"b")),
+                TextToken::MixedContainer,
+                TextToken::Unquoted(Scalar::new(b"10")),
+                TextToken::Unquoted(Scalar::new(b"20")),
+                TextToken::End(1),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_mixed_container_3() {
+        let data = b"levels={a=b 10 c=d}";
+        assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Unquoted(Scalar::new(b"levels")),
+                TextToken::Object {
+                    end: 9,
+                    mixed: true
+                },
+                TextToken::Unquoted(Scalar::new(b"a")),
+                TextToken::Unquoted(Scalar::new(b"b")),
+                TextToken::MixedContainer,
+                TextToken::Unquoted(Scalar::new(b"10")),
+                TextToken::Unquoted(Scalar::new(b"c")),
+                TextToken::Operator(Operator::Equal),
+                TextToken::Unquoted(Scalar::new(b"d")),
+                TextToken::End(1),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_mixed_container_4() {
+        let data = b"levels={a=b 10 c=d 20}";
+        assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Unquoted(Scalar::new(b"levels")),
+                TextToken::Object {
+                    end: 10,
+                    mixed: true
+                },
+                TextToken::Unquoted(Scalar::new(b"a")),
+                TextToken::Unquoted(Scalar::new(b"b")),
+                TextToken::MixedContainer,
+                TextToken::Unquoted(Scalar::new(b"10")),
+                TextToken::Unquoted(Scalar::new(b"c")),
+                TextToken::Operator(Operator::Equal),
+                TextToken::Unquoted(Scalar::new(b"d")),
+                TextToken::Unquoted(Scalar::new(b"20")),
+                TextToken::End(1),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_mixed_container_5() {
+        let data = b"16778374={ levels={ 10 0=2 1=2 } }";
+
+        assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Unquoted(Scalar::new(b"16778374")),
+                TextToken::Object {
+                    end: 13,
+                    mixed: false
+                },
+                TextToken::Unquoted(Scalar::new(b"levels")),
+                TextToken::Array {
+                    end: 12,
+                    mixed: true
+                },
+                TextToken::Unquoted(Scalar::new(b"10")),
+                TextToken::MixedContainer,
+                TextToken::Unquoted(Scalar::new(b"0")),
+                TextToken::Operator(Operator::Equal),
+                TextToken::Unquoted(Scalar::new(b"2")),
+                TextToken::Unquoted(Scalar::new(b"1")),
+                TextToken::Operator(Operator::Equal),
+                TextToken::Unquoted(Scalar::new(b"2")),
+                TextToken::End(3),
+                TextToken::End(1),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_mixed_container_6() {
+        let data = b"levels={ 10 0=2 1=2 } foo={bar=qux}";
+        assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Unquoted(Scalar::new(b"levels")),
+                TextToken::Array {
+                    end: 10,
+                    mixed: true
+                },
+                TextToken::Unquoted(Scalar::new(b"10")),
+                TextToken::MixedContainer,
+                TextToken::Unquoted(Scalar::new(b"0")),
+                TextToken::Operator(Operator::Equal),
+                TextToken::Unquoted(Scalar::new(b"2")),
+                TextToken::Unquoted(Scalar::new(b"1")),
+                TextToken::Operator(Operator::Equal),
+                TextToken::Unquoted(Scalar::new(b"2")),
+                TextToken::End(1),
+                TextToken::Unquoted(Scalar::new(b"foo")),
+                TextToken::Object {
+                    end: 15,
+                    mixed: false
+                },
+                TextToken::Unquoted(Scalar::new(b"bar")),
+                TextToken::Unquoted(Scalar::new(b"qux")),
+                TextToken::End(12),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_mixed_container_7() {
+        let data = br#"brittany_area = { #5
+            color = { 118  99  151 }
+            169 170 171 172 4384
+        }"#;
+
+        assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Unquoted(Scalar::new(b"brittany_area")),
+                TextToken::Object {
+                    end: 14,
+                    mixed: true
+                },
+                TextToken::Unquoted(Scalar::new(b"color")),
+                TextToken::Array {
+                    end: 7,
+                    mixed: false
+                },
+                TextToken::Unquoted(Scalar::new(b"118")),
+                TextToken::Unquoted(Scalar::new(b"99")),
+                TextToken::Unquoted(Scalar::new(b"151")),
+                TextToken::End(3),
+                TextToken::MixedContainer,
+                TextToken::Unquoted(Scalar::new(b"169")),
+                TextToken::Unquoted(Scalar::new(b"170")),
+                TextToken::Unquoted(Scalar::new(b"171")),
+                TextToken::Unquoted(Scalar::new(b"172")),
+                TextToken::Unquoted(Scalar::new(b"4384")),
+                TextToken::End(1),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_mixed_container_8() {
+        let data = br#"brittany_area = { #5
+            color = { 118  99  151 }
+            169
+        }"#;
+
+        assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Unquoted(Scalar::new(b"brittany_area")),
+                TextToken::Object {
+                    end: 10,
+                    mixed: true
+                },
+                TextToken::Unquoted(Scalar::new(b"color")),
+                TextToken::Array {
+                    end: 7,
+                    mixed: false
+                },
+                TextToken::Unquoted(Scalar::new(b"118")),
+                TextToken::Unquoted(Scalar::new(b"99")),
+                TextToken::Unquoted(Scalar::new(b"151")),
+                TextToken::End(3),
+                TextToken::MixedContainer,
+                TextToken::Unquoted(Scalar::new(b"169")),
+                TextToken::End(1),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_mixed_container_9() {
+        let data = b"a {{b=c d c}}";
+        assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Unquoted(Scalar::new(b"a")),
+                TextToken::Array {
+                    end: 9,
+                    mixed: false
+                },
+                TextToken::Object {
+                    end: 8,
+                    mixed: true
+                },
+                TextToken::Unquoted(Scalar::new(b"b")),
+                TextToken::Unquoted(Scalar::new(b"c")),
+                TextToken::MixedContainer,
+                TextToken::Unquoted(Scalar::new(b"d")),
+                TextToken::Unquoted(Scalar::new(b"c")),
+                TextToken::End(2),
+                TextToken::End(1)
+            ]
+        );
+    }
+
+    #[test]
+    fn test_mixed_container_10() {
+        let data = br"on_actions = {
+            faith_holy_order_land_acquisition_pulse
+            delay = { days = { 5 10 }}
+            faith_heresy_events_pulse
+            delay = { days = { 15 20 }}
+            faith_fervor_events_pulse
+          }";
+        assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Unquoted(Scalar::new(b"on_actions")),
+                TextToken::Array {
+                    end: 24,
+                    mixed: true
+                },
+                TextToken::Unquoted(Scalar::new(b"faith_holy_order_land_acquisition_pulse")),
+                TextToken::MixedContainer,
+                TextToken::Unquoted(Scalar::new(b"delay")),
+                TextToken::Operator(Operator::Equal),
+                TextToken::Object {
+                    end: 12,
+                    mixed: false
+                },
+                TextToken::Unquoted(Scalar::new(b"days")),
+                TextToken::Array {
+                    end: 11,
+                    mixed: false
+                },
+                TextToken::Unquoted(Scalar::new(b"5")),
+                TextToken::Unquoted(Scalar::new(b"10")),
+                TextToken::End(8),
+                TextToken::End(6),
+                TextToken::Unquoted(Scalar::new(b"faith_heresy_events_pulse")),
+                TextToken::Unquoted(Scalar::new(b"delay")),
+                TextToken::Operator(Operator::Equal),
+                TextToken::Object {
+                    end: 22,
+                    mixed: false
+                },
+                TextToken::Unquoted(Scalar::new(b"days")),
+                TextToken::Array {
+                    end: 21,
+                    mixed: false
+                },
+                TextToken::Unquoted(Scalar::new(b"15")),
+                TextToken::Unquoted(Scalar::new(b"20")),
+                TextToken::End(18),
+                TextToken::End(16),
+                TextToken::Unquoted(Scalar::new(b"faith_fervor_events_pulse")),
+                TextToken::End(1)
+            ]
+        );
+    }
+
+    #[test]
+    fn test_dont_fail_on_list_keyword() {
+        let data = br"  simple_cross_flag = {
+            pattern = list christian_emblems_list
+            color1 = list normal_colors
+          }";
+
+          assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Unquoted(Scalar::new(b"simple_cross_flag")),
+                TextToken::Object { end: 10, mixed: true },
+                TextToken::Unquoted(Scalar::new(b"pattern")),
+                TextToken::Unquoted(Scalar::new(b"list")),
+                TextToken::MixedContainer,
+                TextToken::Unquoted(Scalar::new(b"christian_emblems_list")),
+                TextToken::Unquoted(Scalar::new(b"color1")),
+                TextToken::Operator(Operator::Equal),
+                TextToken::Unquoted(Scalar::new(b"list")),
+                TextToken::Unquoted(Scalar::new(b"normal_colors")),
+                TextToken::End(1)
+            ]
+          );
+    }
+
+    #[test]
     fn test_parameter_eof() {
         let data = b"[[";
         TextTape::from_slice(data).unwrap_err();
-    }
-
-    #[test]
-    fn test_deny_parameter_in_hidden_object() {
-        let data = b"s{a b=c[[a]}";
-        TextTape::from_slice(data).unwrap_err();
-    }
-
-    #[test]
-    fn deny_complex_trailer() {
-        let data = b"a{b=c a d {t}}";
-        TextTape::from_slice(data).unwrap_err();
-    }
-
-    #[test]
-    fn deny_complex_trailer2() {
-        let data = b"s{{b=c<:d=}=}}";
-        TextTape::from_slice(data).unwrap_err();
-    }
-
-    #[test]
-    fn deny_complex_trailer3() {
-        let data = b"a{c=d b>}";
-        TextTape::from_slice(data).unwrap_err();
-    }
-
-    #[test]
-    fn deny_trailer_inside_hidden_object() {
-        let data = b"k{a=a { ta { b } a=z=aP } } } a }";
-        let err = TextTape::from_slice(data).unwrap_err();
-        match err.kind() {
-            ErrorKind::InvalidSyntax { offset, .. } => {
-                assert_eq!(*offset, 21);
-            }
-            _ => assert!(false),
-        }
     }
 
     #[test]

--- a/tests/tape.rs
+++ b/tests/tape.rs
@@ -1,16 +1,4 @@
-use jomini::{text::Operator, BinaryTape, Scalar, TextTape, TextToken};
-
-#[test]
-fn reject_bin_obj_in_hidden_obj() {
-    let data = include_bytes!("./fixtures/nested-hidden-obj.bin");
-    assert!(BinaryTape::from_slice(&data[..]).is_err());
-}
-
-#[test]
-fn reject_txt_obj_in_hidden_obj() {
-    let data = include_bytes!("./fixtures/nested-hidden-obj.txt");
-    assert!(TextTape::from_slice(&data[..]).is_err());
-}
+use jomini::{text::Operator, Scalar, TextTape, TextToken};
 
 #[test]
 fn test_greater_than_operator() {


### PR DESCRIPTION
There's plenty of examples where a container block is both an array and an object:

```plain
levels={ 10 0=2 1=2 }
```

```plain
brittany_area = { #5
    color = { 118  99  151 }
    169 170 171 172 4384
}
```

The two example aboves have been supported through separate, informal notions: hidden objects and object trailers respectively. They could only handle a single switch between array and object syntax.

But these notions break down when key value pairs are interspered with array values:

```plain
on_actions = {
  faith_holy_order_land_acquisition_pulse
  delay = { days = { 5 10 }}
  faith_heresy_events_pulse
  delay = { days = { 15 20 }}
  faith_fervor_events_pulse
}
```

This commit fixes the issue by unifying hidden objects and array trailers behind what I'm calling "mixed mode".

First, the happy path, where the container block doesn't switch type, don't have their representations changed, so their performance and memory usage are preserved.

What's changing is that the `HiddenObject` text token is being replaced with `MixedContainer` token. When a `MixedContainer` token is encountered, the remaining tokens in the container will essentially be a raw token stream.

For instance:

```plain
levels={ 10 0=2 1=2 }
```

Has the token stream of:

```
scalar: levels
array
scalar: 10
mixed
scalar: 0
operator: =
scalar: 2
scalar: 1
operator: =
scalar: 2
end
```

And

```plain
brittany_area = { #5
    color = { 118  99  151 }
    169 170 171 172 4384
}
```

becomes:

```
scalar: brittany_area
object
scalar: color
array
scalar: 118
scalar: 99
scalar: 151
end
mixed
scalar: 169
scalar: 170
scalar: 171
scalar: 172
scalar: 4384
end
```

In a nutshell here is how everything is changing:

- A new text operator has been added: `Operator::Equal` to represent key value pairs within an array
- `TextToken::HiddenObject` has been removed
- `TextToken::MixedContainer` has been added
- `TextToken::Array` and `Object` now contain a `mixed` field to denote if they contain a `TextToken::MixedContainer` token
- `TextReaders::trailer` renamed to `remainder`
- `BinaryToken::HiddenObject` replaced with `BinaryToken::MixedContainer` and `BinaryToken::Equal`

Closes #103
Closes #96