### PR TITLE
Introduce deserialization Property to capture operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,16 @@ Converters](https://github.com/ParadoxGameConverters) and
 Below is a demonstration on parsing plaintext data using jomini tools.
 
 ```rust
-use jomini::{JominiDeserialize, TextDeserializer};
+use jomini::{
+    text::{Operator, Property},
+    JominiDeserialize, TextDeserializer,
+};
 
 #[derive(JominiDeserialize, PartialEq, Debug)]
 pub struct Model {
     human: bool,
     first: Option<u16>,
+    third: Property<u16>,
     #[jomini(alias = "forth")]
     fourth: u16,
     #[jomini(alias = "core", duplicated)]
@@ -42,6 +46,7 @@ pub struct Model {
 
 let data = br#"
     human = yes
+    third < 5
     forth = 10
     core = "HAB"
     names = { "Johan" "Frederick" }
@@ -51,6 +56,7 @@ let data = br#"
 let expected = Model {
     human: true,
     first: None,
+    third: Property::new(Operator::LessThan, 5),
     fourth: 10,
     cores: vec!["HAB".to_string(), "FRA".to_string()],
     names: vec!["Johan".to_string(), "Frederick".to_string()],

--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -136,11 +136,11 @@ where
             encoding: &self.flavor,
         };
 
-        let mut deserializer = RootDeserializer {
+        let deserializer = RootDeserializer {
             tokens: tape.tokens(),
             config: &config,
         };
-        Ok(T::deserialize(&mut deserializer)?)
+        Ok(T::deserialize(deserializer)?)
     }
 }
 
@@ -155,8 +155,8 @@ struct RootDeserializer<'b, 'a: 'b, 'res: 'a, RES, E> {
     config: &'b BinaryConfig<'res, RES, E>,
 }
 
-impl<'b, 'de, 'r, 'res, RES: TokenResolver, E: BinaryFlavor> de::Deserializer<'de>
-    for &'r mut RootDeserializer<'b, 'de, 'res, RES, E>
+impl<'b, 'de, 'res, RES: TokenResolver, E: BinaryFlavor> de::Deserializer<'de>
+    for RootDeserializer<'b, 'de, 'res, RES, E>
 {
     type Error = DeserializeError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,12 +26,16 @@ Below is a demonstration on parsing plaintext data using jomini tools.
 
 ```rust
 # #[cfg(feature = "derive")] {
-use jomini::{JominiDeserialize, TextDeserializer};
+use jomini::{
+    text::{Operator, Property},
+    JominiDeserialize, TextDeserializer,
+};
 
 #[derive(JominiDeserialize, PartialEq, Debug)]
 pub struct Model {
     human: bool,
     first: Option<u16>,
+    third: Property<u16>,
     #[jomini(alias = "forth")]
     fourth: u16,
     #[jomini(alias = "core", duplicated)]
@@ -41,6 +45,7 @@ pub struct Model {
 
 let data = br#"
     human = yes
+    third < 5
     forth = 10
     core = "HAB"
     names = { "Johan" "Frederick" }
@@ -50,6 +55,7 @@ let data = br#"
 let expected = Model {
     human: true,
     first: None,
+    third: Property::new(Operator::LessThan, 5),
     fourth: 10,
     cores: vec!["HAB".to_string(), "FRA".to_string()],
     names: vec!["Johan".to_string(), "Frederick".to_string()],

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -16,7 +16,7 @@ mod tape;
 mod writer;
 
 #[cfg(feature = "derive")]
-pub use self::de::TextDeserializer;
+pub use self::de::{Property, TextDeserializer};
 pub use self::operator::*;
 pub use self::reader::{
     ArrayReader, FieldGroupsIter, FieldsIter, GroupEntry, GroupEntryIter, ObjectReader, Reader,

--- a/src/text/operator.rs
+++ b/src/text/operator.rs
@@ -83,3 +83,38 @@ impl Operator {
         }
     }
 }
+
+#[cfg(feature = "derive")]
+impl<'de> serde::Deserialize<'de> for Operator {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct OperatorVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for OperatorVisitor {
+            type Value = Operator;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("an operator")
+            }
+
+            fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                match v {
+                    "<" => Ok(Operator::LessThan),
+                    "<=" => Ok(Operator::LessThanEqual),
+                    ">" => Ok(Operator::GreaterThan),
+                    ">=" => Ok(Operator::GreaterThanEqual),
+                    "==" => Ok(Operator::Exact),
+                    "=" => Ok(Operator::Equal),
+                    "!=" => Ok(Operator::NotEqual),
+                    _ => Err(E::custom("did not receive a known operator")),
+                }
+            }
+        }
+        deserializer.deserialize_str(OperatorVisitor)
+    }
+}


### PR DESCRIPTION
As pointed out in an [issue][0], operators are currently ignored in deserialization.

This commit fixes the problem by introducing a specially marked type called `Property` that will preserve an operator if present.

Here's an example:

```rust
use jomini::{
    text::{Operator, Property},
    JominiDeserialize, TextDeserializer,
};
use serde::Deserialize;

let data = b"modifier = { abc=yes factor=2 num > 2 }";
let actual: MyStruct = TextDeserializer::from_windows1252_slice(&data[..])?;
assert_eq!(
    actual,
    MyStruct {
        modifier: Modifier {
            abc: true,
            factor: Property::new(Operator::Equal, 2),
            num: Property::new(Operator::GreaterThan, 2)
        }
    }
);

struct Modifier {
    abc: bool,
    factor: Property<u8>,
    num: Property<u8>,
}

struct MyStruct {
    modifier: Modifier,
}
```

I'm not overly thrilled with having special deserialization types. But this solution seemed the most elegant and ergonomic.

[0]: https://github.com/rakaly/jomini/issues/105#issuecomment-1293401398

Closes #105 