### PR TITLE
More binary parsing optimizations

### DIFF
--- a/benches/jomini_bench.rs
+++ b/benches/jomini_bench.rs
@@ -160,6 +160,17 @@ pub fn binary_parse_benchmark(c: &mut Criterion) {
                     .unwrap();
             })
         });
+
+        if *game == "eu4" {
+            group.bench_function(BenchmarkId::new("binary", "eu4-2"), |b| {
+                let mut tape = BinaryTape::default();
+                b.iter(|| {
+                    BinaryTapeParser
+                        .parse_eu4_slice_into_tape(data.as_slice(), &mut tape)
+                        .unwrap();
+                })
+            });
+        }
     }
 
     group.finish();

--- a/src/binary/tape.rs
+++ b/src/binary/tape.rs
@@ -57,16 +57,17 @@ pub enum BinaryToken<'a> {
     Rgb(Rgb),
 }
 
-const END: u16 = 0x0004;
-const OPEN: u16 = 0x0003;
 const EQUAL: u16 = 0x0001;
-const U32: u16 = 0x0014;
-const U64: u16 = 0x029c;
+const OPEN: u16 = 0x0003;
+const END: u16 = 0x0004;
 const I32: u16 = 0x000c;
+const F32: u16 = 0x000d;
 const BOOL: u16 = 0x000e;
 const QUOTED_STRING: u16 = 0x000f;
+const U32: u16 = 0x0014;
 const UNQUOTED_STRING: u16 = 0x0017;
-const F32: u16 = 0x000d;
+
+const U64: u16 = 0x029c;
 const F64: u16 = 0x0167;
 const RGB: u16 = 0x0243;
 
@@ -75,15 +76,8 @@ const RGB: u16 = 0x0243;
 pub struct BinaryTapeParser;
 
 impl BinaryTapeParser {
-    /// Parse the binary format return the data tape
-    pub fn parse_slice(self, data: &[u8]) -> Result<BinaryTape, Error> {
-        let mut res = BinaryTape::default();
-        self.parse_slice_into_tape(data, &mut res)?;
-        Ok(res)
-    }
-
     /// Parse the binary format into the given tape.
-    pub fn parse_slice_into_tape<'a>(
+    fn parse_slice_into_tape_full<'a, const IS_EU4: bool>(
         self,
         data: &'a [u8],
         tape: &mut BinaryTape<'a>,
@@ -98,8 +92,36 @@ impl BinaryTapeParser {
             token_tape,
         };
 
-        state.parse()?;
+        state.parse::<IS_EU4>()?;
         Ok(())
+    }
+
+    /// Parse the binary format return the data tape
+    pub fn parse_slice(self, data: &[u8]) -> Result<BinaryTape, Error> {
+        let mut res = BinaryTape::default();
+        self.parse_slice_into_tape(data, &mut res)?;
+        Ok(res)
+    }
+
+    /// Parse the binary format into the given tape.
+    pub fn parse_slice_into_tape<'a>(
+        self,
+        data: &'a [u8],
+        tape: &mut BinaryTape<'a>,
+    ) -> Result<(), Error> {
+        self.parse_slice_into_tape_full::<false>(data, tape)
+    }
+
+    /// Parse the binary format into the given tape.
+    ///
+    /// The data is assumed to have resemble the more simple EU4 binary format,
+    /// which may allow for optimizations.
+    pub fn parse_eu4_slice_into_tape<'a>(
+        self,
+        data: &'a [u8],
+        tape: &mut BinaryTape<'a>,
+    ) -> Result<(), Error> {
+        self.parse_slice_into_tape_full::<true>(data, tape)
     }
 }
 
@@ -118,21 +140,29 @@ enum ParseState {
     // Whether the current parent container is both an object and array.
     // Unlike the text format, we only support one level of a mixed
     // container for performance.
-    ArrayValueMixed = 2,
+    ArrayValueMixed = 1,
 
-    ObjectValue = 4,
-    Key = 8,
-    KeyValueSeparator = 16,
-
-    // Need to convert current object into an array
-    ObjectToArray = 32,
-
-    // Start of a container, TBD if array or object
-    OpenFirst = 64,
-
-    // First scalar read after container start, still TBD if array or object
-    OpenSecond = 128,
+    ObjectValue = 2,
+    Key = 3,
+    KeyValueSeparator = 4,
 }
+
+const _: () = assert!(
+    ParserState::next_state(ParseState::ArrayValue) == ParseState::ArrayValue as u8,
+    "State transition incorrect"
+);
+const _: () = assert!(
+    ParserState::next_state(ParseState::ArrayValueMixed) == ParseState::ArrayValueMixed as u8,
+    "State transition incorrect"
+);
+const _: () = assert!(
+    ParserState::next_state(ParseState::ObjectValue) == ParseState::Key as u8,
+    "State transition incorrect"
+);
+const _: () = assert!(
+    ParserState::next_state(ParseState::Key) == ParseState::KeyValueSeparator as u8,
+    "State transition incorrect"
+);
 
 impl<'a, 'b> ParserState<'a, 'b> {
     fn offset(&self, data: &[u8]) -> usize {
@@ -228,11 +258,20 @@ impl<'a, 'b> ParserState<'a, 'b> {
     }
 
     #[inline(always)]
-    fn next_state(state: ParseState) -> ParseState {
+    const fn next_state(state: ParseState) -> u8 {
         let num = state as u8;
-        let offset = num & 2;
-        let next = num.wrapping_mul(2) - offset;
-        unsafe { core::mem::transmute(next) }
+        let offset1 = num >> 1;
+        num + offset1
+    }
+
+    #[inline(always)]
+    fn next_scalar_state(&mut self, state: ParseState) -> ParseState {
+        if state == ParseState::KeyValueSeparator {
+            self.mixed_insert2()
+        } else {
+            let new_state = Self::next_state(state);
+            unsafe { core::mem::transmute(new_state) }
+        }
     }
 
     #[inline]
@@ -246,7 +285,7 @@ impl<'a, 'b> ParserState<'a, 'b> {
         }
     }
 
-    fn parse(&mut self) -> Result<(), Error> {
+    fn parse<const IS_EU4: bool>(&mut self) -> Result<(), Error> {
         let mut data = self.data;
         let mut state = ParseState::Key;
 
@@ -254,56 +293,119 @@ impl<'a, 'b> ParserState<'a, 'b> {
         let mut parent_ind = 0;
 
         while let Some((d, token_id)) = self.parse_next_id_opt(data) {
-            if state == ParseState::ObjectToArray {
-                // This branch should never be taken on any save. It represents
-                // `area = {a=b 10 20}`, which only happens in the text format.
-                // Instead of trapping it and erroring, we just switch to mixed
-                // mode like we do for the text format.
-                state = ParseState::ArrayValueMixed;
-                self.mixed_insert2();
-            }
-
+            // a switch statement that is dense up until 0x17. 5-6% perf
             match token_id {
-                U32 => {
-                    data = self.parse_u32(d)?;
-                    state = Self::next_state(state);
-                }
-                U64 => {
-                    data = self.parse_u64(d)?;
-                    state = Self::next_state(state);
-                }
-                I32 => {
-                    data = self.parse_i32(d)?;
-                    state = Self::next_state(state);
-                }
-                BOOL => {
-                    data = self.parse_bool(d)?;
-                    state = Self::next_state(state);
-                }
-                QUOTED_STRING => {
-                    data = self.parse_quoted_string(d)?;
-                    state = Self::next_state(state);
-                }
-                UNQUOTED_STRING => {
-                    data = self.parse_unquoted_string(d)?;
-                    state = Self::next_state(state);
-                }
-                F32 => {
-                    data = self.parse_f32(d)?;
-                    state = Self::next_state(state);
-                }
-                F64 => {
-                    data = self.parse_f64(d)?;
-                    state = Self::next_state(state);
-                }
+                0x0 => return Err(self.unknown_token(data)),
+                EQUAL => {
+                    data = d;
+                    if state == ParseState::KeyValueSeparator {
+                        state = ParseState::ObjectValue;
+                        continue; // hack to prevent jump table. 10-14% perf
+                    } else if state == ParseState::ArrayValueMixed {
+                        self.token_tape.alloc().init(BinaryToken::Equal);
+                    } else if state == ParseState::ArrayValue {
+                        self.token_tape.reserve(2);
+                        let last = unsafe { self.token_tape.pop().unwrap_unchecked() };
+                        if matches!(last, BinaryToken::Array(_) | BinaryToken::End(_)) {
+                            return Err(self.equal_in_array_err(data));
+                        }
 
+                        // before we enter mixed mode, let's make sure we're not
+                        // proceeded by only empty objects eg: `a={{} {} c=d}`. Only
+                        // found in a smattering of EU4 saves
+                        let mut pairs = self
+                            .token_tape
+                            .get(parent_ind + 1..)
+                            .unwrap_or_default()
+                            .chunks_exact(2);
+
+                        let only_empties = pairs.len() > 0
+                                && pairs.all(|tokens| {
+                                    matches!(tokens, [BinaryToken::Array(x), BinaryToken::End(y)] if *x == y + 1)
+                                });
+
+                        let ptr = self.token_tape.as_mut_ptr();
+                        if only_empties {
+                            unsafe { self.set_parent_to_object(parent_ind) }
+                            unsafe { ptr.add(parent_ind + 1).write(last) };
+                            unsafe { self.token_tape.set_len(parent_ind + 2) }
+                            state = ParseState::ObjectValue;
+                        } else {
+                            let len = self.token_tape.len();
+                            unsafe { ptr.add(len).write(BinaryToken::MixedContainer) };
+                            unsafe { ptr.add(len + 1).write(last) };
+                            unsafe { ptr.add(len + 2).write(BinaryToken::Equal) };
+                            unsafe { self.token_tape.set_len(len + 3) }
+                            state = ParseState::ArrayValueMixed;
+                        }
+                    } else {
+                        return Err(self.equal_key_error(data));
+                    }
+                }
+                0x2 => return Err(self.unknown_token(data)),
                 OPEN => {
                     if state != ParseState::Key {
+                        // Until we encounter an equal token, assume the new container is an array.
+
                         let ind = self.token_tape.len();
                         self.token_tape.alloc().init(BinaryToken::Array(parent_ind));
                         parent_ind = ind;
-                        state = ParseState::OpenFirst;
                         data = d;
+                        state = ParseState::ArrayValue;
+
+                        let mut is_token = false;
+                        let d = match self.parse_next_id_opt(d).ok_or_else(Error::eof)? {
+                            (_, EQUAL) => return Err(self.equal_key_error(data)),
+                            (_, OPEN) => continue,
+                            (_, END) => continue,
+                            (d, I32) => self.parse_i32(d)?,
+                            (d, F32) => self.parse_f32(d)?,
+                            (d, BOOL) => self.parse_bool(d)?,
+                            (d, QUOTED_STRING) => self.parse_quoted_string(d)?,
+                            (d, U32) => self.parse_u32(d)?,
+                            (d, UNQUOTED_STRING) => self.parse_unquoted_string(d)?,
+                            (d, U64) if !IS_EU4 => self.parse_u64(d)?,
+                            (d, F64) => self.parse_f64(d)?,
+                            (d, RGB) if !IS_EU4 => self.parse_rgb(d)?,
+                            (d, x) => {
+                                is_token = true;
+                                self.token_tape.alloc().init(BinaryToken::Token(x));
+                                d
+                            }
+                        };
+
+                        let (d2, id2) = self.parse_next_id_opt(d).ok_or_else(Error::eof)?;
+
+                        if is_token && id2 == EQUAL {
+                            data = d2;
+                            unsafe { self.set_parent_to_object(parent_ind) }
+                            state = ParseState::ObjectValue;
+                            continue;
+                        }
+
+                        data = d;
+                        data = match id2 {
+                            EQUAL => {
+                                unsafe { self.set_parent_to_object(parent_ind) }
+                                state = ParseState::ObjectValue;
+                                d2
+                            }
+                            OPEN => continue,
+                            END => continue,
+                            I32 => self.parse_i32(d2)?,
+                            F32 => self.parse_f32(d2)?,
+                            BOOL => self.parse_bool(d2)?,
+                            QUOTED_STRING => self.parse_quoted_string(d2)?,
+                            U32 => self.parse_u32(d2)?,
+                            UNQUOTED_STRING => self.parse_unquoted_string(d2)?,
+                            U64 if !IS_EU4 => self.parse_u64(d2)?,
+                            F64 => self.parse_f64(d2)?,
+                            RGB if !IS_EU4 => self.parse_rgb(d2)?,
+                            x => {
+                                self.token_tape.alloc().init(BinaryToken::Token(x));
+                                d2
+                            }
+                        };
                     } else if self.token_tape.is_empty() {
                         return Err(self.open_empty_err(data));
                     } else {
@@ -357,63 +459,71 @@ impl<'a, 'b> ParserState<'a, 'b> {
                     parent_ind = grand_ind;
                     data = d;
                 }
-                RGB => {
-                    data = self.parse_rgb(d)?;
-                    state = Self::next_state(state);
-                }
-                EQUAL => {
+                0x5 => return Err(self.unknown_token(data)),
+                0x6 => return Err(self.unknown_token(data)),
+                0x7 => return Err(self.unknown_token(data)),
+                0x8 => return Err(self.unknown_token(data)),
+                0x9 => return Err(self.unknown_token(data)),
+                0xa => return Err(self.unknown_token(data)),
+                0xb => {
                     data = d;
-                    if state == ParseState::KeyValueSeparator {
-                        state = ParseState::ObjectValue;
-                        continue; // prevents turning this into jump table
-                    } else if state == ParseState::OpenSecond {
-                        unsafe { self.set_parent_to_object(parent_ind) }
-                        state = ParseState::ObjectValue;
-                    } else if state == ParseState::ArrayValueMixed {
-                        self.token_tape.alloc().init(BinaryToken::Equal);
-                    } else if state == ParseState::ArrayValue {
-                        self.token_tape.reserve(2);
-                        let last = unsafe { self.token_tape.pop().unwrap_unchecked() };
-                        if matches!(last, BinaryToken::Array(_) | BinaryToken::End(_)) {
-                            return Err(self.equal_in_array_err(data));
-                        }
-
-                        // before we enter mixed mode, let's make sure we're not
-                        // proceeded by only empty objects eg: `a={{} {} c=d}`. Only
-                        // found in a smattering of EU4 saves
-                        let mut pairs = self
-                            .token_tape
-                            .get(parent_ind + 1..)
-                            .unwrap_or_default()
-                            .chunks_exact(2);
-
-                        let only_empties = pairs.len() > 0
-                            && pairs.all(|tokens| {
-                                matches!(tokens, [BinaryToken::Array(x), BinaryToken::End(y)] if *x == y + 1)
-                            });
-
-                        let ptr = self.token_tape.as_mut_ptr();
-                        if only_empties {
-                            unsafe { self.set_parent_to_object(parent_ind) }
-                            unsafe { ptr.add(parent_ind + 1).write(last) };
-                            unsafe { self.token_tape.set_len(parent_ind + 2) }
-                            state = ParseState::ObjectValue;
-                        } else {
-                            let len = self.token_tape.len();
-                            unsafe { ptr.add(len).write(BinaryToken::MixedContainer) };
-                            unsafe { ptr.add(len + 1).write(last) };
-                            unsafe { ptr.add(len + 2).write(BinaryToken::Equal) };
-                            unsafe { self.token_tape.set_len(len + 3) }
-                            state = ParseState::ArrayValueMixed;
-                        }
-                    } else {
-                        return Err(self.equal_key_error(data));
-                    }
+                    self.token_tape.alloc().init(BinaryToken::Token(0xb));
+                    state = self.next_scalar_state(state);
+                }
+                I32 => {
+                    data = self.parse_i32(d)?;
+                    state = self.next_scalar_state(state);
+                }
+                F32 => {
+                    data = self.parse_f32(d)?;
+                    state = self.next_scalar_state(state);
+                }
+                BOOL => {
+                    data = self.parse_bool(d)?;
+                    state = self.next_scalar_state(state);
+                }
+                QUOTED_STRING => {
+                    data = self.parse_quoted_string(d)?;
+                    state = self.next_scalar_state(state);
+                }
+                0x10 => return Err(self.unknown_token(data)),
+                0x11 => return Err(self.unknown_token(data)),
+                0x12 => return Err(self.unknown_token(data)),
+                0x13 => return Err(self.unknown_token(data)),
+                U32 => {
+                    data = self.parse_u32(d)?;
+                    state = self.next_scalar_state(state);
+                }
+                0x15 => {
+                    data = d;
+                    self.token_tape.alloc().init(BinaryToken::Token(0x15));
+                    state = self.next_scalar_state(state);
+                }
+                0x16 => {
+                    data = d;
+                    self.token_tape.alloc().init(BinaryToken::Token(0x16));
+                    state = self.next_scalar_state(state);
+                }
+                UNQUOTED_STRING => {
+                    data = self.parse_unquoted_string(d)?;
+                    state = self.next_scalar_state(state);
+                }
+                U64 if !IS_EU4 => {
+                    data = self.parse_u64(d)?;
+                    state = self.next_scalar_state(state);
+                }
+                F64 => {
+                    data = self.parse_f64(d)?;
+                    state = self.next_scalar_state(state);
+                }
+                RGB if !IS_EU4 => {
+                    data = self.parse_rgb(d)?;
+                    state = self.next_scalar_state(state);
                 }
                 x => {
                     data = d;
                     self.token_tape.alloc().init(BinaryToken::Token(x));
-                    state = Self::next_state(state);
+                    state = self.next_scalar_state(state);
                 }
             }
         }
@@ -425,30 +535,32 @@ impl<'a, 'b> ParserState<'a, 'b> {
         }
     }
 
-    #[inline(never)]
     #[cold]
-    fn mixed_insert2(&mut self) {
-        let stashed1 = match self.token_tape.pop() {
-            Some(x) => x,
-            None => {
-                debug_assert!(false, "empty token tape");
-                return;
+    #[inline(never)]
+    fn mixed_insert2(&mut self) -> ParseState {
+        self.token_tape.reserve(1);
+        let stashed1 = unsafe { self.token_tape.pop().unwrap_unchecked() };
+        match self.token_tape.pop() {
+            Some(stashed2) => {
+                let ptr = self.token_tape.as_mut_ptr();
+                let len = self.token_tape.len();
+                unsafe { ptr.add(len).write(BinaryToken::MixedContainer) };
+                unsafe { ptr.add(len + 1).write(stashed2) };
+                unsafe { ptr.add(len + 2).write(stashed1) };
+                unsafe { self.token_tape.set_len(len + 3) }
+                ParseState::ArrayValueMixed
             }
-        };
-
-        let stashed2 = match self.token_tape.pop() {
-            Some(x) => x,
             None => {
-                debug_assert!(false, "empty token tape");
-                return;
+                let ptr = self.token_tape.as_mut_ptr();
+                let len = self.token_tape.len();
+                unsafe { ptr.add(len).write(stashed1) };
+                unsafe { self.token_tape.set_len(len + 1) }
+                ParseState::ObjectValue
             }
-        };
-
-        self.token_tape.alloc().init(BinaryToken::MixedContainer);
-        self.token_tape.alloc().init(stashed2);
-        self.token_tape.alloc().init(stashed1);
+        }
     }
 
+    #[cold]
     #[inline(never)]
     fn mixed_insert1(&mut self) {
         let stashed1 = match self.token_tape.pop() {
@@ -486,6 +598,15 @@ impl<'a, 'b> ParserState<'a, 'b> {
     fn empty_object_err(&mut self, data: &[u8]) -> Error {
         Error::new(ErrorKind::InvalidSyntax {
             msg: String::from("expected an empty object"),
+            offset: self.offset(data),
+        })
+    }
+
+    #[inline(never)]
+    #[cold]
+    fn unknown_token(&mut self, data: &[u8]) -> Error {
+        Error::new(ErrorKind::InvalidSyntax {
+            msg: String::from("a token in bad range detected"),
             offset: self.offset(data),
         })
     }


### PR DESCRIPTION
Needed to benchmark using two machines as both exhibited different performance behaviors, but after much trial and error I have applied the following optimizations which netted a throughput increase from anywhere from 0-30%

- Added `BinaryTapeParser::parse_eu4_slice_into_tape`, which can be used to opt into optimizations that the simplified EU4 binary format may bring.
- Switch statement over token id made dense until the end of most structural tokens (0x17)
- Eagerly try deducing object and thus remove `OpenFirst` and `OpenSecond` parse statements (this change alone had the biggest impact on one system)
- Remove `ParseState::ObjectToArray` so llvm can optimize assuming the variant doesn't exist (but we have to make sure we rectify the issue before matched on)