### PR TITLE
Data driven binary parsing performance improvements

### DIFF
--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -174,7 +174,13 @@ impl std::fmt::Display for Stats {
     }
 }
 
-fn read_array(keys: &mut Stats, values: &mut Stats, array: &mut Stats, tokens: &[BinaryToken], range: Range<usize>) {
+fn read_array(
+    keys: &mut Stats,
+    values: &mut Stats,
+    array: &mut Stats,
+    tokens: &[BinaryToken],
+    range: Range<usize>,
+) {
     let mut ind = range.start;
     while ind < range.end {
         let token = tokens[ind];
@@ -196,7 +202,13 @@ fn read_array(keys: &mut Stats, values: &mut Stats, array: &mut Stats, tokens: &
     }
 }
 
-fn read_object(keys: &mut Stats, values: &mut Stats, array: &mut Stats, tokens: &[BinaryToken], range: Range<usize>) {
+fn read_object(
+    keys: &mut Stats,
+    values: &mut Stats,
+    array: &mut Stats,
+    tokens: &[BinaryToken],
+    range: Range<usize>,
+) {
     let mut ind = range.start;
     while ind < range.end {
         let token = tokens[ind];


### PR DESCRIPTION
This commit improves the throughput of parsing binary save files by a significant margin:

- EU4:  +53%
- CK3:  +30%
- Vic3: +17%

The optimization is from exploiting patterns in data to parse as far as we can in a single iteration of the core parsing loop. Oftentimes this means parsing entire `<key> = <value>` field at once.

Since EU4 is the most demanding use case for the binary parser, the function has been tailored to data patterns exhibited by EU4 saves, but the other games benefit as well.

All optimizations employed are safe and will fall back to the traditional parsing method if the expected data is not encountered.

Some specific optimizations used:

- Most object keys are tokens
- Most arrays are homogeneous over i32, quoted strings, and f32, so create tailored parsing routines that will consume these homogeneous arrays in one go
- When signed 32-bit integers are seen as object keys, the value is always an i32.
- EU4 has a lot of quoted string as keys, and most of the time the value is an object.

Overall, this makes the code a lot more ugly and it needs a refactor, but the refactor needs to be done carefully as several attempts (like folding the `parent_ind` into the parser state yielded non-negligible performance regressions.

Here's some data:

| Object Key | EU4 (%) | CK3 (%) | Vic3 (%) |
|------------|--------:|--------:|---------:|
| i32        |     8.3 |     1.9 |      7.8 |
| u32        |     0.0 |     6.8 |      7.6 |
| quoted     |    22.7 |     1.0 |      1.6 |
| unquoted   |     2.0 |     0.0 |      0.0 |
| token      |    70.0 |    90.3 |     83.1 |

| Object Value | EU4 (%) | CK3 (%) | Vic3 (%) |
|--------------|--------:|--------:|---------:|
| array        |     2.7 |    13.9 |      8.8 |
| object       |    31.6 |    21.7 |     21.6 |
| bool         |    15.5 |     3.1 |      4.5 |
| u32          |     4.0 |    16.2 |     19.9 |
| i32          |    19.5 |    12.0 |      1.8 |
| u64          |     0.0 |     0.1 |      1.8 |
| quoted       |    14.3 |    19.9 |      9.9 |
| unquoted     |     3.2 |     0.0 |      0.0 |
| f32          |     6.7 |     0.0 |      0.0 |
| f64          |     0.1 |    11.9 |     14.5 |
| token        |     2.4 |     1.1 |     11.4 |
| rgb          |     0.0 |     0.1 |      0.1 |

| Array Value | EU4 (%) | CK3 (%) | Vic3 (%) |
|-------------|--------:|--------:|---------:|
| array       |     0.4 |     4.7 |      0.1 |
| object      |     0.1 |     5.2 |     16.1 |
| bool        |     0.1 |     0.0 |      0.0 |
| u32         |     0.1 |    16.8 |      6.2 |
| i32         |    63.4 |    52.0 |     42.3 |
| quoted      |    28.7 |     6.6 |      4.2 |
| f32         |     7.3 |    14.2 |      0.0 |
| f64         |     0.0 |     0.4 |     29.0 |

Closes #110 