### PR TITLE
More binary parsing improvements based on data and fuzz equality

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,7 +79,7 @@ jobs:
       if: matrix.build == 'nightly'
       run: |
         cargo install cargo-fuzz
-        cargo fuzz build fuzz_binary
+        RUSTFLAGS="--cfg unoptimized_build" cargo fuzz build fuzz_binary
         cargo fuzz build fuzz_scalar_text
         cargo fuzz build fuzz_text
         cargo fuzz build fuzz_date

--- a/fuzz/fuzz_targets/fuzz_binary.rs
+++ b/fuzz/fuzz_targets/fuzz_binary.rs
@@ -62,30 +62,43 @@ fuzz_target!(|data: &[u8]| {
     hash.insert(0x354eu16, "selector");
     hash.insert(0x209u16, "localization");
 
-    let _: Result<Meta, _> = jomini::BinaryTape::from_slice(&data).and_then(|tape| {
-        let tokens = tape.tokens();
-        for (i, token) in tokens.iter().enumerate() {
-            match token {
-                jomini::BinaryToken::Array(ind)
-                | jomini::BinaryToken::Object(ind)
-                | jomini::BinaryToken::End(ind)
-                    if *ind == 0 =>
-                {
-                    panic!("zero ind encountered");
-                }
-                jomini::BinaryToken::MixedContainer => {}
-                jomini::BinaryToken::Equal => {}
-                jomini::BinaryToken::Array(ind) | jomini::BinaryToken::Object(ind) => {
-                    match tokens[*ind] {
-                        jomini::BinaryToken::End(ind2) => {
-                            assert_eq!(ind2, i)
-                        }
-                        _ => panic!("expected end"),
-                    }
-                }
-                _ => {}
+    let mut utape = jomini::BinaryTape::default();
+    let ures =
+        jomini::binary::BinaryTapeParser.parse_slice_into_tape_unoptimized(&data, &mut utape);
+
+    let ores = jomini::BinaryTape::from_slice(&data);
+    assert_eq!(ures.is_ok(), ores.is_ok());
+    if !ures.is_ok() {
+        return;
+    }
+
+    let otape = ores.unwrap();
+
+    assert_eq!(utape.tokens(), otape.tokens());
+
+    let tokens = otape.tokens();
+    for (i, token) in tokens.iter().enumerate() {
+        match token {
+            jomini::BinaryToken::Array(ind)
+            | jomini::BinaryToken::Object(ind)
+            | jomini::BinaryToken::End(ind)
+                if *ind == 0 =>
+            {
+                panic!("zero ind encountered");
             }
+            jomini::BinaryToken::MixedContainer => {}
+            jomini::BinaryToken::Equal => {}
+            jomini::BinaryToken::Array(ind) | jomini::BinaryToken::Object(ind) => {
+                match tokens[*ind] {
+                    jomini::BinaryToken::End(ind2) => {
+                        assert_eq!(ind2, i)
+                    }
+                    _ => panic!("expected end"),
+                }
+            }
+            _ => {}
         }
-        jomini::BinaryDeserializer::builder_flavor(BinaryTestFlavor).from_tape(&tape, &hash)
-    });
+    }
+    let _: Result<Meta, _> =
+        jomini::BinaryDeserializer::builder_flavor(BinaryTestFlavor).from_tape(&otape, &hash);
 });

--- a/fuzz/fuzz_targets/fuzz_text.rs
+++ b/fuzz/fuzz_targets/fuzz_text.rs
@@ -35,7 +35,7 @@ where
     E: crate::Encoding + Clone,
 {
     match value.token() {
-        TextToken::Object {..} => {
+        TextToken::Object { .. } => {
             let obj = value.read_object().unwrap();
             if unsafe { GROUPED } {
                 iterate_object2(obj);
@@ -43,7 +43,7 @@ where
                 iterate_object(obj);
             }
         }
-        TextToken::Array {..} => {
+        TextToken::Array { .. } => {
             iterate_array(value.read_array().unwrap());
         }
         TextToken::End(_) => panic!("end!?"),
@@ -102,17 +102,21 @@ fuzz_target!(|data: &[u8]| {
         let tokens = tape.tokens();
         for (i, token) in tokens.iter().enumerate() {
             match token {
-                TextToken::Array { end: ind, .. } | TextToken::Object{ end: ind, .. } | TextToken::End(ind)
+                TextToken::Array { end: ind, .. }
+                | TextToken::Object { end: ind, .. }
+                | TextToken::End(ind)
                     if *ind == 0 =>
                 {
                     panic!("zero ind encountered");
                 }
-                TextToken::Array { end: ind, .. } | TextToken::Object{ end: ind, .. } => match &tokens[*ind] {
-                    TextToken::End(ind2) => {
-                        assert_eq!(*ind2, i)
+                TextToken::Array { end: ind, .. } | TextToken::Object { end: ind, .. } => {
+                    match &tokens[*ind] {
+                        TextToken::End(ind2) => {
+                            assert_eq!(*ind2, i)
+                        }
+                        x => panic!("expected end not {:?}", x),
                     }
-                    x => panic!("expected end not {:?}", x),
-                },
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
Realizing that there are 125k integers in arrays that weren't being captured by the usual fast-path of key=value detection, I installed a special loop just for i32 instances.

Also included a few more conditionals in the fast-path.

Together the throughput improvement is between 5-10% for EU4 saves. CK3 and VIC3 were unchanged.

This commit also adds in a mechanism for turning off the fast-path. This is mainly used in fuzzing to ensure that both functions return the same result.