### PR TITLE
Implement serde `Deserializer` trait on top level deserializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Below is a demonstration on parsing plaintext data using jomini tools.
 ```rust
 use jomini::{
     text::{Operator, Property},
-    JominiDeserialize, TextDeserializer,
+    JominiDeserialize,
 };
 
 #[derive(JominiDeserialize, PartialEq, Debug)]
@@ -62,7 +62,7 @@ let expected = Model {
     names: vec!["Johan".to_string(), "Frederick".to_string()],
 };
 
-let actual: Model = TextDeserializer::from_windows1252_slice(data)?;
+let actual: Model = jomini::text::de::from_windows1252_slice(data)?;
 assert_eq!(actual, expected);
 ```
 
@@ -112,7 +112,7 @@ let mut map = HashMap::new();
 map.insert(0x2d82, "field1");
 
 let actual: MyStruct = BinaryDeserializer::builder_flavor(BinaryTestFlavor)
-    .from_slice(&data[..], &map)?;
+    .deserialize_slice(&data[..], &map)?;
 assert_eq!(actual, MyStruct { field1: "ENG".to_string() });
 ```
 

--- a/benches/jomini_bench.rs
+++ b/benches/jomini_bench.rs
@@ -5,8 +5,7 @@ use flate2::read::GzDecoder;
 use jomini::{
     binary::{BinaryFlavor, BinaryTapeParser},
     common::Date,
-    BinaryDeserializer, BinaryTape, Encoding, Scalar, TextDeserializer, TextTape, Utf8Encoding,
-    Windows1252Encoding,
+    BinaryDeserializer, BinaryTape, Encoding, Scalar, TextTape, Utf8Encoding, Windows1252Encoding,
 };
 use std::{borrow::Cow, collections::HashMap, io::Read};
 
@@ -116,7 +115,7 @@ pub fn binary_deserialize_benchmark(c: &mut Criterion) {
     group.bench_function("binary", |b| {
         b.iter(|| {
             let _res: Meta = BinaryDeserializer::builder_flavor(BinaryTestFlavor)
-                .from_slice(&data[..], &map)
+                .deserialize_slice(&data[..], &map)
                 .unwrap();
         })
     });
@@ -134,7 +133,7 @@ pub fn text_deserialize_benchmark(c: &mut Criterion) {
     group.throughput(Throughput::Bytes(data.len() as u64));
     group.bench_function("text", |b| {
         b.iter(|| {
-            let _res: Meta = TextDeserializer::from_windows1252_slice(&data[..]).unwrap();
+            let _res: Meta = jomini::text::de::from_windows1252_slice(&data[..]).unwrap();
         })
     });
     group.finish();

--- a/fuzz/fuzz_targets/fuzz_binary.rs
+++ b/fuzz/fuzz_targets/fuzz_binary.rs
@@ -100,5 +100,7 @@ fuzz_target!(|data: &[u8]| {
         }
     }
     let _: Result<Meta, _> =
-        jomini::BinaryDeserializer::builder_flavor(BinaryTestFlavor).from_tape(&otape, &hash);
+        jomini::BinaryDeserializer::builder_flavor(BinaryTestFlavor)
+            .from_tape(&otape, &hash)
+            .deserialize();
 });

--- a/fuzz/fuzz_targets/fuzz_text.rs
+++ b/fuzz/fuzz_targets/fuzz_text.rs
@@ -1,7 +1,7 @@
 #![no_main]
 use jomini::{
     text::{ArrayReader, ObjectReader, ValueReader},
-    Encoding, TextToken,
+    Encoding, TextDeserializer, TextToken,
 };
 use libfuzzer_sys::fuzz_target;
 use serde::Deserialize;
@@ -130,6 +130,6 @@ fuzz_target!(|data: &[u8]| {
             GROUPED = true;
         }
         iterate_object2(tape.windows1252_reader());
-        jomini::TextDeserializer::from_windows1252_tape(&tape)
+        TextDeserializer::from_windows1252_tape(&tape).deserialize()
     });
 });

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -3,15 +3,14 @@
 //! See the top level module documentation for an overview that includes parsing
 //! and deserializing binary data.
 
+/// binary deserialization
 #[cfg(feature = "derive")]
-mod de;
+pub mod de;
 mod flavor;
 mod resolver;
 mod rgb;
 mod tape;
 
-#[cfg(feature = "derive")]
-pub use self::de::{BinaryDeserializer, BinaryDeserializerBuilder};
 pub use self::flavor::BinaryFlavor;
 pub use self::resolver::{FailedResolveStrategy, TokenResolver};
 pub use self::rgb::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ Converters](https://github.com/ParadoxGameConverters) and
 - ✔ Small: Compile with zero dependencies
 - ✔ Safe: Extensively fuzzed against potential malicious input
 - ✔ Ergonomic: Use [serde](https://serde.rs/derive.html)-like macros to have parsing logic automatically implemented
-- ✔ Embeddable: Cross platform native apps, statically compiled services, or in the browser via [WASM](https://webassembly.org/)
+- ✔ Embeddable: Cross platform native apps, statically compiled services, or in the browser via [Wasm](https://webassembly.org/)
 
 ## Quick Start
 
@@ -28,7 +28,7 @@ Below is a demonstration on parsing plaintext data using jomini tools.
 # #[cfg(feature = "derive")] {
 use jomini::{
     text::{Operator, Property},
-    JominiDeserialize, TextDeserializer,
+    JominiDeserialize,
 };
 
 #[derive(JominiDeserialize, PartialEq, Debug)]
@@ -61,7 +61,7 @@ let expected = Model {
     names: vec!["Johan".to_string(), "Frederick".to_string()],
 };
 
-let actual: Model = TextDeserializer::from_windows1252_slice(data)?;
+let actual: Model = jomini::text::de::from_windows1252_slice(data)?;
 assert_eq!(actual, expected);
 # }
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -114,7 +114,7 @@ let mut map = HashMap::new();
 map.insert(0x2d82, "field1");
 
 let actual: MyStruct = BinaryDeserializer::builder_flavor(BinaryTestFlavor)
-    .from_slice(&data[..], &map)?;
+    .deserialize_slice(&data[..], &map)?;
 assert_eq!(actual, MyStruct { field1: "ENG".to_string() });
 # }
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -157,6 +157,8 @@ for (key, _op, value) in reader.fields() {
 #![cfg_attr(
     feature = "json",
     doc = r##"
+### JSON
+
 The mid-level API also provides the excellent utility of converting the
 plaintext Clausewitz format to JSON when the `json` feature is enabled.
 
@@ -250,17 +252,13 @@ pub mod text;
 pub(crate) mod util;
 
 pub use self::binary::{BinaryTape, BinaryToken};
-
-#[cfg(feature = "derive")]
-pub use self::binary::BinaryDeserializer;
-
 pub use self::encoding::*;
 pub use self::errors::*;
 pub use self::scalar::{Scalar, ScalarError};
 pub use self::text::{TextTape, TextToken, TextWriter, TextWriterBuilder};
 
 #[cfg(feature = "derive")]
-pub use self::text::TextDeserializer;
-
+#[doc(inline)]
+pub use self::{binary::de::BinaryDeserializer, text::de::TextDeserializer};
 #[cfg(feature = "derive")]
 pub use jomini_derive::*;

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -7,8 +7,10 @@
 //! [FieldGroupsIter](crate::text::FieldGroupsIter),
 //! [FieldsIter](crate::text::FieldsIter), and
 //! [ValuesIter](crate::text::ValuesIter)
+
+/// text deserialization
 #[cfg(feature = "derive")]
-mod de;
+pub mod de;
 mod fnv;
 mod operator;
 mod reader;
@@ -16,7 +18,8 @@ mod tape;
 mod writer;
 
 #[cfg(feature = "derive")]
-pub use self::de::{Property, TextDeserializer};
+#[doc(inline)]
+pub use self::de::Property;
 pub use self::operator::*;
 pub use self::reader::{
     ArrayReader, FieldGroupsIter, FieldsIter, GroupEntry, GroupEntryIter, ObjectReader, Reader,


### PR DESCRIPTION
There are serde crates that can wrap deserializers to enhance functionality. For instance, [`serde_path_to_err`][0], wraps a deserializer and will return the path to the field that caused a deserialization error. This example is especially important when dealing with imperfect information about the data being deserialized.

Last week, it took me a half hour to track down where and why an EU4 save failed to deserialize without any context. I couldn't use `serde_path_to_error` to help as the underlying `TextDeserializer` and `BinaryDeserializer` here don't implement [`serde::Deserializer`][1], which seems like an oversight or a misnomer.

This commit implements `serde::Deserializer` for the aforementioned types, and allows the following example, which will show the path to the error.

```rust
#[derive(Debug, Deserialize)]
struct Package {
  name: String,
  dependencies: HashMap<String, Dependency>,
}

#[derive(Debug, Deserialize)]
struct Dependency {
  version: u32,
}

let data = b"name=demo dependencies={serde={version=alpha}}";
let jd = jomini::TextDeserializer::from_windows1252_slice(&data[..]).unwrap();
let result: Result<Package, _> = serde_path_to_error::deserialize(&jd);
let err = result.unwrap_err();
assert_eq!(err.path().to_string(), "dependencies.serde.version");
```

Since this is a low level crate, all deserializer wrappers will be opt-in, as wrappers may have some cost associated with them. My plan is for downstream save crates to re-deserialize data with `serde_path_to_err` if the first attempt fails.

This is a breaking change. The shorthand methods for parsing and deserializing text in one step is now:

```
jomini::text::de::from_windows1252_slice()
jomini::text::de::from_utf8_slice()
```

While the methods on `TextDeserializer` now return a `TextDeserializer`.

Same thing with `BinaryDeserializer` except `deserialize_slice` is the new method for parsing and deserializing in one step.


[0]: https://github.com/dtolnay/path-to-error
[1]: https://docs.rs/serde/latest/serde/trait.Deserializer.html