### PR TITLE
Date parsing 30x perf improvement

### DIFF
--- a/benches/jomini_bench.rs
+++ b/benches/jomini_bench.rs
@@ -294,8 +294,19 @@ pub fn json_benchmark(c: &mut Criterion) {
 
 pub fn date_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("date");
-    group.bench_function("valid-date", |b| {
+    group.bench_function("1444.11.11", |b| {
         b.iter(|| Date::parse("1444.11.11").unwrap())
+    });
+    group.bench_function("1444.3.5", |b| b.iter(|| Date::parse("1444.3.5").unwrap()));
+    group.bench_function("1444.12.3", |b| {
+        b.iter(|| Date::parse("1444.12.3").unwrap())
+    });
+    group.bench_function("1444.2.19", |b| {
+        b.iter(|| Date::parse("1444.2.19").unwrap())
+    });
+    group.bench_function("1.1.1", |b| b.iter(|| Date::parse("1.1.1").unwrap()));
+    group.bench_function("-2500.1.1", |b| {
+        b.iter(|| Date::parse("-2500.1.1").unwrap())
     });
     group.bench_function("binary-date", |b| {
         b.iter(|| Date::from_binary(56379360).unwrap())

--- a/fuzz/fuzz_targets/fuzz_date.rs
+++ b/fuzz/fuzz_targets/fuzz_date.rs
@@ -14,7 +14,7 @@ fuzz_target!(|data: &[u8]| {
         match d.game_fmt().to_string().as_str() {
             // I'm not sure how math works when we go across the border
             // as I'm not familiar that EU4 recognizes the zeroth year
-            "1.1.1" | "-1.1.1" => {}
+            "1.1.1" | "-1.1.1" | "0.1.1" | "-0.1.1" => {}
             _ => {
                 assert_eq!(d.days_until(&d.add_days(1)), 1);
                 assert_eq!(d.days_until(&d.add_days(-1)), -1);


### PR DESCRIPTION
Date parsing from text is a hot path of save file parsing. Even the smallest EU4 saves will have a hundred thousand of dates. The largest saves can crack a million.

When attempting to parse the history section of EU4, we attempt to parse a lot of dates (yes, even for binary saves)

When profiling, I noticed that date parsing was
popping up so I decided to dive in and apply the following optimizations:

- Add happy path detection that can do ascii number validation and parsing in two instructions.
- In the general path, we know that month, day, and hour can only be two digits long, so use specialized routines for parsing short numbers
- Add length checking for dates

This resulted in major improvements across the board for all use cases