### PR TITLE
Add enummap test case

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ criterion = "< 0.4"
 quickcheck = "1"
 quickcheck_macros = "1"
 flate2 = "1"
+serde_with = "2.3.1"
 
 [[bin]]
 name = "json"

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -381,3 +381,35 @@ fn test_flatten_overflow2() {
     let txt_out: MyStruct = jomini::text::de::from_windows1252_slice(&data[..]).unwrap();
     assert_eq!(txt_out.meta.a, String::from("b"));
 }
+
+#[test]
+fn test_enum_map() {
+    use serde_with::{serde_as, EnumMap};
+
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
+    struct Event {
+        #[serde_as(as = "EnumMap")]
+        requirements: Vec<Condition>,
+    }
+
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    enum Condition {
+        Country(String),
+        Prestige(u32),
+        #[serde(other)]
+        Other,
+    }
+
+    let data = b"requirements = { country = ENG test = abc prestige = 10 }";
+    let txt_out: Event = jomini::text::de::from_windows1252_slice(&data[..]).unwrap();
+    assert_eq!(
+        txt_out.requirements,
+        vec![
+            Condition::Country(String::from("ENG")),
+            Condition::Other,
+            Condition::Prestige(10)
+        ]
+    );
+}


### PR DESCRIPTION
Stumbled across a solution to allowing one to deserialize an object as a vector of enum value pair using `serde_with`.

Closes #54