### PR TITLE
Support exists operator (?=)

### DIFF
--- a/src/text/operator.rs
+++ b/src/text/operator.rs
@@ -26,6 +26,9 @@ pub enum Operator {
 
     /// A `=` token
     Equal,
+
+    /// A `?=` token
+    Exists,
 }
 
 impl Display for Operator {
@@ -46,6 +49,7 @@ impl Operator {
     /// assert_eq!(Operator::Exact.symbol(), "==");
     /// assert_eq!(Operator::NotEqual.symbol(), "!=");
     /// assert_eq!(Operator::Equal.symbol(), "=");
+    /// assert_eq!(Operator::Exists.symbol(), "?=");
     /// ```
     pub fn symbol(&self) -> &'static str {
         match self {
@@ -56,6 +60,7 @@ impl Operator {
             Operator::Exact => "==",
             Operator::Equal => "=",
             Operator::NotEqual => "!=",
+            Operator::Exists => "?=",
         }
     }
 
@@ -70,6 +75,7 @@ impl Operator {
     /// assert_eq!(Operator::Exact.name(), "EXACT");
     /// assert_eq!(Operator::NotEqual.name(), "NOT_EQUAL");
     /// assert_eq!(Operator::Equal.name(), "EQUAL");
+    /// assert_eq!(Operator::Exists.name(), "EXISTS");
     /// ```
     pub fn name(&self) -> &'static str {
         match self {
@@ -80,6 +86,7 @@ impl Operator {
             Operator::Exact => "EXACT",
             Operator::Equal => "EQUAL",
             Operator::NotEqual => "NOT_EQUAL",
+            Operator::Exists => "EXISTS",
         }
     }
 }
@@ -111,6 +118,7 @@ impl<'de> serde::Deserialize<'de> for Operator {
                     "==" => Ok(Operator::Exact),
                     "=" => Ok(Operator::Equal),
                     "!=" => Ok(Operator::NotEqual),
+                    "?=" => Ok(Operator::Exists),
                     _ => Err(E::custom("did not receive a known operator")),
                 }
             }

--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -674,6 +674,11 @@ impl<'a, 'b> ParserState<'a, 'b> {
                         data = &data[2..];
                         state = ParseState::ObjectValue;
                     }
+                    [b'?', b'=', ..] => {
+                        self.token_tape.push(TextToken::Operator(Operator::Exists));
+                        data = &data[2..];
+                        state = ParseState::ObjectValue;
+                    }
                     [b'=', b'=', ..] => {
                         self.token_tape.push(TextToken::Operator(Operator::Exact));
                         data = &data[2..];
@@ -2099,6 +2104,20 @@ mod tests {
                 TextToken::Unquoted(Scalar::new(b"is_preparing")),
                 TextToken::Unquoted(Scalar::new(b"true")),
                 TextToken::End(1),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_exists_operator() {
+        let data = b"c:RUS ?= this";
+
+        assert_eq!(
+            parse(&data[..]).unwrap().token_tape,
+            vec![
+                TextToken::Unquoted(Scalar::new(b"c:RUS")),
+                TextToken::Operator(Operator::Exists),
+                TextToken::Unquoted(Scalar::new(b"this")),
             ]
         );
     }


### PR DESCRIPTION
[From CK3 1.9 changelog:][0]

> - New 'scope exists' script operator "?=" added, so we don't have to
>   write "exist = bla bla = { stuff }" thousands of times and can just do
>   “bla ?= { stuff }”
> - Scope exists operator `bla ?= {}` in effects will not execute
>   effects inside scope if the scope `bla` does not exist

I don't believe this exists in the binary format so only the text format is updated with this commit

[0]: https://forum.paradoxplaza.com/forum/developer-diary/dev-diary-128-ck3-1-9-0-lance-update.1583293/