### PR TITLE
Add ondemand binary deserializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,23 @@ without any duplication.
 
 One can configure the behavior when a token is unknown (ie: fail immediately or try to continue).
 
+### Ondemand Deserialization
+
+The ondemand deserializer is a one-shot deserialization mode is often faster
+and more memory efficient as it does not parse the input into an intermediate
+tape, and instead deserializes right from the input.
+
+It is instantiated and used similarly to `BinaryDeserializer`
+
+```rust
+use jomini::OndemandBinaryDeserializer;
+// [...snip code from previous example...]
+
+let actual: MyStruct = OndemandBinaryDeserializer::builder_flavor(BinaryTestFlavor)
+    .deserialize_slice(&data[..], &map)?;
+assert_eq!(actual, MyStruct { field1: "ENG".to_string() });
+```
+
 ## Caveats
 
 Caller is responsible for:

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -10,6 +10,7 @@ mod flavor;
 mod resolver;
 mod rgb;
 mod tape;
+mod tokens;
 
 pub use self::flavor::BinaryFlavor;
 pub use self::resolver::{FailedResolveStrategy, TokenResolver};

--- a/src/binary/tape.rs
+++ b/src/binary/tape.rs
@@ -1,3 +1,4 @@
+use super::tokens::*;
 use crate::{
     binary::Rgb,
     copyless::VecHelper,
@@ -56,19 +57,6 @@ pub enum BinaryToken<'a> {
     /// Represents the index of the encoded rgb value
     Rgb(Rgb),
 }
-
-const END: u16 = 0x0004;
-const OPEN: u16 = 0x0003;
-const EQUAL: u16 = 0x0001;
-const U32: u16 = 0x0014;
-const U64: u16 = 0x029c;
-const I32: u16 = 0x000c;
-const BOOL: u16 = 0x000e;
-const QUOTED_STRING: u16 = 0x000f;
-const UNQUOTED_STRING: u16 = 0x0017;
-const F32: u16 = 0x000d;
-const F64: u16 = 0x0167;
-const RGB: u16 = 0x0243;
 
 /// Customizes how the binary tape is parsed from data
 #[derive(Debug)]

--- a/src/binary/tokens.rs
+++ b/src/binary/tokens.rs
@@ -1,0 +1,12 @@
+pub(crate) const END: u16 = 0x0004;
+pub(crate) const OPEN: u16 = 0x0003;
+pub(crate) const EQUAL: u16 = 0x0001;
+pub(crate) const U32: u16 = 0x0014;
+pub(crate) const U64: u16 = 0x029c;
+pub(crate) const I32: u16 = 0x000c;
+pub(crate) const BOOL: u16 = 0x000e;
+pub(crate) const QUOTED_STRING: u16 = 0x000f;
+pub(crate) const UNQUOTED_STRING: u16 = 0x0017;
+pub(crate) const F32: u16 = 0x000d;
+pub(crate) const F64: u16 = 0x0167;
+pub(crate) const RGB: u16 = 0x0243;

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,4 +1,4 @@
-use crate::{binary::Rgb, DeserializeError};
+use crate::{binary::Rgb, Error};
 use de::{DeserializeSeed, SeqAccess, Visitor};
 use serde::de;
 
@@ -15,7 +15,7 @@ impl ColorSequence {
 }
 
 impl<'de, 'r> de::Deserializer<'de> for &'r mut ColorSequence {
-    type Error = DeserializeError;
+    type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
@@ -36,7 +36,7 @@ impl<'de, 'r> de::Deserializer<'de> for &'r mut ColorSequence {
 }
 
 impl<'de> SeqAccess<'de> for ColorSequence {
-    type Error = DeserializeError;
+    type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
     where
@@ -73,7 +73,7 @@ impl InnerColorSequence {
 }
 
 impl<'de, 'r> de::Deserializer<'de> for &'r mut InnerColorSequence {
-    type Error = DeserializeError;
+    type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
@@ -90,7 +90,7 @@ impl<'de, 'r> de::Deserializer<'de> for &'r mut InnerColorSequence {
 }
 
 impl<'de> SeqAccess<'de> for InnerColorSequence {
-    type Error = DeserializeError;
+    type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
     where

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,6 +21,11 @@ impl Error {
         &self.0
     }
 
+    /// Unwrap this error into its underlying type
+    pub fn into_kind(self) -> ErrorKind {
+        *self.0
+    }
+
     /// Returns the byte offset that the error occurs (if available)
     pub fn offset(&self) -> Option<usize> {
         self.0.offset()
@@ -165,6 +170,15 @@ impl std::fmt::Display for DeserializeError {
 }
 
 #[cfg(feature = "serde")]
+impl serde::de::Error for Error {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Error::new(ErrorKind::Deserialize(DeserializeError {
+            kind: DeserializeErrorKind::Message(msg.to_string()),
+        }))
+    }
+}
+
+#[cfg(feature = "serde")]
 impl serde::de::Error for DeserializeError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
         DeserializeError {
@@ -179,11 +193,11 @@ impl From<std::io::Error> for Error {
     }
 }
 
-impl From<ScalarError> for DeserializeError {
+impl From<ScalarError> for Error {
     fn from(error: ScalarError) -> Self {
-        DeserializeError {
+        Error::from(DeserializeError {
             kind: DeserializeErrorKind::Scalar(error),
-        }
+        })
     }
 }
 

--- a/src/text/de.rs
+++ b/src/text/de.rs
@@ -255,7 +255,7 @@ where
     where
         T: Deserialize<'a>,
     {
-        T::deserialize(self).map_err(|e| e.into())
+        T::deserialize(self)
     }
 }
 
@@ -263,17 +263,17 @@ impl<'de, 'a, 'tokens, E> de::Deserializer<'de> for &'a TextDeserializer<'de, 't
 where
     E: Encoding + Clone,
 {
-    type Error = DeserializeError;
+    type Error = Error;
 
     fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        Err(DeserializeError {
+        Err(Error::from(DeserializeError {
             kind: DeserializeErrorKind::Unsupported(String::from(
                 "root deserializer can only work with key value pairs",
             )),
-        })
+        }))
     }
 
     fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -344,7 +344,7 @@ impl<'de, 'tokens, E> de::MapAccess<'de> for MapAccess<'de, 'tokens, E>
 where
     E: Encoding + Clone,
 {
-    type Error = DeserializeError;
+    type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
     where
@@ -454,11 +454,11 @@ macro_rules! deserialize_any_value {
             }
             TextToken::Array { .. } => $self.deserialize_seq($visitor),
             TextToken::Object { .. } => $self.deserialize_map($visitor),
-            _ => Err(DeserializeError {
+            _ => Err(Error::from(DeserializeError {
                 kind: DeserializeErrorKind::Unsupported(String::from(
                     "unsupported value reader token",
                 )),
-            }),
+            })),
         }
     };
 }
@@ -467,7 +467,7 @@ impl<'de, 'tokens, E> de::Deserializer<'de> for ValueDeserializer<'de, 'tokens, 
 where
     E: Encoding + Clone,
 {
-    type Error = DeserializeError;
+    type Error = Error;
 
     fn deserialize_any<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
@@ -622,11 +622,11 @@ where
             let map = MapAccess::new(x.read_object()?, self.config);
             visitor.visit_map(map)
         } else {
-            Err(DeserializeError {
+            Err(Error::from(DeserializeError {
                 kind: DeserializeErrorKind::Unsupported(String::from(
                     "can only deserialize an object as a map",
                 )),
-            })
+            }))
         }
     }
 
@@ -649,11 +649,11 @@ where
                 };
                 visitor.visit_seq(map)
             }
-            _ => Err(DeserializeError {
+            _ => Err(Error::from(DeserializeError {
                 kind: DeserializeErrorKind::Unsupported(String::from(
                     "unexpected reader for sequence",
                 )),
-            }),
+            })),
         }
     }
 
@@ -730,9 +730,9 @@ where
         V: de::Visitor<'de>,
     {
         let err = || {
-            Err(DeserializeError {
+            Err(Error::from(DeserializeError {
                 kind: DeserializeErrorKind::Unsupported(String::from("unexpected reader for enum")),
-            })
+            }))
         };
 
         let value_reader = match self.reader() {
@@ -795,7 +795,7 @@ impl<'de, 'tokens, E> de::MapAccess<'de> for PropertyMap<'de, 'tokens, E>
 where
     E: Encoding + Clone,
 {
-    type Error = DeserializeError;
+    type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
     where
@@ -834,7 +834,7 @@ impl<'de, 'tokens, E> de::SeqAccess<'de> for SeqAccess<'de, 'tokens, E>
 where
     E: Encoding + Clone,
 {
-    type Error = DeserializeError;
+    type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
     where
@@ -867,7 +867,7 @@ impl<'de, 'tokens, E> de::EnumAccess<'de> for EnumAccess<'de, 'tokens, E>
 where
     E: Encoding + Clone,
 {
-    type Error = DeserializeError;
+    type Error = Error;
     type Variant = VariantDeserializer<'de, 'tokens, E>;
 
     fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
@@ -926,7 +926,7 @@ impl<'de, 'tokens, E> de::VariantAccess<'de> for VariantDeserializer<'de, 'token
 where
     E: Encoding + Clone,
 {
-    type Error = DeserializeError;
+    type Error = Error;
 
     fn unit_variant(mut self) -> Result<(), Self::Error> {
         if self.values.is_none() {
@@ -965,7 +965,7 @@ where
 struct StaticDeserializer(&'static str);
 
 impl<'de> de::Deserializer<'de> for StaticDeserializer {
-    type Error = DeserializeError;
+    type Error = Error;
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
@@ -983,7 +983,7 @@ impl<'de> de::Deserializer<'de> for StaticDeserializer {
 struct OperatorDeserializer(Operator);
 
 impl<'de> de::Deserializer<'de> for OperatorDeserializer {
-    type Error = DeserializeError;
+    type Error = Error;
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,


### PR DESCRIPTION
I was doing some unrelated testing and saw that a 50MB binary file
resulted in a 200MB tape (and this is before any deserialization). This
fact didn't sit well with me and required an investigation.

The reason why so much memory is required is the number of tokens (each
16 bits) that occur in the binary file and how each one is much smaller
than the tape's intermediate representation (192 bits).

Simdjson's intermediate representation is 64 bits that can stretch to
128 bits for larger types. This seems possible to emulate and could cut
the weight of the intermediate representation by at least half.

But this got me thinking, is the intermediate representation really
pulling its weight? The native binary format is easy enough to parse
standalone that I realized that those who are fine with one-shot
deserialization could benefit from cutting out the middleman.

What do benchmarks show? The most favorable benchmarks show around a ~3x
throughput increase when deserializing a fraction of the input. If most
of the input is deserialized then the throughput increase drops to
around 50%.

This is a breaking change as deserialization error type has been changed
to `jomini::Error` instead of `jomini::DeserializeError` as the new
ondemand deserializer can encounter an early EOF (an error that didn't
exist previously in `DeserializeError` as it couldn't occur when
deserialization was after parsing).