### PR TITLE
Support new binary i64 data type from HOI4 1.13

### DIFF
--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -18,6 +18,7 @@ struct Stats {
     f64: u32,
     token: u32,
     rgb: u32,
+    i64: u32,
 }
 
 impl Stats {
@@ -31,6 +32,7 @@ impl Stats {
             BinaryToken::Bool(_) => self.bool += 1,
             BinaryToken::U32(_) => self.u32 += 1,
             BinaryToken::U64(_) => self.u64 += 1,
+            BinaryToken::I64(_) => self.i64 += 1,
             BinaryToken::I32(_) => self.i32 += 1,
             BinaryToken::Quoted(_) => self.quoted += 1,
             BinaryToken::Unquoted(_) => self.unquoted += 1,
@@ -56,7 +58,8 @@ impl std::fmt::Display for Stats {
             + self.f32
             + self.f64
             + self.token
-            + self.rgb;
+            + self.rgb
+            + self.i64;
 
         let total = total as f64;
 
@@ -165,6 +168,15 @@ impl std::fmt::Display for Stats {
                 "rgb:\t\t{:<8}({:.2}%)",
                 self.rgb,
                 (self.rgb as f64) / total * 100.0
+            )?;
+        }
+
+        if self.i64 != 0 {
+            writeln!(
+                f,
+                "i64:\t\t{:<8}({:.2}%)",
+                self.i64,
+                (self.i64 as f64) / total * 100.0
             )?;
         }
 

--- a/src/binary/tokens.rs
+++ b/src/binary/tokens.rs
@@ -10,3 +10,4 @@ pub(crate) const UNQUOTED_STRING: u16 = 0x0017;
 pub(crate) const F32: u16 = 0x000d;
 pub(crate) const F64: u16 = 0x0167;
 pub(crate) const RGB: u16 = 0x0243;
+pub(crate) const I64: u16 = 0x0317;


### PR DESCRIPTION
This new data type can be seen in HOI4 1.13 saves as
```
manpower = { ratio = 81900 }
```

This datatype technically conflicts with some detected tokens in Imperator and Vic3 (`playbackrate`), but I believe this token to be unused and shouldn't pose too much of a problem.

I determined that it was signed 64bit by editing the binary to turn all bits on and I saw the output as -1.

This is a breaking change as `BinaryToken` is receiving an addition.