### PR TITLE
Allow direct struct field matching from binary token

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,34 @@ let actual: MyStruct = OndemandBinaryDeserializer::builder_flavor(BinaryTestFlav
 assert_eq!(actual, MyStruct { field1: "ENG".to_string() });
 ```
 
+### Direct identifier deserialization with `token` attribute
+
+There may be some performance loss during binary deserialization as
+tokens are resolved to strings via a `TokenResolver` and then matched against the
+string representations of a struct's fields.
+
+We can fix this issue by directly encoding the expected token value into the struct:
+
+```rust
+#[derive(JominiDeserialize, PartialEq, Debug)]
+struct MyStruct {
+    #[jomini(token = 0x2d82)]
+    field1: String,
+}
+
+// Empty token to string resolver
+let map = HashMap::<u16, String>::new();
+
+let actual: MyStruct = BinaryDeserializer::builder_flavor(BinaryTestFlavor)
+    .deserialize_slice(&data[..], &map)?;
+assert_eq!(actual, MyStruct { field1: "ENG".to_string() });
+```
+
+Couple notes:
+
+- This does not obviate need for the token to string resolver as tokens may be used as values.
+- If the `token` attribute is specified on one field on a struct, it must be specified on all fields of that struct.
+
 ## Caveats
 
 Caller is responsible for:

--- a/jomini_derive/tests/compile-fail/tokens.rs
+++ b/jomini_derive/tests/compile-fail/tokens.rs
@@ -1,0 +1,13 @@
+#[allow(dead_code)]
+use jomini_derive::JominiDeserialize;
+
+#[derive(JominiDeserialize)]
+pub struct Model {
+    #[jomini(token = 0x10)]
+    human: bool,
+    #[jomini(token = 0x11)]
+    checksum: String,
+    fourth: u16,
+}
+
+fn main() {}

--- a/jomini_derive/tests/compile-fail/tokens.stderr
+++ b/jomini_derive/tests/compile-fail/tokens.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> tests/compile-fail/tokens.rs:4:10
+  |
+4 | #[derive(JominiDeserialize)]
+  |          ^^^^^^^^^^^^^^^^^
+  |
+  = help: message: Model does not have #[jomini(token = x)] defined for all fields

--- a/jomini_derive/tests/compiletest.rs
+++ b/jomini_derive/tests/compiletest.rs
@@ -2,4 +2,5 @@
 fn tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/01-parse.rs");
+    t.compile_fail("tests/compile-fail/*.rs");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,61 @@ assert_eq!(actual, MyStruct { field1: "ENG".to_string() });
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
+### Direct identifier deserialization with `token` attribute
+
+There may be some performance loss during binary deserialization as
+tokens are resolved to strings via a `TokenResolver` and then matched against the
+string representations of a struct's fields.
+
+We can fix this issue by directly encoding the expected token value into the struct:
+
+```rust
+# #[cfg(feature = "derive")] {
+# use jomini::{Encoding, JominiDeserialize, Windows1252Encoding, BinaryDeserializer};
+# use std::{borrow::Cow, collections::HashMap};
+#
+# #[derive(Debug, Default)]
+# pub struct BinaryTestFlavor;
+#
+# impl jomini::binary::BinaryFlavor for BinaryTestFlavor {
+#     fn visit_f32(&self, data: [u8; 4]) -> f32 {
+#         f32::from_le_bytes(data)
+#     }
+#
+#     fn visit_f64(&self, data: [u8; 8]) -> f64 {
+#         f64::from_le_bytes(data)
+#     }
+# }
+#
+# impl Encoding for BinaryTestFlavor {
+#     fn decode<'a>(&self, data: &'a [u8]) -> Cow<'a, str> {
+#         Windows1252Encoding::decode(data)
+#     }
+# }
+#
+# let data = [ 0x82, 0x2d, 0x01, 0x00, 0x0f, 0x00, 0x03, 0x00, 0x45, 0x4e, 0x47 ];
+#
+#[derive(JominiDeserialize, PartialEq, Debug)]
+struct MyStruct {
+    #[jomini(token = 0x2d82)]
+    field1: String,
+}
+
+// Empty token to string resolver
+let map = HashMap::<u16, String>::new();
+
+let actual: MyStruct = BinaryDeserializer::builder_flavor(BinaryTestFlavor)
+    .deserialize_slice(&data[..], &map)?;
+assert_eq!(actual, MyStruct { field1: "ENG".to_string() });
+# }
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Couple notes:
+
+- This does not obviate need for the token to string resolver as tokens may be used as values.
+- If the `token` attribute is specified on one field on a struct, it must be specified on all fields of that struct.
+
 ## Caveats
 
 Caller is responsible for:


### PR DESCRIPTION
The binary token resolution leaves some efficiency on the table as it first translates the token to a string and then matches the string against struct fields.

The PR asks the question, what if we reduce the operation to just matching on the 16bit value? Remove the translation step and simplify matching.

This is what I envision and technically now works in this PR:

```rust
#[derive(JominiDeserialize, PartialEq, Debug)]
struct MyStruct {
    #[jomini(token = 0x2d82)]
    field1: String,
}
```

Large caveats:
 - All or no fields in a given struct should have the token attribute

classify each struct if fields can be directly resolved or if it needs translation based on the presence of the `#[jomini(token)]` attribute.

For direct structs, swap the request to `deserialize_identifier` to `deserialize_u16` to give a hint that tokens should not be resolved.

Some unanswered questions:
 - Do the efficiency gains justify the complication?
 - I know PDS doesn't want the token list revealed, I wonder if this is obfuscated enough to be ok.