### PR TITLE
Optimize `get_split` utility

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -7,12 +7,7 @@ fn take<const N: usize>(data: &[u8]) -> [u8; N] {
 
 #[inline]
 pub(crate) fn get_split<const N: usize>(data: &[u8]) -> Option<([u8; N], &[u8])> {
-    if N <= data.len() {
-        let (head, tail) = data.split_at(N);
-        Some((take::<N>(head), tail))
-    } else {
-        None
-    }
+    data.get(N..).map(|d| (take::<N>(data), d))
 }
 
 #[inline]


### PR DESCRIPTION
Throughput of ondemand binary deserializer improves 0-6%.

Looked into it a bit and I'm not sure where the throughput improvement comes from as this method generates more assembly.