### PR TITLE
Fix allow negative dates with from [-100,-999]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ quickcheck = "1"
 quickcheck_macros = "1"
 flate2 = "1"
 serde_with = "2.3.1"
+rstest = "0.18.2"
 
 [[bin]]
 name = "json"


### PR DESCRIPTION
A bug exists where a date like `-100.11.12` will be incorrectly parsed as the fast path fails and then fallsback to trying to parse the synthetic input for the fast path.

This code fixes this by having the fast path return none in the advent that it can't handle the input.

Benchmarks remain unaffected.