### PR TITLE
Fix take_last on last field

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ pub struct Model {
     #[jomini(alias = "core", duplicated)]
     cores: Vec<String>,
     names: Vec<String>,
+    #[jomini(take_last)]
+    checksum: String,
 }
 
 let data = br#"
@@ -51,6 +53,8 @@ let data = br#"
     core = "HAB"
     names = { "Johan" "Frederick" }
     core = FRA
+    checksum = "first"
+    checksum = "second"
 "#;
 
 let expected = Model {
@@ -60,6 +64,7 @@ let expected = Model {
     fourth: 10,
     cores: vec!["HAB".to_string(), "FRA".to_string()],
     names: vec!["Johan".to_string(), "Frederick".to_string()],
+    checksum: "second".to_string(),
 };
 
 let actual: Model = jomini::text::de::from_windows1252_slice(data)?;

--- a/jomini_derive/src/lib.rs
+++ b/jomini_derive/src/lib.rs
@@ -450,7 +450,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
                         while let Some(__key) = ::serde::de::MapAccess::next_key::<__Field>(&mut __map)? {
                             match __key {
-                                #(#builder_fields),*
+                                #(#builder_fields),* ,
                                 _ => { ::serde::de::MapAccess::next_value::<::serde::de::IgnoredAny>(&mut __map)?; }
                             }
                         }

--- a/jomini_derive/tests/11-last.rs
+++ b/jomini_derive/tests/11-last.rs
@@ -8,6 +8,15 @@ pub struct Model {
     fourth: u16,
 }
 
+
+#[derive(JominiDeserialize)]
+pub struct Model2 {
+    human: bool,
+    fourth: u16,
+    #[jomini(take_last)]
+    checksum: String,
+}
+
 #[test]
 fn test_options() {
     let data = r#"
@@ -19,7 +28,12 @@ fn test_options() {
         }"#;
 
     let m: Model = serde_json::from_str(data).unwrap();
+    let m2: Model2 = serde_json::from_str(data).unwrap();
     assert_eq!(m.checksum, String::from("false"));
     assert_eq!(m.human, true);
     assert_eq!(m.fourth, 4);
+    assert_eq!(m.checksum, m2.checksum);
+    assert_eq!(m.human, m2.human);
+    assert_eq!(m.fourth, m2.fourth);
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@ pub struct Model {
     #[jomini(alias = "core", duplicated)]
     cores: Vec<String>,
     names: Vec<String>,
+    #[jomini(take_last)]
+    checksum: String,
 }
 
 let data = br#"
@@ -50,6 +52,8 @@ let data = br#"
     core = "HAB"
     names = { "Johan" "Frederick" }
     core = FRA
+    checksum = "first"
+    checksum = "second"
 "#;
 
 let expected = Model {
@@ -59,6 +63,7 @@ let expected = Model {
     fourth: 10,
     cores: vec!["HAB".to_string(), "FRA".to_string()],
     names: vec!["Johan".to_string(), "Frederick".to_string()],
+    checksum: "second".to_string(),
 };
 
 let actual: Model = jomini::text::de::from_windows1252_slice(data)?;


### PR DESCRIPTION
There's a compilation error on the take_last attribute if it is used on
the final field in a struct. This fixes the compilation error.
    
This commit also showcases take_last attribute in the documentation