### PR TITLE
Support binary rgb values with optional alpha component

### DIFF
--- a/src/binary/rgb.rs
+++ b/src/binary/rgb.rs
@@ -12,4 +12,7 @@ pub struct Rgb {
 
     /// Blue channel
     pub b: u32,
+
+    /// Optional alpha channel
+    pub a: Option<u32>,
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -67,6 +67,7 @@ impl InnerColorSequence {
             1 => self.data.r,
             2 => self.data.g,
             3 => self.data.b,
+            4 => self.data.a.unwrap(),
             _ => unreachable!(),
         }
     }
@@ -96,7 +97,7 @@ impl<'de> SeqAccess<'de> for InnerColorSequence {
     where
         T: DeserializeSeed<'de>,
     {
-        if self.idx >= 3 {
+        if (self.idx >= 3 && self.data.a.is_none()) || (self.idx >= 4 && self.data.a.is_some()) {
             Ok(None)
         } else {
             self.idx += 1;

--- a/src/text/writer.rs
+++ b/src/text/writer.rs
@@ -1,4 +1,5 @@
 use crate::{
+    binary::Rgb,
     common::PdsDateFormatter,
     text::{ArrayReader, ObjectReader, Operator, ValueReader},
     BinaryToken, Encoding, Error, ErrorKind, TextTape, TextToken,
@@ -434,6 +435,36 @@ where
         write!(self, "{}", data)
     }
 
+    /// Write an rgb value
+    ///
+    /// ```
+    /// use jomini::{binary::Rgb, TextWriterBuilder};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut out: Vec<u8> = Vec::new();
+    /// let mut writer = TextWriterBuilder::new().from_writer(&mut out);
+    /// writer.write_unquoted(b"start")?;
+    /// let val = Rgb { r: 10, g: 9, b: 8, a: None };
+    /// writer.write_rgb(&val)?;
+    /// writer.write_unquoted(b"end")?;
+    ///
+    /// let val = Rgb { r: 7, g: 6, b: 5, a: Some(4) };
+    /// writer.write_rgb(&val)?;
+    /// assert_eq!(&out, b"start=rgb {\n  10 9 8\n}\nend=rgb {\n  7 6 5 4\n}");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn write_rgb(&mut self, color: &Rgb) -> Result<(), Error> {
+        self.write_header(b"rgb")?;
+        self.write_array_start()?;
+        self.write_u32(color.r)?;
+        self.write_u32(color.g)?;
+        self.write_u32(color.b)?;
+        if let Some(a) = color.a {
+            self.write_u32(a)?;
+        }
+        self.write_end()
+    }
+
     /// Write formatted data
     ///
     /// Typically not invoked directly but instead through the `write!` macro
@@ -578,14 +609,7 @@ where
             BinaryToken::Token(x) => {
                 write!(self, "__unknown_0x{:x}", x)
             }
-            BinaryToken::Rgb(color) => {
-                self.write_header(b"rgb")?;
-                self.write_array_start()?;
-                self.write_u32(color.r)?;
-                self.write_u32(color.g)?;
-                self.write_u32(color.b)?;
-                self.write_end()
-            }
+            BinaryToken::Rgb(color) => self.write_rgb(color),
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -28,11 +28,6 @@ pub(crate) const fn fast_digit_parse(val: u64) -> Option<u64> {
 }
 
 #[inline]
-pub(crate) fn le_u32(data: &[u8]) -> u32 {
-    u32::from_le_bytes(take::<4>(data))
-}
-
-#[inline]
 pub(crate) fn le_u64(data: &[u8]) -> u64 {
     u64::from_le_bytes(take::<8>(data))
 }


### PR DESCRIPTION
First seen in a late game vic3 save.

Add `write_rgb` to text writer