### PR TITLE
Introduce faster_writer feature (based on itoa)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,13 @@ members = ["jomini_derive"]
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 jomini_derive = { path = "jomini_derive", version = "^0.2.3", optional = true }
+itoa = { version = "1.0", optional = true }
 
 [features]
-default = ["derive"]
+default = ["derive", "faster_writer"]
 derive = ["serde/derive", "jomini_derive"]
 json = ["serde", "serde_json"]
+faster_writer = ["dep:itoa"]
 
 [dev-dependencies]
 attohttpc = { version = "0.24", features = ["tls-vendored"] }


### PR DESCRIPTION
Profiling the melter revealed that 20% of CPU time was spent formatting i32s. That's excessive. Swapping it out with itoa reduced it down to 0.3%.

This feature is enabled by default. Only those after absolute zero dependencies should consider disabling it.

This PR also annotates several writer methods with `#[inline]`