### PR TITLE
Simplify text decoding routines

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -263,11 +263,6 @@ pub(crate) const OPERATOR: u8 = 4;
 pub(crate) const COMMENT: u8 = 8;
 
 #[inline]
-pub(crate) fn is_whitespace(b: u8) -> bool {
-    b.is_ascii_whitespace()
-}
-
-#[inline]
 pub(crate) fn is_boundary(b: u8) -> bool {
     CHARACTER_CLASS[usize::from(b)] != 0
 }


### PR DESCRIPTION
Running the new binary scalar stats on a mid 1600's save, I received the following data:

```plain
Object key tokens:
quoted:         555782  (21.16%)
unquoted:       65347   (2.49%)
text count: 621129
text average length: 7.20
text median length: 5

Object value tokens:
quoted:         414187  (15.77%)
unquoted:       92780   (3.53%)
text count: 506967
text average length: 8.26
text median length: 6

Array value tokens:
quoted:         1180163 (32.09%)
text count: 1180163
text average length: 3.34
text median length: 3
```

Some takeaways:

- Quoted values heavily outweigh unquoted, about 14:1, so no sense optimizing for unquoted.
- Median and average lengths are sub-8 bytes in length and around 4

This commit simplified the decoding routine away from long decoding long runs of text towards being optimized for shorter input. The result was a few percentge improvement in latency in parsing saves.