### PR TITLE
Remove unncessary SliceReader

### DIFF
--- a/src/binary/reader.rs
+++ b/src/binary/reader.rs
@@ -2,7 +2,7 @@ use super::{
     lexer::{read_id, read_string, read_token},
     LexError, LexemeId, LexerError, Token,
 };
-use crate::buffer::{BufferError, BufferWindow, BufferWindowBuilder, SliceReader};
+use crate::buffer::{BufferError, BufferWindow, BufferWindowBuilder};
 use std::{fmt, io::Read};
 
 /// [Lexer](crate::binary::Lexer) that works over a [Read] implementation
@@ -49,9 +49,9 @@ pub struct TokenReader<R> {
 impl TokenReader<()> {
     /// Read from a byte slice without memcpy's
     #[inline]
-    pub fn from_slice(data: &[u8]) -> TokenReader<SliceReader<'_>> {
+    pub fn from_slice(data: &[u8]) -> TokenReader<&'_ [u8]> {
         TokenReader {
-            reader: SliceReader::new(data),
+            reader: data,
             buf: BufferWindow::from_slice(data),
         }
     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,5 @@
 use crate::Scalar;
-use std::{io::Read, marker::PhantomData, ops::Range};
+use std::{io::Read, ops::Range};
 
 #[derive(Debug)]
 pub struct BufferWindow {
@@ -158,21 +158,5 @@ impl BufferWindowBuilder {
             end,
             prior_reads: 0,
         }
-    }
-}
-
-/// An no-op read implementation used for TokenReaders
-#[derive(Debug)]
-pub struct SliceReader<'a>(PhantomData<&'a [u8]>);
-
-impl<'a> SliceReader<'a> {
-    pub(crate) fn new(_data: &'a [u8]) -> Self {
-        SliceReader(PhantomData)
-    }
-}
-
-impl<'a> Read for SliceReader<'a> {
-    fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
-        Ok(0)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,7 +240,6 @@ pub(crate) mod util;
 
 #[doc(inline)]
 pub use self::binary::{BinaryTape, BinaryToken};
-pub use self::buffer::SliceReader;
 pub use self::encoding::*;
 pub use self::errors::*;
 pub use self::scalar::{Scalar, ScalarError};

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -1,6 +1,6 @@
 use super::Operator;
 use crate::{
-    buffer::{BufferError, BufferWindow, BufferWindowBuilder, SliceReader},
+    buffer::{BufferError, BufferWindow, BufferWindowBuilder},
     data::is_boundary,
     util::{contains_zero_byte, count_chunk, repeat_byte},
     Scalar,
@@ -102,9 +102,9 @@ pub struct TokenReader<R> {
 impl TokenReader<()> {
     /// Read from a byte slice without memcpy's
     #[inline]
-    pub fn from_slice(data: &[u8]) -> TokenReader<SliceReader<'_>> {
+    pub fn from_slice(data: &[u8]) -> TokenReader<&'_ [u8]> {
         TokenReader {
-            reader: SliceReader::new(data),
+            reader: data,
             buf: BufferWindow::from_slice(data),
             utf8: Utf8Bom::Unknown,
         }


### PR DESCRIPTION
SliceReader is not necessary as the buffer created will be empty and that is all that is required for `fill_buf` not to trigger undefined behavior

This is technically a breaking change, but since this struct has only been out in the wild for a few days, I'm considering it as a patch.