### PR TITLE
Use pointers in token reader deserializations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,7 +80,7 @@ jobs:
       run: |
         rustup toolchain install nightly --component miri
         cargo miri setup
-        MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo miri test
+        cargo miri test
 
     - name: Compile fuzz
       if: matrix.build == 'nightly'

--- a/src/binary/reader.rs
+++ b/src/binary/reader.rs
@@ -222,11 +222,10 @@ where
     /// ```
     #[inline]
     pub fn read(&mut self) -> Result<Token, ReaderError> {
-        // Workaround for borrow checker :(
-        let s = unsafe { &mut *(self as *mut TokenReader<R>) };
+        let s = std::ptr::addr_of!(self);
         match self.next_opt() {
             (Some(x), _) => Ok(x),
-            (None, None) => Err(s.lex_error(LexError::Eof)),
+            (None, None) => Err(unsafe { (*s).lex_error(LexError::Eof) }),
             (None, Some(e)) => Err(e),
         }
     }

--- a/src/binary/tape.rs
+++ b/src/binary/tape.rs
@@ -263,8 +263,8 @@ impl<'a, 'b> ParserState<'a, 'b> {
         macro_rules! push_end {
             () => {
                 let end_idx = self.token_tape.len();
-                match unsafe { self.token_tape.get_unchecked_mut(parent_ind) } {
-                    BinaryToken::Array(end) | BinaryToken::Object(end) => {
+                match self.token_tape.get_mut(parent_ind) {
+                    Some(BinaryToken::Array(end) | BinaryToken::Object(end)) => {
                         let grand_ind = *end;
                         *end = end_idx;
                         let val = BinaryToken::End(parent_ind);

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -675,11 +675,10 @@ where
     /// ```
     #[inline]
     pub fn read(&mut self) -> Result<Token, ReaderError> {
-        // Workaround for borrow checker :(
-        let s = unsafe { &mut *(self as *mut TokenReader<R>) };
+        let s = std::ptr::addr_of!(self);
         match unsafe { self.next_opt() } {
             (Some(x), _) => Ok(x),
-            (None, None) => Err(s.eof_error()),
+            (None, None) => Err(unsafe { (*s).eof_error() }),
             (None, Some(e)) => Err(e),
         }
     }

--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -1604,6 +1604,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow
     fn test_too_heavily_nested() {
         let mut data = Vec::new();
         data.extend_from_slice(b"foo=");
@@ -1750,6 +1751,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow
     fn test_many_line_comment() {
         let mut data = Vec::new();
         data.extend_from_slice(b"foo=1.000\n");


### PR DESCRIPTION
Instead of invalidating references

Reddit credit: https://www.reddit.com/r/rust/comments/18oe075/comment/kehs8jq/?utm_source=share&utm_medium=web2x&context=3

This allows us to re-enable miri stacked borrow testing, which found an invalid reference in the binary tape parsing

Marked as draft as there is a bit of more work left for (commented out right now).