### PR TITLE
Add optimistic text parsing for 20% improvement

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -44,33 +44,34 @@ const fn create_windows_1252_table() -> [char; 256] {
 }
 
 pub(crate) static WINDOWS_1252: [char; 256] = create_windows_1252_table();
-pub(crate) const BOUNDARY: u8 = 1;
-pub(crate) const WHITESPACE: u8 = 2;
-pub(crate) const OPERATOR: u8 = 4;
-pub(crate) const COMMENT: u8 = 8;
 
 #[inline]
 pub(crate) fn is_boundary(b: u8) -> bool {
-    CHARACTER_CLASS[usize::from(b)] != 0
+    boundary(b) != 0
+}
+
+#[inline]
+pub(crate) fn boundary(b: u8) -> u8 {
+    CHARACTER_CLASS[usize::from(b)]
 }
 
 const fn create_character_class_table() -> [u8; 256] {
     let mut table = [0u8; 256];
-    table[b'\t' as usize] = WHITESPACE;
-    table[b'\n' as usize] = WHITESPACE;
-    table[b'\x0b' as usize] = WHITESPACE; // \v
-    table[b'\x0c' as usize] = WHITESPACE; // \f
-    table[b'\r' as usize] = WHITESPACE;
-    table[b' ' as usize] = WHITESPACE;
-    table[b'!' as usize] = OPERATOR;
-    table[b'#' as usize] = COMMENT;
-    table[b'<' as usize] = OPERATOR;
-    table[b'=' as usize] = OPERATOR;
-    table[b'>' as usize] = OPERATOR;
-    table[b'[' as usize] = BOUNDARY;
-    table[b']' as usize] = BOUNDARY;
-    table[b'}' as usize] = BOUNDARY;
-    table[b'{' as usize] = BOUNDARY;
+    table[b'\t' as usize] = 1;
+    table[b'\n' as usize] = 1;
+    table[b'\x0b' as usize] = 1; // \v
+    table[b'\x0c' as usize] = 1; // \f
+    table[b'\r' as usize] = 1;
+    table[b' ' as usize] = 1;
+    table[b'!' as usize] = 1;
+    table[b'#' as usize] = 1;
+    table[b'<' as usize] = 1;
+    table[b'=' as usize] = 1;
+    table[b'>' as usize] = 1;
+    table[b'[' as usize] = 1;
+    table[b']' as usize] = 1;
+    table[b'}' as usize] = 1;
+    table[b'{' as usize] = 1;
     table
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -72,10 +72,30 @@ pub(crate) const fn count_chunk(value: u64, byte: u8) -> u64 {
     sum_usize(bytewise_equal(value, repeat_byte(byte)))
 }
 
+#[inline]
+pub(crate) fn leading_whitespace(value: u64) -> u32 {
+    let mask1 = repeat_byte(b'\t');
+    let mask2 = repeat_byte(b'\n');
+    let res1 = value ^ mask1;
+    let res2 = value ^ mask2;
+    (res1 & res2).trailing_zeros() >> 3
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use rstest::*;
+
+    #[rstest]
+    #[case(*b"\t\t\t\t\t\t\t\t", 8)]
+    #[case(*b"a\t\t\t\t\t\t\t", 0)]
+    #[case(*b"\t       ", 1)]
+    #[case(*b"\n\na     ", 2)]
+    #[case(*b"\n\ta     ", 2)]
+    fn test_leading_whitespace(#[case] input: [u8; 8], #[case] expected: u32) {
+        let lhs = u64::from_le_bytes(input);
+        assert_eq!(leading_whitespace(lhs), expected);
+    }
 
     #[rstest]
     #[case(*b"        ", 0)]


### PR DESCRIPTION
In the same vein of data driven optimizations: #111, #112

This commit introduces a fast, happy path parsing routine that takes advantage of how typical save files are laid out and how the text deserializer essentially only calls `read` when it either needs a key or a value.

Keys will have leading whitespace (newline followed by tabs), so we consume up to 8 of them at once. For EU4 this covers 100% of keys in about 95% of saves (ie: it is extremely rare for there to be more than 8 whitespace characters in a row).

This happy path hoists the the common keys and values (`{`, `}`, `"`, and alphanumeric+dash) so it's more obvious to the compiler and CPU what we're looking for.

After all these years, I still can't derive a good function to identify a boundary character within 8 bytes, but I think I found the next best thing: loop unrolling. Speaking of boundary characters, I removed the notion of character classes as they were unused.

The happy path for parsing quoted data will now process 8 bytes at once and will ask for forgiveness if an escape character is encountered.

The 20% improvement comes from measuring eu4 save deserialization, so the improvement to this individual function is much greater.