### PR TITLE
Add is_empty to TokenResolver trait

### DIFF
--- a/src/binary/resolver.rs
+++ b/src/binary/resolver.rs
@@ -28,6 +28,29 @@ use std::collections::HashMap;
 pub trait TokenResolver {
     /// Return the string field name of the 16bit token if found
     fn resolve(&self, token: u16) -> Option<&str>;
+
+    /// Return whether [`TokenResolver::resolve`] will always return `None`.
+    /// 
+    /// By default this returns `false`
+    /// 
+    /// This method is not used by jomini itself, but rather targeted at
+    /// downstream save file libraries, who accept an application configured
+    /// [`TokenResolver`]. If the application is not configured for ironman
+    /// support, save file parsers can still handle plain text files, so
+    /// `is_empty` allows the save parsers to lazily check the validity of a
+    /// [`TokenResolver`] when the binary format is encountered. Thus, allowing
+    /// for better error messages. Instead of "missing field" errors, the save
+    /// file libraries can raise a more descriptive "binary file encountered but
+    /// tokens are not configured", as only they know if a non-zero amount of
+    /// tokens need to be resolved for a successful deserialization.
+    /// 
+    /// There's not a way for jomini to know whether an empty [`TokenResolver`]
+    /// constitutes an error, as the client may only be deserializing data from
+    /// keys that are already strings. Or, alternatively, direct token
+    /// deserialization is exclusively used.
+    fn is_empty(&self) -> bool {
+        false
+    }
 }
 
 impl<S, V> TokenResolver for HashMap<u16, V, S>
@@ -38,17 +61,29 @@ where
     fn resolve(&self, token: u16) -> Option<&str> {
         self.get(&token).map(|x| x.as_ref())
     }
+
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
 }
 
 impl<T: TokenResolver> TokenResolver for &'_ T {
     fn resolve(&self, token: u16) -> Option<&str> {
         (**self).resolve(token)
     }
+    
+    fn is_empty(&self) -> bool {
+        (**self).is_empty()
+    }
 }
 
 impl<T: TokenResolver + ?Sized> TokenResolver for Box<T> {
     fn resolve(&self, token: u16) -> Option<&str> {
         (**self).resolve(token)
+    }
+
+    fn is_empty(&self) -> bool {
+        (**self).is_empty()
     }
 }
 


### PR DESCRIPTION
Return whether TokenResolver::resolve will always return `None`.

By default this returns `false`

This method is not used by jomini itself, but rather targeted at downstream save file libraries, who accept an application configured TokenResolver. If the application is not configured for ironman support, save file parsers can still handle plain text files, so `is_empty` allows the save parsers to lazily check the validity of a TokenResolver when the binary format is encountered. Thus, allowing for better error messages. Instead of "missing field" errors, the save file libraries can raise a more descriptive "binary file encountered but tokens are not configured", as only they know if a non-zero amount of tokens need to be resolved for a successful deserialization.

There's not a way for jomini to know whether an empty TokenResolver constitutes an error, as the client may only be deserializing data from keys that are already strings. Or, alternatively, direct token deserialization is exclusively used.