### PR TITLE
Suppress unoptimized cfg lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,8 @@ debug = true
 lto = true
 codegen-units = 1
 debug = true
+
+[lints.rust]
+# suppress unoptimized cfg lint as it's not a "feature", but a mode
+# that's useful to drop into to fuzz against 
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(unoptimized_build)'] }


### PR DESCRIPTION
suppress unoptimized cfg lint as it's not a "feature", but a mode that's useful to drop into to fuzz against