### PR TITLE
Expose a space deliminated format token resolver

### DIFF
--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -80,6 +80,6 @@ mod tape;
 pub use self::flavor::BinaryFlavor;
 pub use self::lexer::{LexError, LexemeId, Lexer, LexerError, Token};
 pub use self::reader::{ReaderError, ReaderErrorKind, TokenReader, TokenReaderBuilder};
-pub use self::resolver::{FailedResolveStrategy, TokenResolver};
+pub use self::resolver::{BasicTokenResolver, FailedResolveStrategy, TokenResolver};
 pub use self::rgb::*;
 pub use self::tape::{BinaryTape, BinaryTapeParser, BinaryToken};


### PR DESCRIPTION
Every save game implementation has an $env variable that points to a file, which the build script turns into a very long `match` statement. This is poor for compile times and doesn't confer much performance improvement.

The $env token resolvers are being sunset with tests and implementations expected to pull from a file.

HOI4save tests goes from 220 to 12 seconds (closing in on 20x faster)