### PR TITLE
Support duplicated derive deserialization for array types

### DIFF
--- a/jomini_derive/Cargo.toml
+++ b/jomini_derive/Cargo.toml
@@ -15,6 +15,7 @@ proc-macro = true
 trybuild = { version = "1.0", features = ["diff"] }
 serde = "1"
 serde_json = "1"
+smallvec = { version = "1.13", features = ["serde", "union"] }
 
 [dependencies]
 syn = "1"

--- a/jomini_derive/src/lib.rs
+++ b/jomini_derive/src/lib.rs
@@ -390,8 +390,16 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
             let farg = &args[0];
 
-            quote! {
-                #match_arm => { (#name).push(serde::de::MapAccess::next_value::<#farg>(&mut __map)?); }
+            match farg {
+                syn::GenericArgument::Type(Type::Array(type_array)) => {
+                    let elem = &type_array.elem;
+                    quote! {
+                        #match_arm => { (#name).push(serde::de::MapAccess::next_value::<#elem>(&mut __map)?); }
+                    }
+                },
+                _ => quote! {
+                    #match_arm => { (#name).push(serde::de::MapAccess::next_value::<#farg>(&mut __map)?); }
+                }
             }
         }
     });


### PR DESCRIPTION
This commit allows the following type to be derived:

```rust
#[derive(JominiDeserialize)]
pub struct Model {
    #[jomini(duplicated)]
    lst: smallvec::SmallVec<[u8; 4]>,
}
```