### PR TITLE
Specify precise dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ all-features = true
 members = ["jomini_derive"]
 
 [dependencies]
-serde = { version = "1", optional = true }
-serde_json = { version = "1", optional = true }
+serde = { version = "1.0.195", optional = true }
+serde_json = { version = "1.0.114", optional = true }
 jomini_derive = { path = "jomini_derive", version = "^0.2.5", optional = true }
 itoa = { version = "1.0", optional = true }
 
@@ -32,10 +32,10 @@ faster_writer = ["dep:itoa"]
 [dev-dependencies]
 attohttpc = { version = "0.28", features = ["tls-vendored"] }
 encoding_rs = "0.8"
-criterion = "< 0.4"
+criterion = "0.3.6"
 quickcheck = "1"
 quickcheck_macros = "1"
-flate2 = "1"
+flate2 = "1.0.28"
 serde_with = "3.8.1"
 rstest = "0.19.0"
 

--- a/jomini_derive/Cargo.toml
+++ b/jomini_derive/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["serde", "deserialization"]
 proc-macro = true
 
 [dev-dependencies]
-trybuild = { version = "1.0", features = ["diff"] }
-serde = "1"
-serde_json = "1"
+trybuild = { version = "1.0.104", features = ["diff"] }
+serde = "1.0.195"
+serde_json = "1.0.114"
 smallvec = { version = "1.13", features = ["serde", "union"] }
 
 [dependencies]
-syn = { version = "2.0.81", features = ["derive"] }
-quote = "1"
+syn = { version = "2.0.50", features = ["derive"] }
+quote = "1.0.34"


### PR DESCRIPTION
Specified dependencies to versions that are ~1 year old and verified everything passed with.

```
cargo minimal-versions test --all --all-features
```