### PR TITLE
Add descriptive errors to JominiDeserialize derive macro

### DIFF
--- a/jomini_derive/tests/compile-fail/duplicated_and_take_last.rs
+++ b/jomini_derive/tests/compile-fail/duplicated_and_take_last.rs
@@ -1,0 +1,10 @@
+#[allow(dead_code)]
+use jomini_derive::JominiDeserialize;
+
+#[derive(JominiDeserialize)]
+pub struct Model {
+    #[jomini(duplicated, take_last)]
+    field: Vec<String>,
+}
+
+fn main() {}

--- a/jomini_derive/tests/compile-fail/duplicated_and_take_last.stderr
+++ b/jomini_derive/tests/compile-fail/duplicated_and_take_last.stderr
@@ -1,0 +1,5 @@
+error: Cannot have both duplicated and take_last attributes on a field
+ --> tests/compile-fail/duplicated_and_take_last.rs:7:5
+  |
+7 |     field: Vec<String>,
+  |     ^^^^^

--- a/jomini_derive/tests/compile-fail/duplicated_non_vec.rs
+++ b/jomini_derive/tests/compile-fail/duplicated_non_vec.rs
@@ -1,0 +1,10 @@
+#[allow(dead_code)]
+use jomini_derive::JominiDeserialize;
+
+#[derive(JominiDeserialize)]
+pub struct Model {
+    #[jomini(duplicated)]
+    field: u32,
+}
+
+fn main() {}

--- a/jomini_derive/tests/compile-fail/duplicated_non_vec.stderr
+++ b/jomini_derive/tests/compile-fail/duplicated_non_vec.stderr
@@ -1,0 +1,7 @@
+error: expected angle bracketed arguments
+ --> tests/compile-fail/duplicated_non_vec.rs:4:10
+  |
+4 | #[derive(JominiDeserialize)]
+  |          ^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `JominiDeserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/jomini_derive/tests/compile-fail/enum_type.rs
+++ b/jomini_derive/tests/compile-fail/enum_type.rs
@@ -1,0 +1,10 @@
+#[allow(dead_code)]
+use jomini_derive::JominiDeserialize;
+
+#[derive(JominiDeserialize)]
+pub enum Model {
+    A,
+    B,
+}
+
+fn main() {}

--- a/jomini_derive/tests/compile-fail/enum_type.stderr
+++ b/jomini_derive/tests/compile-fail/enum_type.stderr
@@ -1,0 +1,5 @@
+error: Expected struct
+ --> tests/compile-fail/enum_type.rs:5:10
+  |
+5 | pub enum Model {
+  |          ^^^^^

--- a/jomini_derive/tests/compile-fail/invalid_token_value.rs
+++ b/jomini_derive/tests/compile-fail/invalid_token_value.rs
@@ -1,0 +1,10 @@
+#[allow(dead_code)]
+use jomini_derive::JominiDeserialize;
+
+#[derive(JominiDeserialize)]
+pub struct Model {
+    #[jomini(token = "not-a-number")]
+    field: String,
+}
+
+fn main() {}

--- a/jomini_derive/tests/compile-fail/invalid_token_value.stderr
+++ b/jomini_derive/tests/compile-fail/invalid_token_value.stderr
@@ -1,0 +1,5 @@
+error: Failed to parse jomini attribute: expected integer literal
+ --> tests/compile-fail/invalid_token_value.rs:7:5
+  |
+7 |     field: String,
+  |     ^^^^^

--- a/jomini_derive/tests/compile-fail/tokens.stderr
+++ b/jomini_derive/tests/compile-fail/tokens.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> tests/compile-fail/tokens.rs:4:10
+error: Model does not have #[jomini(token = x)] defined for all fields
+ --> tests/compile-fail/tokens.rs:5:12
   |
-4 | #[derive(JominiDeserialize)]
-  |          ^^^^^^^^^^^^^^^^^
-  |
-  = help: message: Model does not have #[jomini(token = x)] defined for all fields
+5 | pub struct Model {
+  |            ^^^^^

--- a/jomini_derive/tests/compile-fail/unnamed_fields.rs
+++ b/jomini_derive/tests/compile-fail/unnamed_fields.rs
@@ -1,0 +1,7 @@
+#[allow(dead_code)]
+use jomini_derive::JominiDeserialize;
+
+#[derive(JominiDeserialize)]
+pub struct Model(u32, String);
+
+fn main() {}

--- a/jomini_derive/tests/compile-fail/unnamed_fields.stderr
+++ b/jomini_derive/tests/compile-fail/unnamed_fields.stderr
@@ -1,0 +1,5 @@
+error: Expected named fields
+ --> tests/compile-fail/unnamed_fields.rs:5:12
+  |
+5 | pub struct Model(u32, String);
+  |            ^^^^^


### PR DESCRIPTION
Instead of panicking, it is much better to show a descriptive error of what exactly went wrong with the macro -- especially for structs that may have a 100 fields, highlighting the problem field in question is huge.