### PR TITLE
Designate BufferWindow as an internal API

### DIFF
--- a/src/binary/reader.rs
+++ b/src/binary/reader.rs
@@ -100,9 +100,7 @@ where
             }
         }
 
-        let input = unsafe { std::slice::from_raw_parts(self.buf.start, bytes) };
-        self.buf.advance(bytes);
-        Ok(input)
+        Ok(self.buf.split(bytes))
     }
 
     /// Advance through the containing block until the closing token is consumed
@@ -123,8 +121,7 @@ where
     pub fn skip_container(&mut self) -> Result<(), ReaderError> {
         let mut depth = 1;
         loop {
-            let mut window =
-                unsafe { std::slice::from_raw_parts(self.buf.start, self.buf.window_len()) };
+            let mut window = self.buf.window();
             while let Ok((id, data)) = read_id(window) {
                 match id {
                     LexemeId::CLOSE => {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -2,16 +2,16 @@ use crate::Scalar;
 use std::{io::Read, ops::Range};
 
 #[derive(Debug)]
-pub struct BufferWindow {
-    pub buf: Box<[u8]>,
+pub(crate) struct BufferWindow {
+    pub(crate) buf: Box<[u8]>,
 
     start_buf: *const u8,
 
     // start of window into buffer
-    pub start: *const u8,
+    pub(crate) start: *const u8,
 
     // end of window into buffer
-    pub end: *const u8,
+    pub(crate) end: *const u8,
 
     // number of consumed bytes from prior reads
     pub prior_reads: usize,
@@ -108,6 +108,14 @@ impl BufferWindow {
             }
             Err(e) => Err(BufferError::Io(e)),
         }
+    }
+
+    #[inline]
+    pub fn split(&mut self, amt: usize) -> &[u8] {
+        let amt = amt.min(self.window_len());
+        let window = unsafe { std::slice::from_raw_parts(self.start, amt) };
+        self.start = unsafe { self.start.add(amt) };
+        window
     }
 }
 

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -517,9 +517,7 @@ where
             }
         }
 
-        let input = unsafe { std::slice::from_raw_parts(self.buf.start, bytes) };
-        self.buf.advance(bytes);
-        Ok(input)
+        Ok(self.buf.split(bytes))
     }
 
     /// Advance through the containing block until the closing token is consumed


### PR DESCRIPTION
Make it explicit that the fields are internal. Closes #178

The fields could be made private if they were replicated onto the binary and text readers but that seems like a sub-optimal solution 😉 

Miri provides enough of a safety blanket for me.