### PR TITLE
Add `TextTape::from(Vec<TextToken>, bool)` for Tape construction after token manipulation.

### DIFF
--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -419,6 +419,13 @@ impl<'a> TextTape<'a> {
         TextTapeParser
     }
 
+    // Creates a TextTape from a vector of tokens.
+    pub fn from(tokens: Vec<TextToken>, has_bom: bool) -> TextTape<'_> {
+        TextTape {
+            utf8_bom: has_bom,
+            token_tape: tokens
+        }
+    }
     /// Return the parsed tokens
     pub fn tokens(&self) -> &[TextToken<'a>] {
         self.token_tape.as_slice()


### PR DESCRIPTION
Currently, there is no way to reconstruct a Tape after performing raw token manipulation.
A use case (which is what I have in a project I'm working on) is parsing scripted_variables files and replacing their reference tokens on, say, technologies with their actual values.