### PR TITLE
Add tape parsing and json support for object template syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 assets/saves
+.vscode


### PR DESCRIPTION
Previously when an "=" was encountered, it was assumed the key was a simple scalar value (and fail it otherwise). This should not be the case with the following valid syntax.

```
obj={
    { a = b }={ 1 2 3 }
    { c = d f=g }={ 10 }
}
```

I'm colloquially calling this the object template syntax as `{ a = b }` is getting applied to a list of identifiers.  It's a neat way to save on space. Instead of duplicating all the properties for each identifier, they only need to be specified once.

I still want to keep the ergonomic of keys being scalars, so the code now treats `obj` as an array that is to be processed in chunks of two. So the json gets output as

```json
{"obj":[{"a":"b"},[1,2,3], {"c":"d","f":"g"}, [10]]}
```


Variations of this syntax is supported:

```
obj={ { a=b }=16 }
```