### PR TITLE
Treat semicolons as equivalent to whitespace

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -65,6 +65,7 @@ const fn create_character_class_table() -> [u8; 256] {
     table[b' ' as usize] = 1;
     table[b'!' as usize] = 1;
     table[b'#' as usize] = 1;
+    table[b';' as usize] = 1;
     table[b'<' as usize] = 1;
     table[b'=' as usize] = 1;
     table[b'>' as usize] = 1;

--- a/src/text/dom.rs
+++ b/src/text/dom.rs
@@ -1443,7 +1443,7 @@ mod tests {
         assert_eq!(array.len(), 2);
 
         let mut values = array.values();
-        
+
         // First value should be the template object { a = b }
         let template = values.next().unwrap();
         let template_obj = template.read_object().unwrap();
@@ -1479,7 +1479,7 @@ mod tests {
         assert_eq!(array.len(), 2);
 
         let mut values = array.values();
-        
+
         // First value should be the template array { foo }
         let template = values.next().unwrap();
         let template_arr = template.read_array().unwrap();
@@ -1512,7 +1512,7 @@ mod tests {
         assert_eq!(array.len(), 2);
 
         let mut values = array.values();
-        
+
         // First value should be the template object { a = b }
         let template = values.next().unwrap();
         let template_obj = template.read_object().unwrap();
@@ -1542,7 +1542,7 @@ mod tests {
         assert_eq!(array.len(), 4); // 2 template-value pairs = 4 elements
 
         let mut values = array.values();
-        
+
         // First template-value pair
         let template1 = values.next().unwrap();
         let template1_obj = template1.read_object().unwrap();
@@ -1571,7 +1571,8 @@ mod tests {
 
     #[test]
     fn test_object_template_complex_dom_reader() {
-        let data = br"config={ { debug=yes logging=verbose }={ output_file=debug.log level=trace } }";
+        let data =
+            br"config={ { debug=yes logging=verbose }={ output_file=debug.log level=trace } }";
         let tape = TextTape::from_slice(data).unwrap();
         let reader = tape.windows1252_reader();
 
@@ -1583,12 +1584,12 @@ mod tests {
         assert_eq!(array.len(), 2);
 
         let mut values = array.values();
-        
+
         // First value should be the template object with multiple fields
         let template = values.next().unwrap();
         let template_obj = template.read_object().unwrap();
         assert_eq!(template_obj.fields_len(), 2);
-        
+
         let mut template_groups = template_obj.field_groups();
         let (debug_key, debug_group) = template_groups.next().unwrap();
         assert_eq!(debug_key.read_str(), "debug");
@@ -1607,7 +1608,7 @@ mod tests {
         let values_obj = values.next().unwrap();
         let values_object = values_obj.read_object().unwrap();
         assert_eq!(values_object.fields_len(), 2);
-        
+
         let mut values_groups = values_object.field_groups();
         let (output_key, output_group) = values_groups.next().unwrap();
         assert_eq!(output_key.read_str(), "output_file");

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -1113,6 +1113,30 @@ mod test {
         Token::Operator(Operator::Equal),
         Token::Unquoted(Scalar::new(b"b")),
     ])]
+    // test_semicolon_as_whitespace
+    #[case(b"foo = 0.3;", &[
+        Token::Unquoted(Scalar::new(b"foo")),
+        Token::Operator(Operator::Equal),
+        Token::Unquoted(Scalar::new(b"0.3")),
+    ])]
+    // test_multiple_semicolons_as_whitespace
+    #[case(b"a = 1; b = 2;; c = 3;", &[
+        Token::Unquoted(Scalar::new(b"a")),
+        Token::Operator(Operator::Equal),
+        Token::Unquoted(Scalar::new(b"1")),
+        Token::Unquoted(Scalar::new(b"b")),
+        Token::Operator(Operator::Equal),
+        Token::Unquoted(Scalar::new(b"2")),
+        Token::Unquoted(Scalar::new(b"c")),
+        Token::Operator(Operator::Equal),
+        Token::Unquoted(Scalar::new(b"3")),
+    ])]
+    // test_consecutive_semicolons
+    #[case(b";;;key = value;;;", &[
+        Token::Unquoted(Scalar::new(b"key")),
+        Token::Operator(Operator::Equal),
+        Token::Unquoted(Scalar::new(b"value")),
+    ])]
     fn test_input(#[case] input: &[u8], #[case] expected: &[Token]) {
         let mut reader = TokenReader::new(input);
         for (i, e) in expected.iter().enumerate() {

--- a/src/text/tape.rs
+++ b/src/text/tape.rs
@@ -349,6 +349,7 @@ fn split_at_scalar(d: &[u8]) -> (Scalar, &[u8]) {
         // sp = 0x20
         //  ! = 0x21 *
         //  # = 0x23
+        //  ; = 0x3b
         //  < = 0x3c
         //  = = 0x3d
         //  > = 0x3e
@@ -369,20 +370,22 @@ fn split_at_scalar(d: &[u8]) -> (Scalar, &[u8]) {
             result = _mm_or_si128(result, t3);
             let t4 = _mm_cmpeq_epi8(input, _mm_set1_epi8(35));
             result = _mm_or_si128(result, t4);
-            let t5 = _mm_cmpeq_epi8(input, _mm_set1_epi8(60));
+            let t5 = _mm_cmpeq_epi8(input, _mm_set1_epi8(59));
             result = _mm_or_si128(result, t5);
-            let t6 = _mm_cmpeq_epi8(input, _mm_set1_epi8(61));
+            let t6 = _mm_cmpeq_epi8(input, _mm_set1_epi8(60));
             result = _mm_or_si128(result, t6);
-            let t7 = _mm_cmpeq_epi8(input, _mm_set1_epi8(62));
+            let t7 = _mm_cmpeq_epi8(input, _mm_set1_epi8(61));
             result = _mm_or_si128(result, t7);
-            let t8 = _mm_cmpeq_epi8(input, _mm_set1_epi8(123));
+            let t8 = _mm_cmpeq_epi8(input, _mm_set1_epi8(62));
             result = _mm_or_si128(result, t8);
-            let t9 = _mm_cmpeq_epi8(input, _mm_set1_epi8(125));
+            let t9 = _mm_cmpeq_epi8(input, _mm_set1_epi8(123));
             result = _mm_or_si128(result, t9);
-            let t10 = _mm_cmpeq_epi8(input, _mm_set1_epi8(91));
+            let t10 = _mm_cmpeq_epi8(input, _mm_set1_epi8(125));
             result = _mm_or_si128(result, t10);
-            let t11 = _mm_cmpeq_epi8(input, _mm_set1_epi8(93));
+            let t11 = _mm_cmpeq_epi8(input, _mm_set1_epi8(91));
             result = _mm_or_si128(result, t11);
+            let t12 = _mm_cmpeq_epi8(input, _mm_set1_epi8(93));
+            result = _mm_or_si128(result, t12);
 
             let found_mask = _mm_movemask_epi8(result);
             if found_mask != 0 {
@@ -2897,6 +2900,36 @@ mod tests {
                 TextToken::End(7),
                 TextToken::Unquoted(Scalar::new(b"18")),
                 TextToken::End(1)
+            ]
+        );
+    }
+
+    #[test]
+    fn test_semicolon_as_whitespace() {
+        let data = b"foo = 0.3;";
+        let tape = TextTape::from_slice(&data[..]).unwrap();
+        assert_eq!(
+            tape.tokens(),
+            vec![
+                TextToken::Unquoted(Scalar::new(b"foo")),
+                TextToken::Unquoted(Scalar::new(b"0.3")),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_multiple_semicolons_as_whitespace() {
+        let data = b"a = 1; b = 2;; c = 3;";
+        let tape = TextTape::from_slice(&data[..]).unwrap();
+        assert_eq!(
+            tape.tokens(),
+            vec![
+                TextToken::Unquoted(Scalar::new(b"a")),
+                TextToken::Unquoted(Scalar::new(b"1")),
+                TextToken::Unquoted(Scalar::new(b"b")),
+                TextToken::Unquoted(Scalar::new(b"2")),
+                TextToken::Unquoted(Scalar::new(b"c")),
+                TextToken::Unquoted(Scalar::new(b"3")),
             ]
         );
     }


### PR DESCRIPTION
semicolons should be boundary characters as they can be found in vic3 files:

```
SOMETHING = 3;
```