### PR TITLE
Omit rgb header when deserializing binary colors

### DIFF
--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -2574,32 +2574,8 @@ mod tests {
             where
                 D: Deserializer<'de>,
             {
-                struct ColorVisitor;
-
-                impl<'de> Visitor<'de> for ColorVisitor {
-                    type Value = Color;
-
-                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                        formatter.write_str("a color")
-                    }
-
-                    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-                    where
-                        A: de::SeqAccess<'de>,
-                    {
-                        let ty = seq.next_element::<&str>()?.expect("value type");
-                        match ty {
-                            "rgb" => {
-                                let (red, green, blue) =
-                                    seq.next_element::<(u8, u8, u8)>()?.expect("rgb channels");
-                                Ok(Color { red, green, blue })
-                            }
-                            _ => panic!("unexpected color type"),
-                        }
-                    }
-                }
-
-                deserializer.deserialize_seq(ColorVisitor)
+                let [red, green, blue]: [u8; 3] = Deserialize::deserialize(deserializer)?;
+                Ok(Color { red, green, blue })
             }
         }
     }
@@ -2619,13 +2595,13 @@ mod tests {
         assert_eq!(
             actual,
             MyStruct {
-                color: (String::from("rgb"), (110, 27, 27, 28))
+                color: (110, 27, 27, 28)
             }
         );
 
         #[derive(Deserialize, Debug, PartialEq)]
         struct MyStruct {
-            color: (String, (u8, u8, u8, u8)),
+            color: (u8, u8, u8, u8),
         }
     }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -12,55 +12,6 @@ impl ColorSequence {
     pub(crate) fn new(data: Rgb) -> Self {
         ColorSequence { data, idx: 0 }
     }
-}
-
-impl<'de> de::Deserializer<'de> for &'_ mut ColorSequence {
-    type Error = Error;
-
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if self.idx == 1 {
-            visitor.visit_borrowed_str("rgb")
-        } else {
-            visitor.visit_seq(InnerColorSequence::new(self.data))
-        }
-    }
-
-    serde::forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
-        tuple_struct map struct enum identifier ignored_any
-    }
-}
-
-impl<'de> SeqAccess<'de> for ColorSequence {
-    type Error = Error;
-
-    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
-    where
-        T: DeserializeSeed<'de>,
-    {
-        if self.idx >= 2 {
-            Ok(None)
-        } else {
-            self.idx += 1;
-            seed.deserialize(self).map(Some)
-        }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct InnerColorSequence {
-    data: Rgb,
-    idx: usize,
-}
-
-impl InnerColorSequence {
-    pub(crate) fn new(data: Rgb) -> Self {
-        InnerColorSequence { data, idx: 0 }
-    }
 
     fn val(&self) -> u32 {
         match self.idx {
@@ -73,7 +24,7 @@ impl InnerColorSequence {
     }
 }
 
-impl<'de> de::Deserializer<'de> for &'_ mut InnerColorSequence {
+impl<'de> de::Deserializer<'de> for &'_ mut ColorSequence {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -90,7 +41,7 @@ impl<'de> de::Deserializer<'de> for &'_ mut InnerColorSequence {
     }
 }
 
-impl<'de> SeqAccess<'de> for InnerColorSequence {
+impl<'de> SeqAccess<'de> for ColorSequence {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -5,7 +5,7 @@ use jomini::{
     Windows1252Encoding,
 };
 use serde::{
-    de::{self, Visitor},
+    de::{self},
     Deserialize, Deserializer,
 };
 use std::collections::HashMap;
@@ -37,17 +37,10 @@ impl Encoding for BinaryTestFlavor {
 }
 
 #[test]
-fn same_deserializer_for_header_token() {
+fn unified_rgb_deserializer() {
     #[derive(Deserialize, Debug, PartialEq)]
     struct MyStruct {
-        color: Color,
-    }
-
-    #[derive(Debug, PartialEq)]
-    struct Color {
-        red: u8,
-        blue: u8,
-        green: u8,
+        color: [u8; 3],
     }
 
     let bin_data = [
@@ -58,7 +51,7 @@ fn same_deserializer_for_header_token() {
     let mut map = HashMap::new();
     map.insert(0x053a, "color");
 
-    let txt_data = b"color = rgb { 110 27 27 }";
+    let txt_data = b"color = { 110 27 27 }";
 
     let bin_out: MyStruct = BinaryDeserializer::builder_flavor(BinaryTestFlavor)
         .deserialize_slice(&bin_data[..], &map)
@@ -68,47 +61,9 @@ fn same_deserializer_for_header_token() {
     assert_eq!(
         bin_out,
         MyStruct {
-            color: Color {
-                red: 110,
-                blue: 27,
-                green: 27,
-            }
+            color: [110, 27, 27]
         }
     );
-
-    impl<'de> Deserialize<'de> for Color {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            struct ColorVisitor;
-
-            impl<'de> Visitor<'de> for ColorVisitor {
-                type Value = Color;
-
-                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    formatter.write_str("a color")
-                }
-
-                fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-                where
-                    A: de::SeqAccess<'de>,
-                {
-                    let ty = seq.next_element::<&str>()?.expect("value type");
-                    match ty {
-                        "rgb" => {
-                            let (red, green, blue) =
-                                seq.next_element::<(u8, u8, u8)>()?.expect("rgb channels");
-                            Ok(Color { red, green, blue })
-                        }
-                        _ => panic!("unexpected color type"),
-                    }
-                }
-            }
-
-            deserializer.deserialize_seq(ColorVisitor)
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
Closes #197 

Description copied from 197:

---

In saves, there can be rgb color data and the text will look like:

```
color={ 100 0 0 }
```

The transliteration of the binary format would be:

```
color = rgb { 100 0 0 }
```

This is why in commit fc3e63b rgb data is deserialized as a 3 item sequence so that one could just use `[0u8; 3]` for both formats (and using the same backing datatype for both formats is critical when you are deserializing thousands of fields).

However this was changed in commit 39c3a2d, to support differentiating containers with different headers that can be used in text game formats: 

```
color = rgb { 100 0 0 }
color2 = hsv { 0.43 0.86 0.61 }
```

It is understandably desirable to be able to have "color" and "color2" deserialize to the same enum that allows storage of rgb or hsv values so the enum needs to be visited by some enum tag identifier -- hence why that commit changed the deserialization logic to visit the header first and then the sequence.

But this now impacts rgb binary data, which formally contains the "rgb" header. Thus when deserializing save data and working with rgb data, one needs onerous deserialization logic (ie: is the first element a number or the "rgb" header, and branch accordingly).

Since the binary rgb data only appears in save files, and the "rgb" header is omitted in text save files, it seems prudent to revert the binary deserializer to directly emitting 3 elements to ease sharing of save file deserialization. The support for generic tokens headers in the text format can remain.  

This is a breaking change