### PR TITLE
Separate serde deserializers from derive macro

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,6 +70,8 @@ jobs:
       run: ${{ env.CARGO }} test --no-default-features --all --verbose $TARGET
     - name: Run json tests
       run: ${{ env.CARGO }} test --features json --all --verbose $TARGET
+    - name: Run serde-only tests (no derive macros)
+      run: ${{ env.CARGO }} test --no-default-features --features serde --all --verbose $TARGET
 
     - name: Compile benchmarks
       if: matrix.build == 'stable'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,15 @@ all-features = true
 members = ["jomini_derive"]
 
 [dependencies]
-serde = { version = "1.0.195", optional = true }
+serde = { version = "1.0.195", optional = true, default-features = false }
 serde_json = { version = "1.0.114", optional = true }
 jomini_derive = { path = "jomini_derive", version = "^0.3.0", optional = true }
 itoa = { version = "1.0", optional = true }
 
 [features]
 default = ["derive", "faster_writer"]
-derive = ["serde/derive", "jomini_derive"]
+serde = ["dep:serde"]
+derive = ["serde", "jomini_derive"]
 json = ["serde", "serde_json"]
 faster_writer = ["dep:itoa"]
 

--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -1170,6 +1170,8 @@ impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::VariantAccess<'de>
 /// The example below demonstrates how to deserialize data
 ///
 /// ```
+/// # #[cfg(feature = "derive")] {
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use jomini::{Encoding, JominiDeserialize, Windows1252Encoding, BinaryDeserializer};
 /// use serde::Deserialize;
 /// use std::{borrow::Cow, collections::HashMap};
@@ -1216,7 +1218,9 @@ impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::VariantAccess<'de>
 ///   field2: 89,
 /// });
 ///
-/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # Ok(())
+/// # }
+/// # }
 /// ```
 ///
 /// Build a tweaked binary deserializer
@@ -1334,7 +1338,7 @@ struct BinaryConfig<'res, RES, F> {
     flavor: F,
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "derive"))]
 mod tests {
     use super::*;
     use crate::common::{Date, DateHour};

--- a/src/binary/flavor.rs
+++ b/src/binary/flavor.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "derive")]
+#[cfg(feature = "serde")]
 use crate::{
     binary::{de::BinaryDeserializerBuilder, TokenResolver},
     Error,
@@ -16,7 +16,7 @@ pub trait BinaryFlavor: crate::Encoding {
     fn visit_f64(&self, data: [u8; 8]) -> f64;
 
     /// Create binary deserializer from this binary flavor
-    #[cfg(feature = "derive")]
+    #[cfg(feature = "serde")]
     fn deserializer(&self) -> BinaryDeserializerBuilder<&Self>
     where
         Self: Sized,
@@ -25,7 +25,7 @@ pub trait BinaryFlavor: crate::Encoding {
     }
 
     /// Deserialize value from slice of data with this binary flavor
-    #[cfg(feature = "derive")]
+    #[cfg(feature = "serde")]
     fn deserialize_slice<'de, 'res: 'de, T, RES>(
         &self,
         data: &'de [u8],
@@ -40,7 +40,7 @@ pub trait BinaryFlavor: crate::Encoding {
     }
 
     /// Deserialize value from stream of data with this binary flavor
-    #[cfg(feature = "derive")]
+    #[cfg(feature = "serde")]
     fn deserialize_reader<T, RES, R>(&self, reader: R, resolver: &RES) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned,

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -66,9 +66,9 @@
 //! - If the `token` attribute is specified on one field on a struct, it must be specified on all fields of that struct.
 
 /// binary deserialization
-#[cfg(feature = "derive")]
+#[cfg(feature = "serde")]
 pub mod de;
-#[cfg(feature = "derive")]
+#[cfg(feature = "serde")]
 pub use self::de::{BinaryDeserializer, BinaryDeserializerBuilder};
 
 mod flavor;

--- a/src/common/date.rs
+++ b/src/common/date.rs
@@ -1148,7 +1148,7 @@ fn to_binary(year: i16, ordinal_day: i32, hour: u8) -> i32 {
     (year_part + ordinal_day) * 24 + hour
 }
 
-#[cfg(feature = "derive")]
+#[cfg(feature = "serde")]
 mod datederive {
     use super::{Date, DateHour, PdsDate, UniformDate};
     use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
@@ -1289,7 +1289,7 @@ mod datederive {
     }
 }
 
-#[cfg(not(feature = "derive"))]
+#[cfg(not(feature = "serde"))]
 mod datederive {}
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ pub mod binary;
 pub(crate) mod buffer;
 pub mod common;
 mod data;
-#[cfg(feature = "derive")]
+#[cfg(feature = "serde")]
 pub(crate) mod de;
 mod encoding;
 mod errors;
@@ -296,7 +296,7 @@ pub use self::scalar::{Scalar, ScalarError};
 #[doc(inline)]
 pub use self::text::{TextTape, TextToken, TextWriter, TextWriterBuilder};
 
-#[cfg(feature = "derive")]
+#[cfg(feature = "serde")]
 #[doc(inline)]
 pub use self::{binary::de::BinaryDeserializer, text::de::TextDeserializer};
 #[cfg(feature = "derive")]

--- a/src/text/de.rs
+++ b/src/text/de.rs
@@ -17,6 +17,8 @@ use std::{
 /// preserve operators.
 ///
 /// ```
+/// # #[cfg(feature = "derive")] {
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use jomini::{
 ///     text::{Operator, Property},
 ///     JominiDeserialize, TextDeserializer,
@@ -47,7 +49,9 @@ use std::{
 /// struct MyStruct {
 ///     modifier: Modifier,
 /// }
-/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # Ok(())
+/// # }
+/// # }
 /// ```
 #[derive(serde::Deserialize)]
 #[serde(rename = "_internal_jomini_property")]
@@ -1745,7 +1749,7 @@ impl<'de> de::Deserializer<'de> for OperatorDeserializer {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "derive"))]
 mod tests {
     use super::*;
     use crate::common::{Date, DateHour, UniformDate};

--- a/src/text/dom.rs
+++ b/src/text/dom.rs
@@ -598,7 +598,7 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(feature = "derive")]
+    #[cfg(feature = "serde")]
     pub fn deserialize<T>(&self) -> Result<T, crate::Error>
     where
         T: serde::Deserialize<'data>,
@@ -681,7 +681,7 @@ impl<'data, E> ValueReader<'data, '_, E> {
         &self.tokens[self.value_ind]
     }
 
-    #[cfg(feature = "derive")]
+    #[cfg(feature = "serde")]
     pub(crate) fn next(&mut self) -> Option<&TextToken<'data>> {
         self.value_ind += 1;
         self.tokens.get(self.value_ind)

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -21,7 +21,7 @@
 //! - [ValuesIter]
 
 /// text deserialization
-#[cfg(feature = "derive")]
+#[cfg(feature = "serde")]
 pub mod de;
 mod dom;
 mod fnv;
@@ -30,7 +30,7 @@ mod reader;
 mod tape;
 mod writer;
 
-#[cfg(feature = "derive")]
+#[cfg(feature = "serde")]
 #[doc(inline)]
 pub use self::de::Property;
 pub use self::dom::{

--- a/src/text/operator.rs
+++ b/src/text/operator.rs
@@ -91,7 +91,7 @@ impl Operator {
     }
 }
 
-#[cfg(feature = "derive")]
+#[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Operator {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where


### PR DESCRIPTION
Add new `serde` feature to enable jomini deserializers without heavyweight proc-macro dependencies brought in by `jomini_derive` like `syn`. This allows downstream libraries to use hand-crafted `Deserialize` implementations with minimal dependencies.