### PR TITLE
Remove repeated "deserialize error:" prefix from serde error chain

### DIFF
--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -38,9 +38,9 @@ impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor, R: Read> de::Deseriali
         V: Visitor<'de>,
     {
         Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from(
+            kind: DeserializeErrorKind::Unsupported(
                 "root deserializer can only work with key value pairs",
-            )),
+            ),
         }))
     }
 
@@ -591,9 +591,9 @@ impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor, R> de::VariantAccess<'
         T: DeserializeSeed<'de>,
     {
         Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from(
+            kind: DeserializeErrorKind::Unsupported(
                 "unsupported enum deserialization. Please file issue",
-            )),
+            ),
         }))
     }
 
@@ -602,9 +602,9 @@ impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor, R> de::VariantAccess<'
         V: Visitor<'de>,
     {
         Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from(
+            kind: DeserializeErrorKind::Unsupported(
                 "unsupported enum deserialization. Please file issue",
-            )),
+            ),
         }))
     }
 
@@ -617,9 +617,9 @@ impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor, R> de::VariantAccess<'
         V: Visitor<'de>,
     {
         Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from(
+            kind: DeserializeErrorKind::Unsupported(
                 "unsupported enum deserialization. Please file issue",
-            )),
+            ),
         }))
     }
 }
@@ -650,9 +650,9 @@ impl<'de, RES: TokenResolver, F: BinaryFlavor> de::Deserializer<'de>
         V: Visitor<'de>,
     {
         Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from(
+            kind: DeserializeErrorKind::Unsupported(
                 "root deserializer can only work with key value pairs",
-            )),
+            ),
         }))
     }
 
@@ -1197,9 +1197,9 @@ impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::VariantAccess<'de>
         T: DeserializeSeed<'de>,
     {
         Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from(
+            kind: DeserializeErrorKind::Unsupported(
                 "unsupported enum deserialization. Please file issue",
-            )),
+            ),
         }))
     }
 
@@ -1208,9 +1208,9 @@ impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::VariantAccess<'de>
         V: Visitor<'de>,
     {
         Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from(
+            kind: DeserializeErrorKind::Unsupported(
                 "unsupported enum deserialization. Please file issue",
-            )),
+            ),
         }))
     }
 
@@ -1223,9 +1223,9 @@ impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::VariantAccess<'de>
         V: Visitor<'de>,
     {
         Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from(
+            kind: DeserializeErrorKind::Unsupported(
                 "unsupported enum deserialization. Please file issue",
-            )),
+            ),
         }))
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -31,6 +31,14 @@ impl Error {
         })
     }
 
+    pub(crate) fn deserialize(kind: DeserializeErrorKind) -> Self {
+        Self::new(ErrorKind::Deserialize(DeserializeError { kind }))
+    }
+
+    pub(crate) fn deserialize_msg(msg: impl Into<Box<str>>) -> Self {
+        Self::deserialize(DeserializeErrorKind::Message(msg.into()))
+    }
+
     /// Return the specific type of error
     pub fn kind(&self) -> &ErrorKind {
         &self.0
@@ -126,7 +134,7 @@ impl std::fmt::Display for Error {
                 "invalid syntax encountered: {} (offset: {})",
                 msg, offset
             ),
-            ErrorKind::Deserialize(ref err) => write!(f, "deserialize error: {}", err),
+            ErrorKind::Deserialize(ref err) => err.fmt(f),
             ErrorKind::Io(ref err) => write!(f, "io error: {}", err),
             ErrorKind::BufferFull => {
                 write!(f, "max buffer size exceeded")
@@ -194,10 +202,10 @@ impl DeserializeError {
 #[derive(Debug, PartialEq)]
 pub enum DeserializeErrorKind {
     /// A generic Serde deserialization error
-    Message(String),
+    Message(Box<str>),
 
     /// Requested serde operation is unsupported
-    Unsupported(String),
+    Unsupported(&'static str),
 
     /// Error converting underlying data to desired format
     Scalar(ScalarError),
@@ -222,7 +230,7 @@ impl std::fmt::Display for DeserializeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.kind {
             DeserializeErrorKind::Message(ref msg) => write!(f, "{}", msg),
-            DeserializeErrorKind::Unsupported(ref msg) => {
+            DeserializeErrorKind::Unsupported(msg) => {
                 write!(f, "unsupported deserializer method: {}", msg)
             }
             DeserializeErrorKind::Scalar(ref e) => e.fmt(f),
@@ -236,9 +244,7 @@ impl std::fmt::Display for DeserializeError {
 #[cfg(feature = "serde")]
 impl serde::de::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        Error::new(ErrorKind::Deserialize(DeserializeError {
-            kind: DeserializeErrorKind::Message(msg.to_string()),
-        }))
+        Error::deserialize_msg(msg.to_string())
     }
 }
 
@@ -246,7 +252,7 @@ impl serde::de::Error for Error {
 impl serde::de::Error for DeserializeError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
         DeserializeError {
-            kind: DeserializeErrorKind::Message(msg.to_string()),
+            kind: DeserializeErrorKind::Message(msg.to_string().into_boxed_str()),
         }
     }
 }
@@ -259,9 +265,7 @@ impl From<std::io::Error> for Error {
 
 impl From<ScalarError> for Error {
     fn from(error: ScalarError) -> Self {
-        Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Scalar(error),
-        })
+        Error::deserialize(DeserializeErrorKind::Scalar(error))
     }
 }
 
@@ -272,5 +276,17 @@ mod tests {
     #[test]
     fn test_size_error_struct() {
         assert!(std::mem::size_of::<Error>() <= 8);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_no_duplicate_deserialize_prefix() {
+        use serde::de::Error as _;
+        let inner = Error::custom("io error: something bad");
+        let mid = Error::custom(inner.to_string());
+        let outer = Error::custom(mid.to_string());
+        assert_eq!(inner.to_string(), mid.to_string());
+        assert_eq!(mid.to_string(), outer.to_string());
+        assert_eq!(outer.to_string(), "io error: something bad");
     }
 }

--- a/src/text/de.rs
+++ b/src/text/de.rs
@@ -180,9 +180,9 @@ impl<'de, R: Read, E: Encoding> de::Deserializer<'de> for &'_ mut TextReaderDese
         V: Visitor<'de>,
     {
         Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from(
+            kind: DeserializeErrorKind::Unsupported(
                 "root deserializer can only work with key value pairs",
-            )),
+            ),
         }))
     }
 
@@ -703,9 +703,9 @@ impl<'de, R: Read, E: Encoding> de::VariantAccess<'de> for TextReaderEnum<'_, R,
         T: DeserializeSeed<'de>,
     {
         Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from(
+            kind: DeserializeErrorKind::Unsupported(
                 "unsupported enum deserialization. Please file issue",
-            )),
+            ),
         }))
     }
 
@@ -714,9 +714,9 @@ impl<'de, R: Read, E: Encoding> de::VariantAccess<'de> for TextReaderEnum<'_, R,
         V: Visitor<'de>,
     {
         Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from(
+            kind: DeserializeErrorKind::Unsupported(
                 "unsupported enum deserialization. Please file issue",
-            )),
+            ),
         }))
     }
 
@@ -729,9 +729,9 @@ impl<'de, R: Read, E: Encoding> de::VariantAccess<'de> for TextReaderEnum<'_, R,
         V: Visitor<'de>,
     {
         Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from(
+            kind: DeserializeErrorKind::Unsupported(
                 "unsupported enum deserialization. Please file issue",
-            )),
+            ),
         }))
     }
 }
@@ -966,9 +966,9 @@ where
         V: Visitor<'de>,
     {
         Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from(
+            kind: DeserializeErrorKind::Unsupported(
                 "root deserializer can only work with key value pairs",
-            )),
+            ),
         }))
     }
 
@@ -1166,9 +1166,7 @@ macro_rules! deserialize_any_value {
             TextToken::Array { .. } => $self.deserialize_seq($visitor),
             TextToken::Object { .. } => $self.deserialize_map($visitor),
             _ => Err(Error::from(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from(
-                    "unsupported value reader token",
-                )),
+                kind: DeserializeErrorKind::Unsupported("unsupported value reader token"),
             })),
         }
     };
@@ -1482,7 +1480,7 @@ where
     {
         let err = || {
             Err(Error::from(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from("unexpected reader for enum")),
+                kind: DeserializeErrorKind::Unsupported("unexpected reader for enum"),
             }))
         };
 
@@ -1653,10 +1651,8 @@ where
             .values
             .as_mut()
             .and_then(|x| x.next())
-            .ok_or_else(|| DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from(
-                    "unexpected none for enum variant seed",
-                )),
+            .ok_or(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported("unexpected none for enum variant seed"),
             })?;
 
         Ok(ValueKind::Value(val))

--- a/src/text/dom.rs
+++ b/src/text/dom.rs
@@ -212,7 +212,7 @@ where
             Reader::Scalar(x) => Ok(x.read_str()),
             Reader::Value(x) => x.read_str(),
             _ => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+                kind: DeserializeErrorKind::Unsupported("not a scalar"),
             }),
         }
     }
@@ -224,7 +224,7 @@ where
             Reader::Scalar(x) => Ok(x.read_string()),
             Reader::Value(x) => x.read_string(),
             _ => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+                kind: DeserializeErrorKind::Unsupported("not a scalar"),
             }),
         }
     }
@@ -236,7 +236,7 @@ where
             Reader::Scalar(x) => Ok(x.read_scalar()),
             Reader::Value(x) => x.read_scalar(),
             _ => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+                kind: DeserializeErrorKind::Unsupported("not a scalar"),
             }),
         }
     }
@@ -717,19 +717,17 @@ where
     /// Interpret the current value as string
     #[inline]
     pub fn read_str(&self) -> Result<Cow<'data, str>, DeserializeError> {
-        self.raw_str().ok_or_else(|| DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(String::from("not a string")),
+        self.raw_str().ok_or(DeserializeError {
+            kind: DeserializeErrorKind::Unsupported("not a string"),
         })
     }
 
     /// Interpret the current value as string
     #[inline]
     pub fn read_string(&self) -> Result<String, DeserializeError> {
-        self.raw_str()
-            .map(String::from)
-            .ok_or_else(|| DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from("not a string")),
-            })
+        self.raw_str().map(String::from).ok_or(DeserializeError {
+            kind: DeserializeErrorKind::Unsupported("not a string"),
+        })
     }
 
     /// Interpret the current value as a scalar
@@ -737,8 +735,8 @@ where
     pub fn read_scalar(&self) -> Result<Scalar<'data>, DeserializeError> {
         self.tokens[self.value_ind]
             .as_scalar()
-            .ok_or_else(|| DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from("not a scalar")),
+            .ok_or(DeserializeError {
+                kind: DeserializeErrorKind::Unsupported("not a scalar"),
             })
     }
 
@@ -771,7 +769,7 @@ where
             }),
 
             _ => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from("not an object")),
+                kind: DeserializeErrorKind::Unsupported("not an object"),
             }),
         }
     }
@@ -809,7 +807,7 @@ where
             }),
 
             _ => Err(DeserializeError {
-                kind: DeserializeErrorKind::Unsupported(String::from("not an array")),
+                kind: DeserializeErrorKind::Unsupported("not an array"),
             }),
         }
     }


### PR DESCRIPTION
The prefix was added at every serde boundary crossing (e.g. through erased-serde), causing output like:

```
deserialize error: deserialize error: deserialize error: io error:
```

Breaking change: DeserializeErrorKind is removed, use DeserializeKind.