### PR TITLE
Introduce parser source and adapt binary token reader to it

### DIFF
--- a/bench/src/benchmarks/binary.rs
+++ b/bench/src/benchmarks/binary.rs
@@ -115,8 +115,17 @@ pub(crate) fn deserialize_reader(data: &[u8]) -> Gamestate {
 }
 
 #[inline(never)]
-pub(crate) fn read_compressed_archive(archive: &CorpusArchive) -> Vec<u8> {
-    black_box(corpus::read_archive_to_vec(archive))
+pub(crate) fn read_compressed_archive(archive: &CorpusArchive) -> u64 {
+    corpus::with_archive_reader(archive, |reader| {
+        let mut reader = jomini::binary::TokenReader::new(reader);
+        let mut counter: u64 = 0;
+        while let Ok(Some(token)) = reader.next() {
+            if let jomini::binary::Token::Id(x) = token {
+                counter = counter.wrapping_add(u64::from(x));
+            }
+        }
+        black_box(counter)
+    })
 }
 
 fn setup_eu4() -> &'static [u8] {
@@ -265,7 +274,7 @@ pub mod gungraun_benches {
     #[bench::eu4(setup = setup_eu4_archive)]
     #[bench::v3(setup = setup_vic3_archive)]
     #[bench::ck3(setup = setup_ck3_archive)]
-    fn compressed_read(archive: &CorpusArchive) -> Vec<u8> {
+    fn compressed_read(archive: &CorpusArchive) -> u64 {
         read_compressed_archive(archive)
     }
 

--- a/bench/src/corpus.rs
+++ b/bench/src/corpus.rs
@@ -136,6 +136,27 @@ pub fn bytes(corpus: Corpus) -> CorpusBytes {
 }
 
 pub fn read_archive_to_vec(archive: &CorpusArchive) -> Vec<u8> {
+    with_archive_reader(archive, |reader| {
+        let capacity = archive
+            .uncompressed_size
+            .saturating_sub(archive.header_skip as u64) as usize;
+        let mut output = Vec::with_capacity(capacity);
+        reader
+            .read_to_end(&mut output)
+            .unwrap_or_else(|e| panic!("failed to decompress {}: {e}", archive.corpus));
+        output
+    })
+}
+
+pub fn with_archive_reader<T, F>(archive: &CorpusArchive, f: F) -> T
+where
+    F: FnOnce(
+        &mut rawzip::ZipVerifier<
+            flate2::read::DeflateDecoder<rawzip::ZipReader<&rawzip::FileReader>>,
+            &rawzip::FileReader,
+        >,
+    ) -> T,
+{
     let file = std::fs::File::open(&archive.path).unwrap_or_else(|e| {
         panic!(
             "failed to open corpus archive {} at {}: {e}",
@@ -146,7 +167,7 @@ pub fn read_archive_to_vec(archive: &CorpusArchive) -> Vec<u8> {
     let mut buf = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
     let zip = rawzip::ZipArchive::from_file(file, &mut buf)
         .unwrap_or_else(|e| panic!("failed to read zip archive {}: {e}", archive.corpus));
-    let (wayfinder, compression_method, max_size) = largest_entry(&zip, &mut buf, archive.corpus);
+    let (wayfinder, compression_method, _) = largest_entry(&zip, &mut buf, archive.corpus);
 
     assert_eq!(
         compression_method,
@@ -169,12 +190,7 @@ pub fn read_archive_to_vec(archive: &CorpusArchive) -> Vec<u8> {
         )
     });
 
-    let capacity = max_size.saturating_sub(archive.header_skip as u64) as usize;
-    let mut output = Vec::with_capacity(capacity);
-    reader
-        .read_to_end(&mut output)
-        .unwrap_or_else(|e| panic!("failed to decompress {}: {e}", archive.corpus));
-    output
+    f(&mut reader)
 }
 
 fn fetch_and_validate(corpus: Corpus) -> CorpusArchive {

--- a/fuzz/fuzz_targets/fuzz_binary.rs
+++ b/fuzz/fuzz_targets/fuzz_binary.rs
@@ -65,9 +65,8 @@ fuzz_target!(|data: &[u8]| {
     // Fuzz equality between the lexer and reader when the reader has a buffer
     // large enough to hold all possible binary tokens
     let mut lexer = jomini::binary::Lexer::new(data);
-    let mut reader = jomini::binary::TokenReader::builder()
-        .buffer_len(usize::from(u16::MAX) + 4)
-        .build(data);
+    let mut reader =
+        jomini::binary::TokenReader::from_reader_with_buf(data, vec![0; usize::from(u16::MAX) + 4]);
 
     loop {
         match (lexer.next_token(), reader.next()) {
@@ -77,7 +76,7 @@ fuzz_target!(|data: &[u8]| {
             (Ok(Some(t1)), Ok(Some(t2))) => assert_eq!(t1, t2),
             (Err(e1), Err(e2)) => match e2.kind() {
                 jomini::binary::ReaderErrorKind::Lexer(e) => {
-                    assert_eq!(e1.kind(), e);
+                    assert_eq!(e1.kind(), &e);
                     break;
                 }
                 _ => panic!("different errors"),
@@ -89,9 +88,8 @@ fuzz_target!(|data: &[u8]| {
     // Fuzz equality when reader doesn't have enough space to hold everything
     let mut lexer = jomini::binary::Lexer::new(data);
     let buffer_len = 100;
-    let mut reader = jomini::binary::TokenReader::builder()
-        .buffer_len(buffer_len + 4)
-        .build(data);
+    let mut reader =
+        jomini::binary::TokenReader::from_reader_with_buf(data, vec![0; buffer_len + 4]);
 
     loop {
         match (lexer.read_token(), reader.read()) {

--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -1,5 +1,5 @@
 use super::{
-    LexError, TokenReader, TokenReaderBuilder,
+    LexError, TokenReader,
     lexer::{LexemeId, Lexer},
 };
 use crate::{
@@ -13,12 +13,12 @@ use serde::de::{
 use std::{borrow::Cow, io::Read};
 
 /// Serde deserializer over a streaming binary reader
-pub struct BinaryReaderDeserializer<'res, RES, F, R> {
-    reader: TokenReader<R>,
+pub struct BinaryReaderDeserializer<'r, 'res, RES, F> {
+    reader: TokenReader<'r>,
     config: BinaryConfig<'res, RES, F>,
 }
 
-impl<RES: TokenResolver, E: BinaryFlavor, R: Read> BinaryReaderDeserializer<'_, RES, E, R> {
+impl<RES: TokenResolver, E: BinaryFlavor> BinaryReaderDeserializer<'_, '_, RES, E> {
     /// Deserialize into provided type
     pub fn deserialize<T>(&mut self) -> Result<T, Error>
     where
@@ -28,8 +28,8 @@ impl<RES: TokenResolver, E: BinaryFlavor, R: Read> BinaryReaderDeserializer<'_, 
     }
 }
 
-impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor, R: Read> de::Deserializer<'de>
-    for &'_ mut BinaryReaderDeserializer<'res, RES, F, R>
+impl<'de, 'r, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::Deserializer<'de>
+    for &'_ mut BinaryReaderDeserializer<'r, 'res, RES, F>
 {
     type Error = Error;
 
@@ -70,19 +70,19 @@ impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor, R: Read> de::Deseriali
     }
 }
 
-struct BinaryReaderMap<'a: 'a, 'res, RES: 'a, F, R> {
-    de: &'a mut BinaryReaderDeserializer<'res, RES, F, R>,
+struct BinaryReaderMap<'a: 'a, 'r, 'res, RES: 'a, F> {
+    de: &'a mut BinaryReaderDeserializer<'r, 'res, RES, F>,
     root: bool,
 }
 
-impl<'a, 'res, RES: 'a, F, R> BinaryReaderMap<'a, 'res, RES, F, R> {
-    fn new(de: &'a mut BinaryReaderDeserializer<'res, RES, F, R>, root: bool) -> Self {
+impl<'a, 'r, 'res, RES: 'a, F> BinaryReaderMap<'a, 'r, 'res, RES, F> {
+    fn new(de: &'a mut BinaryReaderDeserializer<'r, 'res, RES, F>, root: bool) -> Self {
         BinaryReaderMap { de, root }
     }
 }
 
-impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor, R: Read> MapAccess<'de>
-    for BinaryReaderMap<'_, 'res, RES, F, R>
+impl<'de, 'r, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> MapAccess<'de>
+    for BinaryReaderMap<'_, 'r, 'res, RES, F>
 {
     type Error = Error;
 
@@ -125,15 +125,14 @@ impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor, R: Read> MapAccess<'de
     }
 }
 
-struct BinaryReaderTokenDeserializer<'a, 'res, RES: 'a, F, R> {
-    de: &'a mut BinaryReaderDeserializer<'res, RES, F, R>,
+struct BinaryReaderTokenDeserializer<'a, 'r, 'res, RES: 'a, F> {
+    de: &'a mut BinaryReaderDeserializer<'r, 'res, RES, F>,
     token: TokenKind,
 }
 
-impl<'res, RES: TokenResolver, F, R> BinaryReaderTokenDeserializer<'_, 'res, RES, F, R>
+impl<'r, 'res, RES: TokenResolver, F> BinaryReaderTokenDeserializer<'_, 'r, 'res, RES, F>
 where
     F: BinaryFlavor,
-    R: Read,
 {
     #[inline]
     fn deser<'de, V>(self, visitor: V) -> Result<V::Value, Error>
@@ -219,8 +218,8 @@ macro_rules! deserialize_scalar {
     };
 }
 
-impl<'a, 'de: 'a, 'res: 'de, RES: TokenResolver, F: BinaryFlavor, R: Read> de::Deserializer<'de>
-    for BinaryReaderTokenDeserializer<'a, 'res, RES, F, R>
+impl<'a, 'de: 'a, 'r, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::Deserializer<'de>
+    for BinaryReaderTokenDeserializer<'a, 'r, 'res, RES, F>
 {
     type Error = Error;
 
@@ -514,19 +513,19 @@ impl<'a, 'de: 'a, 'res: 'de, RES: TokenResolver, F: BinaryFlavor, R: Read> de::D
     }
 }
 
-struct BinaryReaderSeq<'a: 'a, 'res, RES: 'a, F, R> {
-    de: &'a mut BinaryReaderDeserializer<'res, RES, F, R>,
+struct BinaryReaderSeq<'a: 'a, 'r, 'res, RES: 'a, F> {
+    de: &'a mut BinaryReaderDeserializer<'r, 'res, RES, F>,
     hit_end: bool,
 }
 
-impl<'a, 'res, RES: 'a, F, R> BinaryReaderSeq<'a, 'res, RES, F, R> {
-    fn new(de: &'a mut BinaryReaderDeserializer<'res, RES, F, R>) -> Self {
+impl<'a, 'r, 'res, RES: 'a, F> BinaryReaderSeq<'a, 'r, 'res, RES, F> {
+    fn new(de: &'a mut BinaryReaderDeserializer<'r, 'res, RES, F>) -> Self {
         BinaryReaderSeq { de, hit_end: false }
     }
 }
 
-impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor, R: Read> SeqAccess<'de>
-    for BinaryReaderSeq<'_, 'res, RES, F, R>
+impl<'de, 'r, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> SeqAccess<'de>
+    for BinaryReaderSeq<'_, 'r, 'res, RES, F>
 {
     type Error = Error;
 
@@ -548,19 +547,19 @@ impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor, R: Read> SeqAccess<'de
     }
 }
 
-struct BinaryReaderEnum<'a, 'res, RES: 'a, F, R> {
-    de: &'a mut BinaryReaderDeserializer<'res, RES, F, R>,
+struct BinaryReaderEnum<'a, 'r, 'res, RES: 'a, F> {
+    de: &'a mut BinaryReaderDeserializer<'r, 'res, RES, F>,
     token: TokenKind,
 }
 
-impl<'a, 'res, RES: 'a, F, R> BinaryReaderEnum<'a, 'res, RES, F, R> {
-    fn new(de: &'a mut BinaryReaderDeserializer<'res, RES, F, R>, token: TokenKind) -> Self {
+impl<'a, 'r, 'res, RES: 'a, F> BinaryReaderEnum<'a, 'r, 'res, RES, F> {
+    fn new(de: &'a mut BinaryReaderDeserializer<'r, 'res, RES, F>, token: TokenKind) -> Self {
         BinaryReaderEnum { de, token }
     }
 }
 
-impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor, R: Read> de::EnumAccess<'de>
-    for BinaryReaderEnum<'_, 'res, RES, F, R>
+impl<'de, 'r, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::EnumAccess<'de>
+    for BinaryReaderEnum<'_, 'r, 'res, RES, F>
 {
     type Error = Error;
     type Variant = Self;
@@ -577,8 +576,8 @@ impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor, R: Read> de::EnumAcces
     }
 }
 
-impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor, R> de::VariantAccess<'de>
-    for BinaryReaderEnum<'_, 'res, RES, F, R>
+impl<'de, 'r, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::VariantAccess<'de>
+    for BinaryReaderEnum<'_, 'r, 'res, RES, F>
 {
     type Error = Error;
 
@@ -1297,7 +1296,7 @@ impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::VariantAccess<'de>
 pub struct BinaryDeserializerBuilder<F> {
     failed_resolve_strategy: FailedResolveStrategy,
     flavor: F,
-    reader_config: TokenReaderBuilder,
+    reader_buffer: Option<Vec<u8>>,
 }
 
 /// Type alias for the binary deserializer builder for backward compatibility
@@ -1322,7 +1321,7 @@ where
         BinaryDeserializerBuilder {
             failed_resolve_strategy: FailedResolveStrategy::Ignore,
             flavor,
-            reader_config: TokenReaderBuilder::default(),
+            reader_buffer: None,
         }
     }
 
@@ -1332,22 +1331,26 @@ where
         self
     }
 
-    /// Set the reader buffer config (unused for slice deserializations)
-    pub fn reader_config(&mut self, val: TokenReaderBuilder) -> &mut Self {
-        self.reader_config = val;
+    /// Set the reader buffer configuration (unused for slice deserializations)
+    pub fn reader_buffer(&mut self, val: Vec<u8>) -> &mut Self {
+        self.reader_buffer = Some(val);
         self
     }
 
     /// Create binary deserializer from reader
-    pub fn from_reader<RES, R>(
+    pub fn from_reader<'r, 'res, RES, R>(
         self,
         reader: R,
-        resolver: &RES,
-    ) -> BinaryReaderDeserializer<'_, RES, F, R>
+        resolver: &'res RES,
+    ) -> BinaryReaderDeserializer<'r, 'res, RES, F>
     where
         RES: TokenResolver,
+        R: Read + 'r,
     {
-        let reader = self.reader_config.build(reader);
+        let reader = match self.reader_buffer {
+            Some(buffer) => TokenReader::from_reader_with_buf(reader, buffer),
+            None => TokenReader::new(reader),
+        };
         let config = BinaryConfig {
             resolver,
             failed_resolve_strategy: self.failed_resolve_strategy,
@@ -1358,10 +1361,11 @@ where
     }
 
     /// Deserialize value from reader
-    pub fn deserialize_reader<RES, T, R: Read>(self, reader: R, resolver: &RES) -> Result<T, Error>
+    pub fn deserialize_reader<RES, T, R>(self, reader: R, resolver: &RES) -> Result<T, Error>
     where
         T: DeserializeOwned,
         RES: TokenResolver,
+        R: Read,
     {
         self.from_reader(reader, resolver).deserialize()
     }

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -76,9 +76,11 @@ mod lexer;
 mod reader;
 mod resolver;
 mod rgb;
+mod source;
 
 pub use self::flavor::BinaryFlavor;
 pub use self::lexer::{LexError, LexemeId, Lexer, LexerError, Token, TokenKind};
-pub use self::reader::{ReaderError, ReaderErrorKind, TokenReader, TokenReaderBuilder};
+pub use self::reader::{ReaderError, ReaderErrorKind, TokenReader};
 pub use self::resolver::{BasicTokenResolver, FailedResolveStrategy, TokenResolver};
 pub use self::rgb::*;
+pub use self::source::{BinarySourceExt, ParserError, ParserSource};

--- a/src/binary/reader.rs
+++ b/src/binary/reader.rs
@@ -1,11 +1,7 @@
-use super::{
-    LexError, LexemeId, LexerError, Token,
-    lexer::{read_id, read_rgb, read_string},
-};
+use super::{LexError, LexemeId, LexerError, ParserError, ParserSource, Token, lexer::read_rgb};
 use crate::{
     Scalar,
     binary::{Rgb, lexer::TokenKind},
-    buffer::{BufferError, BufferWindow, BufferWindowBuilder},
     util::get_split,
 };
 use std::{fmt, io::Read};
@@ -41,243 +37,165 @@ use std::{fmt, io::Read};
 /// - [TokenReader] can not inform the caller if the container is an array or
 ///   object (or neither).
 ///
-///  This is a much more raw view of the data that can be used to construct
+/// This is a much more raw view of the data that can be used to construct
 /// higher level parsers, melters, and deserializers that operate over a stream
 /// of data.
 ///
 /// [TokenReader] operates over a fixed size buffer, so using a
-/// [BufRead](std::io::BufRead) affords no benefits. An error will be returned
-/// for tokens that are impossible to fit within the buffer (eg: if the provided
-/// with 100 byte buffer but there is a binary string that is 101 bytes long).
-#[derive(Debug)]
-pub struct TokenReader<R> {
-    reader: R,
-    buf: BufferWindow,
+/// [BufRead](std::io::BufRead) affords no benefits.
+pub struct TokenReader<'a> {
+    source: ParserSource<'a>,
     data: [u8; 8],
 }
 
-impl TokenReader<()> {
-    /// Read from a byte slice without memcpy's
+impl<'a> TokenReader<'a> {
+    /// Convenience method for constructing the default token reader.
     #[inline]
-    pub fn from_slice(data: &[u8]) -> TokenReader<&'_ [u8]> {
-        TokenReader {
-            reader: data,
-            buf: BufferWindow::from_slice(data),
-            data: [0; 8],
-        }
+    pub fn new<R>(reader: R) -> Self
+    where
+        R: Read + 'a,
+    {
+        TokenReader::from_source(ParserSource::from_reader(reader))
+    }
+
+    /// Construct a token reader with a caller-provided streaming buffer.
+    ///
+    /// ```
+    /// use jomini::binary::{Token, TokenReader};
+    ///
+    /// let buffer = vec![0; 128];
+    /// let mut reader = TokenReader::from_reader_with_buf(&[0xd2, 0x28][..], buffer);
+    /// assert_eq!(reader.read().unwrap(), Token::Id(0x28d2));
+    /// ```
+    #[inline]
+    pub fn from_reader_with_buf<R>(reader: R, buffer: Vec<u8>) -> Self
+    where
+        R: Read + 'a,
+    {
+        TokenReader::from_source(ParserSource::from_reader_with_buf(reader, buffer))
     }
 }
 
-impl<R> TokenReader<R>
-where
-    R: Read,
-{
-    /// Convenience method for constructing the default token reader
+impl<'a> TokenReader<'a> {
+    /// Read from a byte slice without memcpy's.
     #[inline]
-    pub fn new(reader: R) -> Self {
-        TokenReader::builder().build(reader)
+    pub fn from_slice(data: &'a [u8]) -> Self {
+        TokenReader::from_source(ParserSource::from_slice(data))
+    }
+
+    /// Create a token reader from an existing parser source.
+    #[inline]
+    pub fn from_source(source: ParserSource<'a>) -> Self {
+        TokenReader {
+            source,
+            data: [0; 8],
+        }
     }
 
     /// Returns the byte position of the data stream that has been processed.
     ///
-    /// ```rust
-    /// use jomini::binary::{TokenReader, Token};
+    /// ```
+    /// use jomini::binary::{Token, TokenReader};
+    ///
     /// let mut reader = TokenReader::new(&[0xd2, 0x28, 0xff][..]);
     /// assert_eq!(reader.read().unwrap(), Token::Id(0x28d2));
     /// assert_eq!(reader.position(), 2);
     /// ```
     #[inline]
     pub fn position(&self) -> usize {
-        self.buf.position()
+        self.source.position()
+    }
+
+    #[inline]
+    fn ensure_bytes(&mut self, required: usize) -> Result<(), ReaderError> {
+        self.source
+            .ensure_bytes(required)
+            .map_err(|e| self.parser_error(e))
     }
 
     /// Advance a given number of bytes and return them.
     ///
-    /// The internal buffer must be large enough to accomodate all bytes.
+    /// The internal buffer must be large enough to accommodate all bytes.
     ///
-    /// ```rust
-    /// use jomini::binary::{TokenReader, LexError, ReaderErrorKind};
+    /// ```
+    /// use jomini::binary::{LexError, ReaderErrorKind, TokenReader};
+    ///
     /// let mut reader = TokenReader::new(&b"EU4bin"[..]);
     /// assert_eq!(reader.read_bytes(6).unwrap(), &b"EU4bin"[..]);
-    /// assert!(matches!(reader.read_bytes(1).unwrap_err().kind(), ReaderErrorKind::Lexer(LexError::Eof)));
+    /// assert!(matches!(
+    ///     reader.read_bytes(1).unwrap_err().kind(),
+    ///     ReaderErrorKind::Lexer(LexError::Eof),
+    /// ));
     /// ```
     #[inline]
     pub fn read_bytes(&mut self, bytes: usize) -> Result<&[u8], ReaderError> {
-        while self.buf.window_len() < bytes {
-            match self.buf.fill_buf(&mut self.reader) {
-                Ok(0) => return Err(self.lex_error(LexError::Eof)),
-                Ok(_) => {}
-                Err(e) => return Err(self.buffer_error(e)),
-            }
-        }
-
-        Ok(self.buf.split(bytes))
+        // SAFETY: the source borrow ends with `take` on the error path
+        let s = std::ptr::addr_of!(self);
+        self.source
+            .take(bytes)
+            .map_err(|e| unsafe { s.read().parser_error(e) })
     }
 
-    /// Advance through the containing block until the closing token is consumed
+    /// Advance through the containing block until the closing token is consumed.
     ///
-    /// ```rust
-    /// use jomini::binary::{TokenReader, Token};
+    /// ```
+    /// use jomini::binary::{Token, TokenReader};
+    ///
     /// let mut reader = TokenReader::new(&[
     ///     0xd2, 0x28, 0x01, 0x00, 0x03, 0x00, 0x03, 0x00,
-    ///     0x04, 0x00, 0x04, 0x00, 0xff, 0xff
+    ///     0x04, 0x00, 0x04, 0x00, 0xff, 0xff,
     /// ][..]);
     /// assert_eq!(reader.read().unwrap(), Token::Id(0x28d2));
     /// assert_eq!(reader.read().unwrap(), Token::Equal);
     /// assert_eq!(reader.read().unwrap(), Token::Open);
-    /// assert!(reader.skip_container().is_ok());
+    /// reader.skip_container().unwrap();
     /// assert_eq!(reader.read().unwrap(), Token::Id(0xffff));
     /// ```
     #[inline]
     pub fn skip_container(&mut self) -> Result<(), ReaderError> {
-        let mut depth = 1;
+        let mut depth = 1usize;
         loop {
-            let mut window = self.buf.window();
-            while let Ok((id, data)) = read_id(window) {
-                match id {
-                    LexemeId::CLOSE => {
-                        depth -= 1;
-                        if depth == 0 {
-                            self.buf.advance_to(data.as_ptr());
-                            return Ok(());
-                        }
-                        window = data;
+            let token = self.read_token()?;
+            match token {
+                TokenKind::Close => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Ok(());
                     }
-                    LexemeId::OPEN => {
-                        window = data;
-                        depth += 1
-                    }
-                    LexemeId::BOOL => match data.get(1..) {
-                        Some(d) => window = d,
-                        None => break,
-                    },
-                    LexemeId::F32 | LexemeId::U32 | LexemeId::I32 => match data.get(4..) {
-                        Some(d) => window = d,
-                        None => break,
-                    },
-                    LexemeId::F64 | LexemeId::I64 | LexemeId::U64 => match data.get(8..) {
-                        Some(d) => window = d,
-                        None => break,
-                    },
-                    LexemeId::QUOTED | LexemeId::UNQUOTED => match read_string(data) {
-                        Ok((_, d)) => window = d,
-                        Err(_) => break,
-                    },
-                    LexemeId::LOOKUP_U8 => match data.get(1..) {
-                        Some(d) => window = d,
-                        None => break,
-                    },
-                    LexemeId::LOOKUP_U16 => match data.get(2..) {
-                        Some(d) => window = d,
-                        None => break,
-                    },
-                    LexemeId::LOOKUP_U8_ALT => match data.get(1..) {
-                        Some(d) => window = d,
-                        None => break,
-                    },
-                    LexemeId::LOOKUP_U16_ALT => match data.get(2..) {
-                        Some(d) => window = d,
-                        None => break,
-                    },
-                    LexemeId::LOOKUP_U24 => match data.get(3..) {
-                        Some(d) => window = d,
-                        None => break,
-                    },
-                    LexemeId::FIXED5_ZERO => window = data,
-                    LexemeId::FIXED5_U8 | LexemeId::FIXED5_I8 => match data.get(1..) {
-                        Some(d) => window = d,
-                        None => break,
-                    },
-                    LexemeId::FIXED5_U16 | LexemeId::FIXED5_I16 => match data.get(2..) {
-                        Some(d) => window = d,
-                        None => break,
-                    },
-                    LexemeId::FIXED5_U24 | LexemeId::FIXED5_I24 => match data.get(3..) {
-                        Some(d) => window = d,
-                        None => break,
-                    },
-                    LexemeId::FIXED5_U32 | LexemeId::FIXED5_I32 => match data.get(4..) {
-                        Some(d) => window = d,
-                        None => break,
-                    },
-                    LexemeId::FIXED5_U40 | LexemeId::FIXED5_I40 => match data.get(5..) {
-                        Some(d) => window = d,
-                        None => break,
-                    },
-                    LexemeId::FIXED5_U48 | LexemeId::FIXED5_I48 => match data.get(6..) {
-                        Some(d) => window = d,
-                        None => break,
-                    },
-                    LexemeId::FIXED5_U56 | LexemeId::FIXED5_I56 => match data.get(7..) {
-                        Some(d) => window = d,
-                        None => break,
-                    },
-                    _ => window = data,
                 }
-            }
-
-            self.buf.advance_to(window.as_ptr());
-            match self.buf.fill_buf(&mut self.reader) {
-                Ok(0) => return Err(self.lex_error(LexError::Eof)),
-                Ok(_) => {}
-                Err(e) => return Err(self.buffer_error(e)),
+                TokenKind::Open => depth += 1,
+                _ => {}
             }
         }
-    }
-
-    /// Consume the token reader and return the internal buffer and reader. This
-    /// allows the buffer to be reused.
-    ///
-    /// ```rust
-    /// use jomini::binary::TokenReader;
-    /// let data = b"EU4bin";
-    /// let mut reader = TokenReader::new(&data[..]);
-    /// assert_eq!(reader.read_bytes(6).unwrap(), &data[..]);
-    ///
-    /// let (buf, _) = reader.into_parts();
-    /// let data = b"HOI4bin";
-    /// let mut reader = TokenReader::builder().buffer(buf).build(&data[..]);
-    /// assert_eq!(reader.read_bytes(7).unwrap(), &data[..]);
-    /// ```
-    #[inline]
-    pub fn into_parts(self) -> (Box<[u8]>, R) {
-        (self.buf.buf, self.reader)
     }
 
     /// Read the next token in the stream. Will error if not enough data remains
     /// to decode a token.
     ///
-    /// ```rust
-    /// use jomini::binary::{TokenReader, Token, ReaderErrorKind, LexError};
+    /// ```
+    /// use jomini::binary::{LexError, ReaderErrorKind, Token, TokenReader};
+    ///
     /// let mut reader = TokenReader::new(&[
-    ///     0xd2, 0x28, 0x01, 0x00, 0x03, 0x00, 0x04, 0x00
+    ///     0xd2, 0x28, 0x01, 0x00, 0x03, 0x00, 0x04, 0x00,
     /// ][..]);
     /// assert_eq!(reader.read().unwrap(), Token::Id(0x28d2));
     /// assert_eq!(reader.read().unwrap(), Token::Equal);
     /// assert_eq!(reader.read().unwrap(), Token::Open);
     /// assert_eq!(reader.read().unwrap(), Token::Close);
-    /// assert!(matches!(reader.read().unwrap_err().kind(), ReaderErrorKind::Lexer(LexError::Eof)));
+    /// assert!(matches!(
+    ///     reader.read().unwrap_err().kind(),
+    ///     ReaderErrorKind::Lexer(LexError::Eof),
+    /// ));
     /// ```
     #[inline]
     pub fn read(&mut self) -> Result<Token<'_>, ReaderError> {
+        // SAFETY: borrow of `self` ends with `next()`
         let s = std::ptr::addr_of!(self);
         self.next()?
             .ok_or_else(|| unsafe { s.read().lex_error(LexError::Eof) })
     }
 
-    fn refill_with<T>(
-        &mut self,
-        f: impl FnOnce(&mut Self) -> Result<Option<T>, ReaderError>,
-    ) -> Result<Option<T>, ReaderError> {
-        match self.buf.fill_buf(&mut self.reader) {
-            Ok(0) if self.buf.window_len() == 0 => Ok(None),
-            Ok(0) => Err(self.lex_error(LexError::Eof)),
-            Ok(_) => f(self),
-            Err(e) => Err(self.buffer_error(e)),
-        }
-    }
-
-    /// Read a token, returning none when all the data has been consumed
+    /// Read a token, returning none when all the data has been consumed.
     ///
     /// ```rust
     /// use jomini::binary::{TokenReader, Token};
@@ -299,7 +217,7 @@ where
         }
     }
 
-    /// Construct a [Token] from a [TokenKind] using stored data
+    /// Construct a [Token] from a [TokenKind] using stored data.
     #[inline]
     fn token_from_kind(&self, kind: TokenKind) -> Token<'_> {
         match kind {
@@ -321,78 +239,75 @@ where
         }
     }
 
-    /// Return the id associated with the last [`TokenKind::Id`] token.
+    /// Returns the id for the most recently decoded token.
     #[inline]
     pub fn token_id(&self) -> u16 {
         u16::from_le_bytes([self.data[0], self.data[1]])
     }
 
-    /// Return the scalar data associated with [`TokenKind::Quoted`] and
-    /// [`TokenKind::Unquoted`].
+    /// Returns scalar bytes for the most recently decoded scalar token.
     ///
     /// # Safety
     ///
-    /// It is undefined behavior if this method is called and the previous
-    /// [`Self::next_token`] or [`Self::read_token`] did not return [`TokenKind::Quoted`] or
-    /// [`TokenKind::Unquoted`].
+    /// The most recent token must be [`TokenKind::Quoted`] or
+    /// [`TokenKind::Unquoted`], and the underlying source must not have been
+    /// advanced past the token's backing bytes except by `TokenReader`.
     #[inline]
     pub unsafe fn scalar_data(&self) -> Scalar<'_> {
-        let len = u16::from_le_bytes([self.data[0], self.data[1]]);
-        let data = unsafe {
-            std::slice::from_raw_parts(self.buf.start.byte_sub(len as usize), len as usize)
-        };
-        Scalar::new(data)
+        let len = u16::from_le_bytes([self.data[0], self.data[1]]) as usize;
+        let data = unsafe { self.source.as_slice().as_ptr().byte_sub(len) };
+        Scalar::new(unsafe { std::slice::from_raw_parts(data, len) })
     }
 
-    /// Return the u64 data associated with [`TokenKind::U64`].
+    /// Returns `u64` data for the most recently decoded token.
     #[inline]
     pub fn u64_data(&self) -> u64 {
         u64::from_le_bytes(self.data)
     }
 
-    /// Return the i64 data associated with [`TokenKind::I64`].
+    /// Returns `i64` data for the most recently decoded token.
     #[inline]
     pub fn i64_data(&self) -> i64 {
         i64::from_le_bytes(self.data)
     }
 
-    /// Return the f64 data associated with [`TokenKind::F64`].
+    /// Returns raw `f64` bytes for the most recently decoded token.
     #[inline]
     pub fn f64_data(&self) -> [u8; 8] {
         self.data
     }
 
-    /// Return the u32 data associated with [`TokenKind::U32`].
+    /// Returns `u32` data for the most recently decoded token.
     #[inline]
     pub fn u32_data(&self) -> u32 {
         u32::from_le_bytes([self.data[0], self.data[1], self.data[2], self.data[3]])
     }
 
-    /// Return the i32 data associated with [`TokenKind::I32`].
+    /// Returns `i32` data for the most recently decoded token.
     #[inline]
     pub fn i32_data(&self) -> i32 {
         i32::from_le_bytes([self.data[0], self.data[1], self.data[2], self.data[3]])
     }
 
-    /// Return the f32 data associated with [`TokenKind::F32`].
+    /// Returns raw `f32` bytes for the most recently decoded token.
     #[inline]
     pub fn f32_data(&self) -> [u8; 4] {
         [self.data[0], self.data[1], self.data[2], self.data[3]]
     }
 
-    /// Return the bool data associated with [`TokenKind::Bool`].
+    /// Returns boolean data for the most recently decoded token.
     #[inline]
     pub fn bool_data(&self) -> bool {
         self.data[0] != 0
     }
 
-    /// Return the 32-bit data associated with [`TokenKind::Lookup`].
+    /// Returns lookup data for the most recently decoded token.
     #[inline]
     pub fn lookup_data(&self) -> u32 {
         u32::from_le_bytes([self.data[0], self.data[1], self.data[2], 0])
     }
 
-    /// Return the RGB data associated with [`TokenKind::Rgb`].
+    /// Returns RGB data for the most recently decoded token.
     ///
     /// # Safety
     ///
@@ -401,7 +316,8 @@ where
     #[inline]
     pub fn rgb_data(&self) -> Rgb {
         let size = self.data[0] as usize;
-        let data = unsafe { std::slice::from_raw_parts(self.buf.start.byte_sub(size), size) };
+        let data = unsafe { self.source.as_slice().as_ptr().byte_sub(size) };
+        let data = unsafe { std::slice::from_raw_parts(data, size) };
         let (result, _data) = read_rgb(data).expect("valid rgb data");
         result
     }
@@ -412,21 +328,20 @@ where
         let lexeme = LexemeId::new(u16::from_le_bytes(*id));
         match lexeme {
             LexemeId::OPEN => {
-                self.buf.advance_to(rest.as_ptr());
+                self.source.advance(2);
                 Some(TokenKind::Open)
             }
             LexemeId::CLOSE => {
-                self.buf.advance_to(rest.as_ptr());
+                self.source.advance(2);
                 Some(TokenKind::Close)
             }
             LexemeId::EQUAL => {
-                self.buf.advance_to(rest.as_ptr());
+                self.source.advance(2);
                 Some(TokenKind::Equal)
             }
             LexemeId::U32 | LexemeId::I32 | LexemeId::F32 => {
-                let (data, rest) = rest.split_at(4);
-                self.data[..4].copy_from_slice(data);
-                self.buf.advance_to(rest.as_ptr());
+                self.data[..4].copy_from_slice(&rest[..4]);
+                self.source.advance(6);
                 if lexeme == LexemeId::F32 {
                     Some(TokenKind::F32)
                 } else if lexeme == LexemeId::U32 {
@@ -436,9 +351,8 @@ where
                 }
             }
             LexemeId::U64 | LexemeId::I64 | LexemeId::F64 => {
-                let (data, rest) = rest.split_at(8);
-                self.data[..8].copy_from_slice(data);
-                self.buf.advance_to(rest.as_ptr());
+                self.data[..8].copy_from_slice(&rest[..8]);
+                self.source.advance(10);
                 if lexeme == LexemeId::F64 {
                     Some(TokenKind::F64)
                 } else if lexeme == LexemeId::U64 {
@@ -448,17 +362,16 @@ where
                 }
             }
             LexemeId::BOOL => {
-                let (data, rest) = rest.split_at(1);
-                self.data[0] = data[0];
-                self.buf.advance_to(rest.as_ptr());
+                self.data[0] = rest[0];
+                self.source.advance(3);
                 Some(TokenKind::Bool)
             }
             LexemeId::QUOTED | LexemeId::UNQUOTED => {
                 let (len_data, rest) = get_split::<2>(rest).unwrap();
                 let len = u16::from_le_bytes(*len_data) as usize;
-                let (_str_data, rest) = rest.split_at_checked(len)?;
+                rest.get(len..)?;
                 self.data[0..2].copy_from_slice(len_data);
-                self.buf.advance_to(rest.as_ptr());
+                self.source.advance(4 + len);
                 if lexeme == LexemeId::UNQUOTED {
                     Some(TokenKind::Unquoted)
                 } else {
@@ -466,27 +379,21 @@ where
                 }
             }
             LexemeId::LOOKUP_U8 | LexemeId::LOOKUP_U8_ALT => {
-                let (data, rest) = rest.split_at(1);
-                let mut tmp = [0u8; 8];
-                tmp[0] = data[0];
-                self.data = tmp;
-                self.buf.advance_to(rest.as_ptr());
+                self.data = [0; 8];
+                self.data[0] = rest[0];
+                self.source.advance(3);
                 Some(TokenKind::Lookup)
             }
             LexemeId::LOOKUP_U16 | LexemeId::LOOKUP_U16_ALT => {
-                let (data, rest) = get_split::<2>(rest).unwrap();
-                let mut tmp = [0u8; 8];
-                tmp[0..2].copy_from_slice(data);
-                self.data = tmp;
-                self.buf.advance_to(rest.as_ptr());
+                self.data = [0; 8];
+                self.data[0..2].copy_from_slice(&rest[..2]);
+                self.source.advance(4);
                 Some(TokenKind::Lookup)
             }
             LexemeId::LOOKUP_U24 => {
-                let (data, rest) = get_split::<3>(rest).unwrap();
-                let mut tmp = [0u8; 8];
-                tmp[0..3].copy_from_slice(data);
-                self.data = tmp;
-                self.buf.advance_to(rest.as_ptr());
+                self.data = [0; 8];
+                self.data[0..3].copy_from_slice(&rest[..3]);
+                self.source.advance(5);
                 Some(TokenKind::Lookup)
             }
             LexemeId::RGB => None,
@@ -494,181 +401,201 @@ where
                 let offset = lexeme.0 - LexemeId::FIXED5_ZERO.0;
                 let is_negative = offset > 7;
                 let byte_count = offset - (is_negative as u16 * 7);
-                let (data, rest) = rest.split_at(byte_count as usize);
-                // Use a temporary zero-initialized array to avoid leftover bytes from previous tokens
                 let mut buf = [0u8; 8];
-                buf[..byte_count as usize].copy_from_slice(data);
-                self.buf.advance_to(rest.as_ptr());
+                buf[..byte_count as usize].copy_from_slice(&rest[..byte_count as usize]);
                 let sign = 1i64 - (is_negative as i64) * 2;
                 self.data = (u64::from_le_bytes(buf) as i64 * sign).to_le_bytes();
+                self.source.advance(2 + byte_count as usize);
                 Some(TokenKind::F64)
             }
             _ => {
                 self.data[..2].copy_from_slice(id);
-                self.buf.advance_to(rest.as_ptr());
+                self.source.advance(2);
                 Some(TokenKind::Id)
             }
         }
     }
 
-    /// Read the next token in the stream. Will error if not enough data
-    /// remains.
-    ///
-    /// Use one of the `*_data` methods to get the associated data for the
-    /// token.
+    /// Reads the next token kind without constructing a borrowed [`Token`].
     #[inline]
     pub fn read_token(&mut self) -> Result<TokenKind, ReaderError> {
-        let s = std::ptr::addr_of!(self);
-        self.next_token()?
-            .ok_or_else(|| unsafe { s.read().lex_error(LexError::Eof) })
+        match self.next_token()? {
+            Some(t) => Ok(t),
+            None => Err(self.lex_error(LexError::Eof)),
+        }
     }
 
-    fn next_token_slow(&mut self) -> Result<TokenKind, LexError> {
-        let window = unsafe { std::slice::from_raw_parts(self.buf.start, self.buf.window_len()) };
-        let (id, rest) = get_split::<2>(window).ok_or(LexError::Eof)?;
-        let lexeme = LexemeId::new(u16::from_le_bytes(*id));
-        match lexeme {
+    fn next_token_slow(&mut self, id: [u8; 2]) -> Result<TokenKind, ReaderError> {
+        let lexeme = LexemeId::new(u16::from_le_bytes(id));
+        let kind = match lexeme {
             LexemeId::OPEN => {
-                self.buf.advance_to(rest.as_ptr());
-                Ok(TokenKind::Open)
+                self.source.advance(2);
+                TokenKind::Open
             }
             LexemeId::CLOSE => {
-                self.buf.advance_to(rest.as_ptr());
-                Ok(TokenKind::Close)
+                self.source.advance(2);
+                TokenKind::Close
             }
             LexemeId::EQUAL => {
-                self.buf.advance_to(rest.as_ptr());
-                Ok(TokenKind::Equal)
+                self.source.advance(2);
+                TokenKind::Equal
             }
             LexemeId::U32 | LexemeId::I32 | LexemeId::F32 => {
-                let (data, rest) = get_split::<4>(rest).ok_or(LexError::Eof)?;
-                self.data[..4].copy_from_slice(data);
-                self.buf.advance_to(rest.as_ptr());
+                self.ensure_bytes(6)?;
+                let data = unsafe { self.source.get_slice_unchecked(6) };
+                self.data[..4].copy_from_slice(&data[2..6]);
+                self.source.advance(6);
                 if lexeme == LexemeId::F32 {
-                    Ok(TokenKind::F32)
+                    TokenKind::F32
                 } else if lexeme == LexemeId::U32 {
-                    Ok(TokenKind::U32)
+                    TokenKind::U32
                 } else {
-                    Ok(TokenKind::I32)
+                    TokenKind::I32
                 }
             }
             LexemeId::U64 | LexemeId::I64 | LexemeId::F64 => {
-                let (data, rest) = get_split::<8>(rest).ok_or(LexError::Eof)?;
-                self.data[..8].copy_from_slice(data);
-                self.buf.advance_to(rest.as_ptr());
+                self.ensure_bytes(10)?;
+                let data = unsafe { self.source.get_slice_unchecked(10) };
+                self.data[..8].copy_from_slice(&data[2..10]);
+                self.source.advance(10);
                 if lexeme == LexemeId::F64 {
-                    Ok(TokenKind::F64)
+                    TokenKind::F64
                 } else if lexeme == LexemeId::U64 {
-                    Ok(TokenKind::U64)
+                    TokenKind::U64
                 } else {
-                    Ok(TokenKind::I64)
+                    TokenKind::I64
                 }
             }
             LexemeId::BOOL => {
-                let (data, rest) = get_split::<1>(rest).ok_or(LexError::Eof)?;
-                self.data[0] = data[0];
-                self.buf.advance_to(rest.as_ptr());
-                Ok(TokenKind::Bool)
+                self.ensure_bytes(3)?;
+                let data = unsafe { self.source.get_slice_unchecked(3) };
+                self.data[0] = data[2];
+                self.source.advance(3);
+                TokenKind::Bool
             }
             LexemeId::QUOTED | LexemeId::UNQUOTED => {
-                let (len_data, rest) = get_split::<2>(rest).ok_or(LexError::Eof)?;
-                let len = u16::from_le_bytes(*len_data) as usize;
-                let rest = rest.get(len..).ok_or(LexError::Eof)?;
-                self.data[0..2].copy_from_slice(len_data);
-                self.buf.advance_to(rest.as_ptr());
+                self.ensure_bytes(4)?;
+                let data = unsafe { self.source.get_slice_unchecked(4) };
+                let len_data = [data[2], data[3]];
+                let len = u16::from_le_bytes(len_data) as usize;
+                self.ensure_bytes(4 + len)?;
+                self.data[0..2].copy_from_slice(&len_data);
+                self.source.advance(4 + len);
                 if lexeme == LexemeId::UNQUOTED {
-                    Ok(TokenKind::Unquoted)
+                    TokenKind::Unquoted
                 } else {
-                    Ok(TokenKind::Quoted)
+                    TokenKind::Quoted
                 }
             }
             LexemeId::LOOKUP_U8 | LexemeId::LOOKUP_U8_ALT => {
-                let (data, rest) = get_split::<1>(rest).ok_or(LexError::Eof)?;
-                let mut tmp = [0u8; 8];
-                tmp[0] = data[0];
-                self.data = tmp;
-                self.buf.advance_to(rest.as_ptr());
-                Ok(TokenKind::Lookup)
+                self.ensure_bytes(3)?;
+                let data = unsafe { self.source.get_slice_unchecked(3) };
+                self.data = [0; 8];
+                self.data[0] = data[2];
+                self.source.advance(3);
+                TokenKind::Lookup
             }
             LexemeId::LOOKUP_U16 | LexemeId::LOOKUP_U16_ALT => {
-                let (data, rest) = get_split::<2>(rest).ok_or(LexError::Eof)?;
-                let mut tmp = [0u8; 8];
-                tmp[0..2].copy_from_slice(data);
-                self.data = tmp;
-                self.buf.advance_to(rest.as_ptr());
-                Ok(TokenKind::Lookup)
+                self.ensure_bytes(4)?;
+                let data = unsafe { self.source.get_slice_unchecked(4) };
+                self.data = [0; 8];
+                self.data[0..2].copy_from_slice(&data[2..4]);
+                self.source.advance(4);
+                TokenKind::Lookup
             }
             LexemeId::LOOKUP_U24 => {
-                let (data, rest) = get_split::<3>(rest).ok_or(LexError::Eof)?;
-                let mut tmp = [0u8; 8];
-                tmp[0..3].copy_from_slice(data);
-                self.data = tmp;
-                self.buf.advance_to(rest.as_ptr());
-                Ok(TokenKind::Lookup)
+                self.ensure_bytes(5)?;
+                let data = unsafe { self.source.get_slice_unchecked(5) };
+                self.data = [0; 8];
+                self.data[0..3].copy_from_slice(&data[2..5]);
+                self.source.advance(5);
+                TokenKind::Lookup
             }
             LexemeId::RGB => {
-                let (_, nrest) = read_rgb(rest)?;
-                let size = nrest.as_ptr() as usize - rest.as_ptr() as usize;
-                self.data[0] = size as u8;
-                self.buf.advance_to(nrest.as_ptr());
-                Ok(TokenKind::Rgb)
+                self.ensure_bytes(24)?;
+                let data = self.source.as_slice();
+                match read_rgb(&data[2..]) {
+                    Ok((_rgb, rest)) => {
+                        let size = rest.as_ptr() as usize - data[2..].as_ptr() as usize;
+                        self.data[0] = size as u8;
+                        self.source.advance(2 + size);
+                        TokenKind::Rgb
+                    }
+                    Err(LexError::Eof) => {
+                        self.ensure_bytes(30)?;
+                        let data = self.source.as_slice();
+                        let (_rgb, rest) = read_rgb(&data[2..]).map_err(|e| self.lex_error(e))?;
+                        let size = rest.as_ptr() as usize - data[2..].as_ptr() as usize;
+                        self.data[0] = size as u8;
+                        self.source.advance(2 + size);
+                        TokenKind::Rgb
+                    }
+                    Err(e) => return Err(self.lex_error(e)),
+                }
             }
             lexeme if lexeme >= LexemeId::FIXED5_ZERO && lexeme <= LexemeId::FIXED5_I56 => {
                 let offset = lexeme.0 - LexemeId::FIXED5_ZERO.0;
                 let is_negative = offset > 7;
                 let byte_count = offset - (is_negative as u16 * 7);
-                let (data, rest) = rest
-                    .split_at_checked(byte_count as usize)
-                    .ok_or(LexError::Eof)?;
+                self.ensure_bytes(2 + byte_count as usize)?;
+                let data = unsafe { self.source.get_slice_unchecked(2 + byte_count as usize) };
                 let mut buf = [0u8; 8];
-                buf[..byte_count as usize].copy_from_slice(data);
-                self.buf.advance_to(rest.as_ptr());
+                buf[..byte_count as usize].copy_from_slice(&data[2..]);
                 let sign = 1i64 - (is_negative as i64) * 2;
                 self.data = (u64::from_le_bytes(buf) as i64 * sign).to_le_bytes();
-                Ok(TokenKind::F64)
+                self.source.advance(2 + byte_count as usize);
+                TokenKind::F64
             }
             _ => {
-                self.data[..2].copy_from_slice(id);
-                self.buf.advance_to(rest.as_ptr());
-                Ok(TokenKind::Id)
+                self.data[..2].copy_from_slice(&id);
+                self.source.advance(2);
+                TokenKind::Id
             }
-        }
+        };
+
+        Ok(kind)
     }
 
-    #[inline(never)]
-    fn next_token_slow_refill(&mut self) -> Result<Option<TokenKind>, ReaderError> {
-        match self.next_token_slow() {
-            Ok(kind) => Ok(Some(kind)),
-            Err(LexError::Eof) => self.refill_with(|s| s.next_token()),
-            Err(e) => Err(self.lex_error(e)),
-        }
-    }
-
-    /// Read the next token in the stream. Will return None when all data has
-    /// been consumed.
-    ///
-    /// Use one of the `*_data` methods to get the associated data for the
-    /// token.
+    /// Reads the next token kind, returning `None` when all data is consumed.
     #[inline]
     pub fn next_token(&mut self) -> Result<Option<TokenKind>, ReaderError> {
-        let window = unsafe { std::slice::from_raw_parts(self.buf.start, self.buf.window_len()) };
-
-        // If we have enough data we can use the fast path to avoid most bound checks
+        // The raw-pointer reborrow side-steps the borrow checker. This is safe
+        // as long as the "next_token_fast" doesn't cause a refill.
+        let window = self.source.as_slice();
         if window.len() >= 16
-            && let Some(kind) = self.next_token_fast(window)
+            && let Some(kind) = self.next_token_fast(unsafe { &*(window as *const [u8]) })
         {
             return Ok(Some(kind));
         }
 
-        self.next_token_slow_refill()
+        let id = match self.source.peek::<2>() {
+            Ok(Some(id)) => *id,
+            Ok(None) => {
+                return if self.source.remaining() == 0 {
+                    Ok(None)
+                } else {
+                    Err(self.lex_error(LexError::Eof))
+                };
+            }
+            Err(e) if e.is_eof() => return Ok(None),
+            Err(e) => return Err(self.parser_error(e)),
+        };
+        self.next_token_slow(id).map(Some)
     }
 
     #[cold]
     #[inline(never)]
-    fn buffer_error(&self, e: BufferError) -> ReaderError {
-        ReaderError {
-            position: self.position(),
-            kind: ReaderErrorKind::from(e),
+    fn parser_error(&self, e: ParserError) -> ReaderError {
+        if e.is_eof() {
+            self.lex_error(LexError::Eof)
+        } else if e.is_buffer_too_small() {
+            ReaderError {
+                packed: ReaderError::pack(self.position(), ReaderErrorKind::BufferTooSmall),
+            }
+        } else {
+            ReaderError {
+                packed: ReaderError::pack(self.position(), ReaderErrorKind::Read),
+            }
         }
     }
 
@@ -679,72 +606,15 @@ where
     }
 }
 
-impl TokenReader<()> {
-    /// Initializes a default [TokenReaderBuilder]
-    pub fn builder() -> TokenReaderBuilder {
-        TokenReaderBuilder::default()
-    }
-}
-
-/// Creates a binary token reader
-#[derive(Debug, Default)]
-pub struct TokenReaderBuilder {
-    buffer: BufferWindowBuilder,
-}
-
-impl TokenReaderBuilder {
-    /// Set the fixed size buffer to the given buffer
-    ///
-    /// See [buffer_len](Self::buffer_len) for more information
-    #[inline]
-    pub fn buffer(mut self, val: Box<[u8]>) -> TokenReaderBuilder {
-        self.buffer = self.buffer.buffer(val);
-        self
-    }
-
-    /// Set the length of the buffer if no buffer is provided
-    ///
-    /// The size of the buffer must be large enough to decode an entire binary
-    /// token, not just the contained binary data. For instance, for quoted
-    /// scalars there are 4 bytes of additional data to the token (2 bytes for
-    /// token discriminant and 2 to the string size).
-    ///
-    /// With how the binary format is laid out, a minimal buffer size that can
-    /// handle all inputs can be derived
-    ///
-    /// ```rust
-    /// use jomini::binary::TokenReader;
-    /// let len = usize::from(u16::MAX) + 4;
-    /// let reader = TokenReader::builder().buffer_len(len);
-    /// # let _reader2 = reader;
-    /// ```
-    #[inline]
-    pub fn buffer_len(mut self, val: usize) -> TokenReaderBuilder {
-        self.buffer = self.buffer.buffer_len(val);
-        self
-    }
-
-    /// Create a binary token reader around a given reader.
-    #[inline]
-    pub fn build<R>(self, reader: R) -> TokenReader<R> {
-        let buf = self.buffer.build();
-        TokenReader {
-            reader,
-            buf,
-            data: [0; 8],
-        }
-    }
-}
-
 /// The specific binary reader error type.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReaderErrorKind {
     /// An underlying error from a [Read]er
-    Read(std::io::Error),
+    Read,
 
     /// The internal buffer does not have enough room to store data for the next
     /// token
-    BufferFull,
+    BufferTooSmall,
 
     /// The data is corrupted
     Lexer(LexError),
@@ -753,48 +623,59 @@ pub enum ReaderErrorKind {
 /// An binary lexing error over a `Read` implementation
 #[derive(Debug)]
 pub struct ReaderError {
-    position: usize,
-    kind: ReaderErrorKind,
+    // Keep ReaderError to one word to minimize the impact of error handling on
+    // hot paths. The top byte stores ReaderErrorKind and the lower 56 bits
+    // store position.
+    packed: u64,
 }
 
 impl ReaderError {
-    /// Return the byte position where the error occurred
-    pub fn position(&self) -> usize {
-        self.position
+    const KIND_SHIFT: u64 = 56;
+    const POSITION_MASK: u64 = (1 << Self::KIND_SHIFT) - 1;
+
+    #[inline]
+    fn pack(position: usize, kind: ReaderErrorKind) -> u64 {
+        ((kind.tag() as u64) << Self::KIND_SHIFT) | ((position as u64) & Self::POSITION_MASK)
     }
 
-    /// Return a reference the error kind
-    pub fn kind(&self) -> &ReaderErrorKind {
-        &self.kind
+    /// Return the byte position where the error occurred
+    pub fn position(&self) -> usize {
+        (self.packed & Self::POSITION_MASK) as usize
+    }
+
+    /// Return the error kind
+    pub fn kind(&self) -> ReaderErrorKind {
+        ReaderErrorKind::from_tag((self.packed >> Self::KIND_SHIFT) as u8)
     }
 
     /// Consume self and return the error kind
     #[must_use]
     pub fn into_kind(self) -> ReaderErrorKind {
-        self.kind
+        self.kind()
     }
 }
 
 impl std::error::Error for ReaderError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match &self.kind {
-            ReaderErrorKind::Read(cause) => Some(cause),
-            _ => None,
-        }
+        None
     }
 }
 
 impl std::fmt::Display for ReaderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match &self.kind {
-            ReaderErrorKind::Read { .. } => {
-                write!(f, "failed to read past position: {}", self.position)
+        match self.kind() {
+            ReaderErrorKind::Read => {
+                write!(f, "failed to read past position: {}", self.position())
             }
-            ReaderErrorKind::BufferFull => {
-                write!(f, "max buffer size exceeded at position: {}", self.position)
+            ReaderErrorKind::BufferTooSmall => {
+                write!(
+                    f,
+                    "token exceeds buffer capacity at position: {}",
+                    self.position()
+                )
             }
             ReaderErrorKind::Lexer(cause) => {
-                write!(f, "{} at position: {}", cause, self.position)
+                write!(f, "{} at position: {}", cause, self.position())
             }
         }
     }
@@ -803,17 +684,30 @@ impl std::fmt::Display for ReaderError {
 impl From<LexerError> for ReaderError {
     fn from(value: LexerError) -> Self {
         ReaderError {
-            position: value.position(),
-            kind: ReaderErrorKind::Lexer(value.into_kind()),
+            packed: ReaderError::pack(value.position(), ReaderErrorKind::Lexer(value.into_kind())),
         }
     }
 }
 
-impl From<BufferError> for ReaderErrorKind {
-    fn from(value: BufferError) -> Self {
-        match value {
-            BufferError::Io(x) => ReaderErrorKind::Read(x),
-            BufferError::BufferFull => ReaderErrorKind::BufferFull,
+impl ReaderErrorKind {
+    #[inline]
+    const fn tag(self) -> u8 {
+        match self {
+            ReaderErrorKind::Read => 0,
+            ReaderErrorKind::BufferTooSmall => 1,
+            ReaderErrorKind::Lexer(LexError::Eof) => 2,
+            ReaderErrorKind::Lexer(LexError::InvalidRgb) => 3,
+        }
+    }
+
+    #[inline]
+    const fn from_tag(tag: u8) -> Self {
+        match tag {
+            0 => ReaderErrorKind::Read,
+            1 => ReaderErrorKind::BufferTooSmall,
+            2 => ReaderErrorKind::Lexer(LexError::Eof),
+            3 => ReaderErrorKind::Lexer(LexError::InvalidRgb),
+            _ => unreachable!(),
         }
     }
 }
@@ -925,7 +819,7 @@ mod tests {
 
         // reader buffer size
         for i in 30..40 {
-            let mut reader = TokenReader::builder().buffer_len(i).build(data.as_slice());
+            let mut reader = TokenReader::from_reader_with_buf(data.as_slice(), vec![0; i]);
             for e in input {
                 assert_eq!(*e, reader.read().unwrap(), "failure at token idx: {}", i);
             }
@@ -940,7 +834,12 @@ mod tests {
         let mut reader = TokenReader::new(&[0x43][..]);
         assert!(matches!(
             reader.read().unwrap_err().kind(),
-            &ReaderErrorKind::Lexer(LexError::Eof)
+            ReaderErrorKind::Lexer(LexError::Eof)
         ));
+    }
+
+    #[test]
+    fn reader_error_is_eight_bytes() {
+        assert_eq!(std::mem::size_of::<ReaderError>(), 8);
     }
 }

--- a/src/binary/source.rs
+++ b/src/binary/source.rs
@@ -1,0 +1,802 @@
+use std::io::{self, Read};
+use std::marker::PhantomData;
+use std::ptr;
+
+use crate::binary::LexemeId;
+
+const DEFAULT_CAPACITY: usize = 32 * 1024;
+
+/// Error returned by [`ParserSource`] operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParserError {
+    /// The source ended before the requested bytes were available.
+    Eof,
+
+    /// The streaming refill buffer is too small to hold the requested block.
+    BufferTooSmall,
+
+    /// An underlying reader returned an IO error.
+    Io,
+}
+
+impl ParserError {
+    /// Constructs a [`ParserError`] representing a clean unexpected end-of-stream.
+    #[inline]
+    pub fn eof() -> Self {
+        ParserError::Eof
+    }
+
+    /// Returns true if this error is an unexpected EOF.
+    #[inline]
+    pub fn is_eof(&self) -> bool {
+        matches!(self, ParserError::Eof)
+    }
+
+    /// Constructs a [`ParserError`] indicating the streaming refill buffer is
+    /// too small to hold the requested block.
+    #[inline]
+    pub fn buffer_too_small() -> Self {
+        ParserError::BufferTooSmall
+    }
+
+    /// Returns true if this error indicates the refill buffer was too small
+    /// to hold the requested block.
+    #[inline]
+    pub fn is_buffer_too_small(&self) -> bool {
+        matches!(self, ParserError::BufferTooSmall)
+    }
+}
+
+impl std::fmt::Display for ParserError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParserError::Eof => write!(f, "unexpected end of file"),
+            ParserError::BufferTooSmall => write!(f, "requested read exceeds buffer capacity"),
+            ParserError::Io => write!(f, "io error"),
+        }
+    }
+}
+
+impl std::error::Error for ParserError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
+impl From<io::Error> for ParserError {
+    fn from(_: io::Error) -> Self {
+        ParserError::Io
+    }
+}
+
+impl From<ParserError> for io::Error {
+    fn from(err: ParserError) -> Self {
+        match err {
+            ParserError::Eof => io::Error::from(io::ErrorKind::UnexpectedEof),
+            ParserError::BufferTooSmall => io::Error::from(io::ErrorKind::InvalidInput),
+            ParserError::Io => io::Error::other("parser source io error"),
+        }
+    }
+}
+
+enum Backing<'a> {
+    Stream {
+        buffer: Vec<u8>,
+        source: Box<dyn Read + 'a>,
+    },
+    Owned {
+        #[expect(dead_code)] // must keep it alive
+        owner: Box<dyn AsRef<[u8]> + 'a>,
+    },
+}
+
+/// A windowed byte parser that unifies zero-copy slice parsing and buffered
+/// streaming parsing.
+///
+/// Two construction modes are supported:
+///
+/// - [`ParserSource::from_slice`] for a borrowed in-memory slice (zero-copy).
+/// - [`ParserSource::from_reader`] for a streaming source backed by an internal
+///   buffer of a fixed maximum capacity.
+///
+/// All accessors that may need more data transparently refill when in streaming
+/// mode.
+///
+/// [`ParserSource`] is tailored to data that is being read from a compressed
+/// source, like how many save files are structured.
+///
+/// # Example
+///
+/// A typical pull loop: keep reading fixed-size records until the parser
+/// reports EOF. The same code works for both slice and streaming inputs.
+///
+/// ```
+/// use jomini::binary::{ParserSource, ParserError};
+///
+/// fn sum_u32_records(parser: &mut ParserSource<'_>) -> Result<u64, ParserError> {
+///     let mut total = 0u64;
+///     while !parser.is_eof()? {
+///         let bytes = parser.take_array::<4>()?;
+///         total += u32::from_le_bytes(*bytes) as u64;
+///     }
+///     Ok(total)
+/// }
+///
+/// let data = [1u32, 2, 3, 4]
+///     .iter()
+///     .flat_map(|x| x.to_le_bytes())
+///     .collect::<Vec<_>>();
+/// let mut parser = ParserSource::from_slice(&data);
+/// assert_eq!(sum_u32_records(&mut parser).unwrap(), 10);
+/// ```
+pub struct ParserSource<'a> {
+    ptr: *const u8,
+    end: *const u8,
+    base_ptr: *const u8, // Immutable anchor tracking the true start of memory
+    total_bytes_parsed: usize,
+    streaming: Option<Box<Backing<'a>>>,
+    _marker: PhantomData<&'a [u8]>,
+}
+
+impl<'a> ParserSource<'a> {
+    /// Zero-copy initialization for in-memory byte slices.
+    pub fn from_slice(data: &'a [u8]) -> Self {
+        let start = data.as_ptr();
+        Self {
+            ptr: start,
+            end: unsafe { start.add(data.len()) },
+            base_ptr: start,
+            total_bytes_parsed: 0,
+            streaming: None,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Zero-copy initialization that takes ownership of the underlying buffer.
+    ///
+    /// ```
+    /// use jomini::binary::ParserSource;
+    ///
+    /// let mut parser = ParserSource::from_owned(vec![1u8, 2, 3, 4]);
+    /// assert_eq!(parser.take_array::<4>().unwrap(), &[1u8, 2, 3, 4]);
+    /// ```
+    pub fn from_owned<T: AsRef<[u8]> + 'a>(owner: T) -> Self {
+        let boxed: Box<dyn AsRef<[u8]> + 'a> = Box::new(owner);
+        let slice = (*boxed).as_ref();
+        let start = slice.as_ptr();
+        let len = slice.len();
+        Self {
+            ptr: start,
+            end: unsafe { start.add(len) },
+            base_ptr: start,
+            total_bytes_parsed: 0,
+            streaming: Some(Box::new(Backing::Owned { owner: boxed })),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Streaming initialization with the default buffer capacity.
+    ///
+    /// # Performance
+    ///
+    /// Reader constructors internally manages a buffer to optimize parsing
+    /// throughput. To avoid the memory overhead of double-buffering, prefer
+    /// passing a raw reader or decompression stream directly instead of
+    /// wrapping it in `BufReader`.
+    pub fn from_reader<R: Read + 'a>(source: R) -> Self {
+        Self::from_reader_with_buf(source, vec![0u8; DEFAULT_CAPACITY])
+    }
+
+    /// Streaming initialization with a caller-provided buffer.
+    ///
+    /// This lets callers control capacity or reuse an existing allocation.
+    ///
+    /// ```
+    /// use jomini::binary::ParserSource;
+    ///
+    /// let buffer = vec![0; 1024];
+    /// let _parser = ParserSource::from_reader_with_buf(&b"EU4bin"[..], buffer);
+    /// ```
+    pub fn from_reader_with_buf<R>(source: R, buffer: Vec<u8>) -> Self
+    where
+        R: Read + 'a,
+    {
+        let vec = buffer;
+        let start = vec.as_ptr();
+        Self {
+            ptr: start,
+            end: start, // Starts empty to force an immediate first chunk read
+            base_ptr: start,
+            total_bytes_parsed: 0,
+            streaming: Some(Box::new(Backing::Stream {
+                buffer: vec,
+                source: Box::new(source),
+            })),
+            _marker: PhantomData,
+        }
+    }
+
+    /// High-performance check for structured boundary limits (e.g., matching keys)
+    #[inline(always)]
+    pub fn is_eof(&mut self) -> Result<bool, ParserError> {
+        if self.ptr != self.end {
+            return Ok(false);
+        }
+        self.refill_and_check_empty()
+    }
+
+    /// Guaranteed contiguous memory validation. Crucial for speculative parsing.
+    #[inline(always)]
+    pub fn ensure_bytes(&mut self, required: usize) -> Result<(), ParserError> {
+        let available = unsafe { self.end.offset_from_unsigned(self.ptr) };
+        if available >= required {
+            return Ok(());
+        }
+        self.refill_slow(required)
+    }
+
+    /// On-demand metric progress tracking with absolute zero hot-path write overhead.
+    #[inline(always)]
+    pub fn position(&self) -> usize {
+        let consumed_in_current_window = unsafe { self.ptr.offset_from_unsigned(self.base_ptr) };
+        self.total_bytes_parsed + consumed_in_current_window
+    }
+
+    /// Advances the parse cursor by `bytes` without bounds checking.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `bytes <= self.remaining()`; typically by first
+    /// calling [`ensure_bytes`](Self::ensure_bytes).
+    #[inline(always)]
+    pub unsafe fn advance_unchecked(&mut self, bytes: usize) {
+        self.ptr = unsafe { self.ptr.add(bytes) };
+    }
+
+    /// Advances the parse cursor by `bytes` within the current window.
+    ///
+    /// Returns `false` if `bytes` exceeds the current contiguous unread window.
+    #[inline(always)]
+    pub fn advance(&mut self, bytes: usize) -> bool {
+        if bytes <= self.remaining() {
+            unsafe {
+                self.advance_unchecked(bytes);
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns a slice of the next `len` bytes without bounds checking or
+    /// advancing the cursor.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `len <= self.remaining()`; typically by first
+    /// calling [`ensure_bytes`](Self::ensure_bytes).
+    #[inline(always)]
+    pub unsafe fn get_slice_unchecked(&self, len: usize) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.ptr, len) }
+    }
+
+    /// Current window length (no refill).
+    #[inline(always)]
+    pub fn remaining(&self) -> usize {
+        unsafe { self.end.offset_from_unsigned(self.ptr) }
+    }
+
+    /// Returns the current unread window without refilling.
+    #[inline(always)]
+    pub fn as_slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.ptr, self.remaining()) }
+    }
+
+    /// Peek at the next `N` bytes without advancing.
+    ///
+    /// Returns `Ok(None)` only at clean EOF with fewer than `N` bytes left
+    /// and no more available from the stream. Refills internally as needed.
+    #[inline(always)]
+    pub fn peek<const N: usize>(&mut self) -> Result<Option<&[u8; N]>, ParserError> {
+        if self.remaining() >= N {
+            unsafe { return Ok(Some(&*self.ptr.cast::<[u8; N]>())) };
+        }
+        self.peek_slow::<N>()
+    }
+
+    #[inline(never)]
+    fn peek_slow<const N: usize>(&mut self) -> Result<Option<&[u8; N]>, ParserError> {
+        match self.ensure_bytes(N) {
+            Ok(()) => unsafe { Ok(Some(&*self.ptr.cast::<[u8; N]>())) },
+            Err(e) if e.is_eof() => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Reads the next `N` bytes as a fixed-size array, advancing the cursor.
+    ///
+    /// Returns [`ParserError::eof`] if fewer than `N` bytes remain even after
+    /// refilling.
+    #[inline(always)]
+    pub fn take_array<const N: usize>(&mut self) -> Result<&[u8; N], ParserError> {
+        self.ensure_bytes(N)?;
+        unsafe {
+            let array_ref = &*self.ptr.cast::<[u8; N]>();
+            self.advance_unchecked(N);
+            Ok(array_ref)
+        }
+    }
+
+    /// Reads the next `n` bytes as a slice, advancing the cursor.
+    ///
+    /// Returns [`ParserError::eof`] if fewer than `n` bytes remain even after
+    /// refilling.
+    #[inline(always)]
+    pub fn take(&mut self, n: usize) -> Result<&[u8], ParserError> {
+        self.ensure_bytes(n)?;
+        unsafe {
+            let slice = std::slice::from_raw_parts(self.ptr, n);
+            self.advance_unchecked(n);
+            Ok(slice)
+        }
+    }
+
+    #[inline(never)]
+    fn refill_and_check_empty(&mut self) -> Result<bool, ParserError> {
+        let (buffer, source) = match self.streaming.as_deref_mut() {
+            None => return Ok(true),
+            Some(Backing::Owned { .. }) => return Ok(true),
+            Some(Backing::Stream { buffer, source }) => (buffer, source),
+        };
+
+        self.total_bytes_parsed += unsafe { self.ptr.offset_from_unsigned(self.base_ptr) };
+
+        let internal_buffer_start = buffer.as_mut_ptr();
+        self.ptr = internal_buffer_start;
+        self.end = internal_buffer_start;
+        // self.base_ptr remains fully immutable pointing to the vec start.
+
+        let bytes_written = source.read(&mut buffer[..])?;
+        if bytes_written == 0 {
+            return Ok(true);
+        }
+
+        self.end = unsafe { internal_buffer_start.add(bytes_written) };
+        Ok(false)
+    }
+
+    #[inline(never)]
+    fn refill_slow(&mut self, required: usize) -> Result<(), ParserError> {
+        // Owned buffers expose the entire payload up front; if we got here the
+        // request is bigger than what remains, so the answer is EOF — do *not*
+        // slide, because the data lives in the caller's allocation, not in a
+        // mutable refill buffer.
+        let (buffer, source) = match self.streaming.as_deref_mut() {
+            Some(Backing::Owned { .. }) | None => return Err(ParserError::eof()),
+            Some(Backing::Stream { buffer, source }) => (buffer, source),
+        };
+
+        if required > buffer.len() {
+            return Err(ParserError::buffer_too_small());
+        }
+
+        // 1. Commit metrics before transforming pointer arrays
+        let consumed_in_window = unsafe { self.ptr.offset_from_unsigned(self.base_ptr) };
+        self.total_bytes_parsed += consumed_in_window;
+
+        // 2. Identify unparsed trailing slices to save
+        let unparsed_len = unsafe { self.end.offset_from_unsigned(self.ptr) };
+        let internal_buffer_start = buffer.as_mut_ptr();
+
+        if unparsed_len > 0 {
+            unsafe {
+                // Slide data down to base alignment
+                ptr::copy(self.ptr, internal_buffer_start, unparsed_len);
+            }
+        }
+
+        // 3. Align tracking parameters to the head of the buffer
+        self.ptr = internal_buffer_start;
+        self.end = unsafe { internal_buffer_start.add(unparsed_len) };
+
+        // 4. Top up the buffer until it is completely full, or the stream
+        //    dries up. Only fail with EOF if we couldn't satisfy `required`.
+        loop {
+            let current_buffer_len =
+                unsafe { self.end.offset_from_unsigned(internal_buffer_start) };
+            if current_buffer_len >= buffer.len() {
+                return Ok(());
+            }
+
+            let target_slice = &mut buffer[current_buffer_len..];
+            let bytes_written = source.read(target_slice)?;
+
+            if bytes_written == 0 {
+                let available = unsafe { self.end.offset_from_unsigned(self.ptr) };
+                if available >= required {
+                    return Ok(());
+                }
+                return Err(ParserError::eof());
+            }
+
+            self.end = unsafe { self.end.add(bytes_written) };
+        }
+    }
+}
+
+/// Jomini binary-format helpers for [`ParserSource`].
+pub trait BinarySourceExt {
+    /// Reads a Jomini binary byte string.
+    ///
+    /// Binary strings are encoded as a little-endian `u16` byte length followed by
+    /// that many raw bytes. The returned bytes are not decoded; callers should use
+    /// the active game encoding or format to interpret them.
+    fn read_bstr(&mut self) -> Result<&[u8], ParserError>;
+
+    /// Reads the next two bytes as a Jomini binary lexeme id.
+    fn read_lexeme_id(&mut self) -> Result<LexemeId, ParserError>;
+
+    /// Peeks at the next two bytes as a Jomini binary lexeme id without advancing.
+    fn peek_lexeme_id(&mut self) -> Result<Option<LexemeId>, ParserError>;
+}
+
+impl BinarySourceExt for ParserSource<'_> {
+    #[inline]
+    fn read_bstr(&mut self) -> Result<&[u8], ParserError> {
+        self.ensure_bytes(2)?;
+        let len = u16::from_le_bytes(unsafe { *self.ptr.cast::<[u8; 2]>() }) as usize;
+        self.ensure_bytes(2 + len)?;
+        unsafe {
+            self.advance_unchecked(2);
+            let data = std::slice::from_raw_parts(self.ptr, len);
+            self.advance_unchecked(len);
+            Ok(data)
+        }
+    }
+
+    #[inline]
+    fn read_lexeme_id(&mut self) -> Result<LexemeId, ParserError> {
+        Ok(LexemeId::new(u16::from_le_bytes(*self.take_array::<2>()?)))
+    }
+
+    #[inline]
+    fn peek_lexeme_id(&mut self) -> Result<Option<LexemeId>, ParserError> {
+        Ok(self
+            .peek::<2>()?
+            .map(|x| LexemeId::new(u16::from_le_bytes(*x))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{self, Read};
+
+    /// A [`Read`] adapter that hands out at most `chunk` bytes per call,
+    /// stressing the refill paths of [`ParserSource::from_reader`].
+    ///
+    /// Use `chunk = 1` to force a refill between every byte.
+    struct ChunkedReader {
+        data: Vec<u8>,
+        pos: usize,
+        chunk: usize,
+    }
+
+    impl ChunkedReader {
+        fn new(data: Vec<u8>, chunk: usize) -> Self {
+            assert!(chunk > 0);
+            Self {
+                data,
+                pos: 0,
+                chunk,
+            }
+        }
+    }
+
+    impl Read for ChunkedReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let remaining = self.data.len() - self.pos;
+            let n = remaining.min(buf.len()).min(self.chunk);
+            buf[..n].copy_from_slice(&self.data[self.pos..self.pos + n]);
+            self.pos += n;
+            Ok(n)
+        }
+    }
+
+    struct FailingReader;
+
+    impl Read for FailingReader {
+        fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::InvalidData, "read failed"))
+        }
+    }
+
+    /// Builds matched slice/stream parsers over the same input.
+    fn parsers(
+        data: &[u8],
+        chunk: usize,
+        capacity: usize,
+    ) -> (ParserSource<'_>, ParserSource<'static>) {
+        let slice = ParserSource::from_slice(data);
+        let stream = ParserSource::from_reader_with_buf(
+            ChunkedReader::new(data.to_vec(), chunk),
+            vec![0; capacity],
+        );
+        (slice, stream)
+    }
+
+    #[test]
+    fn parser_error_classifies_io_error() {
+        use std::error::Error as _;
+
+        let err = ParserError::from(io::Error::other("boom"));
+        assert_eq!(err, ParserError::Io);
+        assert_eq!(err.to_string(), "io error");
+        assert!(err.source().is_none());
+
+        let parser_err = ParserError::from(io::Error::new(io::ErrorKind::InvalidData, "bad"));
+        let io_err: io::Error = parser_err.into();
+        assert_eq!(io_err.kind(), io::ErrorKind::Other);
+    }
+
+    #[test]
+    fn empty_input_is_immediately_eof() {
+        let mut s = ParserSource::from_slice(&[]);
+        assert!(s.is_eof().unwrap());
+
+        let mut r = ParserSource::from_reader_with_buf(ChunkedReader::new(vec![], 1), vec![0; 16]);
+        assert!(r.is_eof().unwrap());
+    }
+
+    #[test]
+    fn is_eof_is_false_when_window_has_remaining_bytes() {
+        let mut parser = ParserSource::from_slice(&[1, 2, 3]);
+        assert!(!parser.is_eof().unwrap());
+    }
+
+    #[test]
+    fn slice_ensure_bytes_past_end_is_eof() {
+        let mut s = ParserSource::from_slice(&[1, 2, 3]);
+        let err = s.ensure_bytes(4).unwrap_err();
+        assert!(err.is_eof());
+    }
+
+    #[test]
+    fn read_fixed_parity_byte_at_a_time() {
+        let data: Vec<u8> = (0..50u8).collect();
+        let (mut slice, mut stream) = parsers(&data, 1, 16);
+
+        for _ in 0..10 {
+            let a = *slice.take_array::<5>().unwrap();
+            let b = *stream.take_array::<5>().unwrap();
+            assert_eq!(a, b);
+            assert_eq!(slice.position(), stream.position());
+        }
+        assert!(slice.is_eof().unwrap());
+        assert!(stream.is_eof().unwrap());
+    }
+
+    #[test]
+    fn peek_does_not_advance_and_matches_read() {
+        let data: Vec<u8> = (0..20u8).collect();
+        let (mut slice, mut stream) = parsers(&data, 1, 8);
+
+        let ps = *slice.peek::<4>().unwrap().unwrap();
+        let pr = *stream.peek::<4>().unwrap().unwrap();
+        assert_eq!(ps, pr);
+        // Peeking should not advance.
+        assert_eq!(slice.position(), 0);
+        assert_eq!(stream.position(), 0);
+
+        let rs = *slice.take_array::<4>().unwrap();
+        let rr = *stream.take_array::<4>().unwrap();
+        assert_eq!(ps, rs);
+        assert_eq!(pr, rr);
+    }
+
+    #[test]
+    fn peek_propagates_non_eof_read_errors() {
+        let mut parser = ParserSource::from_reader_with_buf(FailingReader, vec![0; 8]);
+        let err = parser.peek::<1>().unwrap_err();
+
+        assert!(!err.is_eof());
+        assert_eq!(err, ParserError::Io);
+    }
+
+    #[test]
+    fn peek_at_eof_returns_none() {
+        let data = [1u8, 2, 3];
+        let (mut slice, mut stream) = parsers(&data, 1, 8);
+        slice.take_array::<3>().unwrap();
+        stream.take_array::<3>().unwrap();
+        assert!(slice.peek::<4>().unwrap().is_none());
+        assert!(stream.peek::<4>().unwrap().is_none());
+    }
+
+    #[test]
+    fn length_prefixed_slice_parity_across_refills() {
+        // Three length-prefixed payloads. The streaming buffer (capacity 8) is
+        // intentionally smaller than the largest payload+prefix, so the slow
+        // path's "slide unparsed bytes down" branch is exercised.
+        let mut data = Vec::new();
+        for payload in [b"abcd".as_slice(), b"hi", b"streaming!!"] {
+            data.extend_from_slice(&(payload.len() as u16).to_le_bytes());
+            data.extend_from_slice(payload);
+        }
+
+        // Use a tiny buffer (16 bytes) and 1-byte chunks to force many refills.
+        let (mut slice, mut stream) = parsers(&data, 1, 16);
+
+        for expected in [b"abcd".as_slice(), b"hi", b"streaming!!"] {
+            let a = slice.read_bstr().unwrap().to_vec();
+            let b = stream.read_bstr().unwrap().to_vec();
+            assert_eq!(a, expected);
+            assert_eq!(b, expected);
+        }
+        assert!(slice.is_eof().unwrap());
+        assert!(stream.is_eof().unwrap());
+    }
+
+    #[test]
+    fn length_prefix_preserved_when_body_unavailable() {
+        // Stream: 2-byte length prefix says 10, then truncated body of 4 bytes.
+        let mut data = Vec::new();
+        data.extend_from_slice(&10u16.to_le_bytes());
+        data.extend_from_slice(b"abcd");
+
+        let mut stream =
+            ParserSource::from_reader_with_buf(ChunkedReader::new(data.clone(), 1), vec![0; 32]);
+
+        let err = stream.read_bstr().unwrap_err();
+        assert!(err.is_eof());
+
+        // The contract: cursor remains intact, so the length prefix is still
+        // visible to a subsequent peek.
+        let prefix = stream.peek::<2>().unwrap().unwrap();
+        assert_eq!(u16::from_le_bytes(*prefix), 10);
+    }
+
+    #[test]
+    fn position_is_cumulative_across_refills() {
+        let data: Vec<u8> = (0..100u8).collect();
+        let mut stream =
+            ParserSource::from_reader_with_buf(ChunkedReader::new(data.clone(), 1), vec![0; 8]);
+
+        let mut consumed = 0usize;
+        while !stream.is_eof().unwrap() {
+            let _ = stream.take_array::<1>().unwrap();
+            consumed += 1;
+            assert_eq!(stream.position(), consumed);
+        }
+        assert_eq!(consumed, data.len());
+    }
+
+    #[test]
+    fn as_slice_and_remaining_reflect_window() {
+        let data = [1u8, 2, 3, 4, 5];
+        let mut slice = ParserSource::from_slice(&data);
+        assert_eq!(slice.remaining(), 5);
+        assert_eq!(slice.as_slice(), &data);
+        slice.take_array::<2>().unwrap();
+        assert_eq!(slice.remaining(), 3);
+        assert_eq!(slice.as_slice(), &[3, 4, 5]);
+    }
+
+    #[test]
+    fn advance_within_window_moves_cursor_and_subsequent_reads_follow() {
+        let mut parser = ParserSource::from_slice(&[10, 20, 30, 40, 50]);
+        assert!(parser.advance(2));
+        assert_eq!(parser.remaining(), 3);
+        assert_eq!(parser.position(), 2);
+        assert_eq!(*parser.take_array::<2>().unwrap(), [30, 40]);
+        assert_eq!(parser.as_slice(), &[50]);
+    }
+
+    #[test]
+    fn advance_past_window_returns_false_and_does_not_move() {
+        let mut parser = ParserSource::from_slice(&[1, 2, 3]);
+        assert!(!parser.advance(4));
+        assert_eq!(parser.remaining(), 3);
+        assert_eq!(parser.as_slice(), &[1, 2, 3]);
+        assert_eq!(parser.position(), 0);
+    }
+
+    #[test]
+    fn advance_does_not_refill_streaming_window() {
+        // Streaming parser starts with an empty window — advance must not
+        // trigger a refill, so a non-zero request fails until the window is
+        // materialized by another call (e.g. ensure_bytes).
+        let data: Vec<u8> = (0..10u8).collect();
+        let mut stream =
+            ParserSource::from_reader_with_buf(ChunkedReader::new(data, 1), vec![0; 8]);
+        assert_eq!(stream.remaining(), 0);
+        assert!(!stream.advance(1));
+
+        stream.ensure_bytes(4).unwrap();
+        let window = stream.remaining();
+        assert!(!stream.advance(window + 1));
+        assert!(stream.advance(window));
+        assert_eq!(stream.position(), window);
+    }
+
+    #[test]
+    fn get_slice_unchecked_returns_current_window_prefix() {
+        let mut parser = ParserSource::from_slice(&[1, 2, 3, 4]);
+        parser.ensure_bytes(3).unwrap();
+
+        let slice = unsafe { parser.get_slice_unchecked(3) };
+        assert_eq!(slice, &[1, 2, 3]);
+        assert_eq!(parser.position(), 0);
+    }
+
+    #[test]
+    fn ensure_bytes_errors_when_request_exceeds_capacity() {
+        let mut stream =
+            ParserSource::from_reader_with_buf(ChunkedReader::new(vec![0u8; 32], 1), vec![0; 8]);
+        let err = stream.ensure_bytes(16).unwrap_err();
+        assert!(err.is_buffer_too_small());
+    }
+
+    #[test]
+    fn from_owned_vec_parity_with_slice() {
+        let data: Vec<u8> = (0..50u8).collect();
+        let mut slice = ParserSource::from_slice(&data);
+        let mut owned = ParserSource::from_owned(data.clone());
+
+        for _ in 0..10 {
+            let a = *slice.take_array::<5>().unwrap();
+            let b = *owned.take_array::<5>().unwrap();
+            assert_eq!(a, b);
+            assert_eq!(slice.position(), owned.position());
+        }
+        assert!(slice.is_eof().unwrap());
+        assert!(owned.is_eof().unwrap());
+    }
+
+    #[test]
+    fn from_owned_array_is_static() {
+        // `[u8; N]` owned by value — confirms the bound accepts non-Vec owners
+        // and that the returned parser is `'static`.
+        fn requires_static(_: &ParserSource<'static>) {}
+        let owned = ParserSource::from_owned([1u8, 2, 3, 4]);
+        requires_static(&owned);
+        let mut owned = owned;
+        assert_eq!(*owned.take_array::<4>().unwrap(), [1, 2, 3, 4]);
+        assert!(owned.is_eof().unwrap());
+    }
+
+    #[test]
+    fn from_owned_arc_keeps_data_alive() {
+        use std::sync::Arc;
+        let arc: Arc<[u8]> = Arc::from(vec![10u8, 20, 30, 40, 50].into_boxed_slice());
+        let mut owned = ParserSource::from_owned(Arc::clone(&arc));
+        drop(arc); // owner inside ParserSource must keep allocation alive
+        assert_eq!(*owned.take_array::<5>().unwrap(), [10, 20, 30, 40, 50]);
+        assert!(owned.is_eof().unwrap());
+    }
+
+    #[test]
+    fn from_owned_ensure_bytes_past_end_is_eof_without_slide() {
+        // After consuming a prefix, requesting more than remains must return
+        // EOF without disturbing the cursor: the tail of the owner's slice
+        // should still be visible via as_slice().
+        let mut owned = ParserSource::from_owned(vec![1u8, 2, 3, 4, 5]);
+        owned.take_array::<2>().unwrap();
+        let tail_ptr_before = owned.as_slice().as_ptr();
+        let err = owned.ensure_bytes(10).unwrap_err();
+        assert!(err.is_eof());
+        assert_eq!(owned.as_slice(), &[3, 4, 5]);
+        // No slide: the slice still points into the original owner allocation.
+        assert_eq!(owned.as_slice().as_ptr(), tail_ptr_before);
+    }
+
+    #[test]
+    fn from_owned_static_bytes() {
+        static DATA: &[u8] = b"hello world";
+        let mut owned = ParserSource::from_owned(DATA);
+        assert_eq!(*owned.take_array::<5>().unwrap(), *b"hello");
+        owned.take_array::<1>().unwrap();
+        assert_eq!(*owned.take_array::<5>().unwrap(), *b"world");
+        assert!(owned.is_eof().unwrap());
+    }
+}

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -19,7 +19,7 @@ pub(crate) struct BufferWindow {
 
 pub enum BufferError {
     Io(std::io::Error),
-    BufferFull,
+    BufferTooSmall,
 }
 
 impl BufferWindow {
@@ -90,7 +90,7 @@ impl BufferWindow {
         // Copy over the unconsumed bytes to the start of the buffer
         if carry_over != 0 {
             if carry_over >= self.buf.len() {
-                return Err(BufferError::BufferFull);
+                return Err(BufferError::BufferTooSmall);
             }
             self.buf.copy_within(self.consumed_data().., 0);
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -82,7 +82,7 @@ pub enum ErrorKind {
 
     /// The internal buffer does not have enough room to store data for the next
     /// token
-    BufferFull,
+    BufferTooSmall,
 }
 
 impl ErrorKind {
@@ -128,8 +128,8 @@ impl std::fmt::Display for Error {
             ),
             ErrorKind::Deserialize(ref err) => write!(f, "deserialize error: {}", err),
             ErrorKind::Io(ref err) => write!(f, "io error: {}", err),
-            ErrorKind::BufferFull => {
-                write!(f, "max buffer size exceeded")
+            ErrorKind::BufferTooSmall => {
+                write!(f, "token exceeds buffer capacity")
             }
         }
     }
@@ -157,8 +157,10 @@ impl From<BinReaderError> for Error {
     fn from(value: BinReaderError) -> Self {
         let pos = value.position();
         match value.into_kind() {
-            crate::binary::ReaderErrorKind::Read(x) => Error::new(ErrorKind::Io(x)),
-            crate::binary::ReaderErrorKind::BufferFull => Error::new(ErrorKind::BufferFull),
+            crate::binary::ReaderErrorKind::Read => Error::new(ErrorKind::Io(
+                std::io::Error::other("binary reader io error"),
+            )),
+            crate::binary::ReaderErrorKind::BufferTooSmall => Error::new(ErrorKind::BufferTooSmall),
             crate::binary::ReaderErrorKind::Lexer(LexError::Eof) => Error::eof(),
             crate::binary::ReaderErrorKind::Lexer(LexError::InvalidRgb) => {
                 Error::invalid_syntax("invalid rgb", pos)
@@ -171,7 +173,7 @@ impl From<TextReaderError> for Error {
     fn from(value: TextReaderError) -> Self {
         match value.into_kind() {
             crate::text::ReaderErrorKind::Read(x) => Error::new(ErrorKind::Io(x)),
-            crate::text::ReaderErrorKind::BufferFull => Error::new(ErrorKind::BufferFull),
+            crate::text::ReaderErrorKind::BufferTooSmall => Error::new(ErrorKind::BufferTooSmall),
             crate::text::ReaderErrorKind::Eof => Error::eof(),
         }
     }

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -865,7 +865,7 @@ pub enum ReaderErrorKind {
 
     /// The internal buffer does not have enough room to store data for the next
     /// token
-    BufferFull,
+    BufferTooSmall,
 
     /// An early end of the data encountered
     Eof,
@@ -876,7 +876,7 @@ impl From<BufferError> for ReaderErrorKind {
     fn from(value: BufferError) -> Self {
         match value {
             BufferError::Io(x) => ReaderErrorKind::Read(x),
-            BufferError::BufferFull => ReaderErrorKind::BufferFull,
+            BufferError::BufferTooSmall => ReaderErrorKind::BufferTooSmall,
         }
     }
 }
@@ -894,8 +894,12 @@ impl std::fmt::Display for ReaderError {
             ReaderErrorKind::Read { .. } => {
                 write!(f, "failed to read past position: {}", self.position)
             }
-            ReaderErrorKind::BufferFull => {
-                write!(f, "max buffer size exceeded at position: {}", self.position)
+            ReaderErrorKind::BufferTooSmall => {
+                write!(
+                    f,
+                    "token exceeds buffer capacity at position: {}",
+                    self.position
+                )
             }
             ReaderErrorKind::Eof => {
                 write!(f, "unexpected end of file at position: {}", self.position)

--- a/tests/envelope.rs
+++ b/tests/envelope.rs
@@ -448,39 +448,50 @@ impl BinaryFlavor for TestFlavor {
     }
 }
 
-type BinaryDeserializer<'res, RES, R> = BinaryReaderDeserializer<'res, RES, TestFlavor, R>;
+type BinaryDeserializer<'r, 'res, RES> = BinaryReaderDeserializer<'r, 'res, RES, TestFlavor>;
 
 trait DeserializeBinary {
-    fn deserializer<'res, RES: TokenResolver>(
-        &mut self,
+    fn deserializer<'r, 'res, RES: TokenResolver>(
+        &'r mut self,
         resolver: &'res RES,
-    ) -> BinaryDeserializer<'res, RES, impl Read + '_>;
+    ) -> BinaryDeserializer<'r, 'res, RES>
+    where
+        Self: 'r;
 }
 
 impl<R: ReaderAt> DeserializeBinary for SaveData<BinaryEncoding, R> {
-    fn deserializer<'res, RES: TokenResolver>(
-        &mut self,
+    fn deserializer<'r, 'res, RES: TokenResolver>(
+        &'r mut self,
         resolver: &'res RES,
-    ) -> BinaryDeserializer<'res, RES, impl Read + '_> {
+    ) -> BinaryDeserializer<'r, 'res, RES>
+    where
+        Self: 'r,
+    {
         BinaryDeserializerBuilder::with_flavor(TestFlavor)
             .from_reader(self.body().cursor(), resolver)
     }
 }
 
 impl<R: Read> DeserializeBinary for SaveContent<BinaryEncoding, R> {
-    fn deserializer<'res, RES: TokenResolver>(
-        &mut self,
+    fn deserializer<'r, 'res, RES: TokenResolver>(
+        &'r mut self,
         resolver: &'res RES,
-    ) -> BinaryDeserializer<'res, RES, impl Read + '_> {
+    ) -> BinaryDeserializer<'r, 'res, RES>
+    where
+        Self: 'r,
+    {
         BinaryDeserializerBuilder::with_flavor(TestFlavor).from_reader(self, resolver)
     }
 }
 
 impl<R: Read> DeserializeBinary for SaveMetadata<BinaryEncoding, R> {
-    fn deserializer<'res, RES: TokenResolver>(
-        &mut self,
+    fn deserializer<'r, 'res, RES: TokenResolver>(
+        &'r mut self,
         resolver: &'res RES,
-    ) -> BinaryDeserializer<'res, RES, impl Read + '_> {
+    ) -> BinaryDeserializer<'r, 'res, RES>
+    where
+        Self: 'r,
+    {
         BinaryDeserializerBuilder::with_flavor(TestFlavor).from_reader(self, resolver)
     }
 }


### PR DESCRIPTION
One source abstraction for slices, readers, and owned buffers

- eu4: 47.385 ms vs old 55.025 ms, -13.88% time, improved
- v3: 78.224 ms vs old 92.697 ms, -15.61% time, improved
- ck3: 38.864 ms vs old 45.981 ms, -15.48% time, improved