### PR TITLE
Introduce BinaryFormat extension point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+**/target
 **/*.rs.bk
 Cargo.lock
 assets/saves

--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -1,10 +1,11 @@
 use super::{
-    LexError, TokenReader,
+    LexError,
+    format::{BinaryFormat, FlavorFormat},
     lexer::{LexemeId, Lexer},
 };
 use crate::{
-    DeserializeError, DeserializeErrorKind, Error,
-    binary::{BinaryFlavor, FailedResolveStrategy, TokenKind, TokenResolver},
+    BinarySourceExt, DeserializeError, DeserializeErrorKind, Error, ParserSource,
+    binary::{BinaryFlavor, FailedResolveStrategy, TokenResolver},
     de::ColorSequence,
 };
 use serde::de::{
@@ -12,614 +13,59 @@ use serde::de::{
 };
 use std::{borrow::Cow, io::Read};
 
-/// Serde deserializer over a streaming binary reader
+/// Serde deserializer over a streaming binary reader.
+///
+/// Wraps a [`BinaryFormatDeserializer`] using the crate's built-in
+/// `FlavorFormat`, which bridges a [`BinaryFlavor`] and a [`TokenResolver`].
 pub struct BinaryReaderDeserializer<'r, 'res, RES, F> {
-    reader: TokenReader<'r>,
-    config: BinaryConfig<'res, RES, F>,
+    de: BinaryFormatDeserializer<'r, FlavorFormat<F, &'res RES>>,
 }
 
-impl<RES: TokenResolver, E: BinaryFlavor> BinaryReaderDeserializer<'_, '_, RES, E> {
-    /// Deserialize into provided type
+impl<'r, 'res: 'r, RES: TokenResolver, F: BinaryFlavor> BinaryReaderDeserializer<'r, 'res, RES, F> {
+    /// Deserialize into the provided type.
     pub fn deserialize<T>(&mut self) -> Result<T, Error>
     where
         T: DeserializeOwned,
     {
-        T::deserialize(self)
+        self.de.deserialize()
     }
 }
 
-impl<'de, 'r, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::Deserializer<'de>
-    for &'_ mut BinaryReaderDeserializer<'r, 'res, RES, F>
+impl<'de, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::Deserializer<'de>
+    for &mut BinaryReaderDeserializer<'de, 'res, RES, F>
 {
     type Error = Error;
 
-    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(
-                "root deserializer can only work with key value pairs",
-            ),
-        }))
+        de::Deserializer::deserialize_any(&mut self.de, visitor)
     }
 
     fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_map(BinaryReaderMap::new(self, true))
+        de::Deserializer::deserialize_map(&mut self.de, visitor)
     }
 
     fn deserialize_struct<V>(
         self,
-        _name: &'static str,
-        _fields: &'static [&'static str],
+        name: &'static str,
+        fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        self.deserialize_map(visitor)
+        de::Deserializer::deserialize_struct(&mut self.de, name, fields, visitor)
     }
 
     serde::forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct enum ignored_any identifier
-    }
-}
-
-struct BinaryReaderMap<'a: 'a, 'r, 'res, RES: 'a, F> {
-    de: &'a mut BinaryReaderDeserializer<'r, 'res, RES, F>,
-    root: bool,
-}
-
-impl<'a, 'r, 'res, RES: 'a, F> BinaryReaderMap<'a, 'r, 'res, RES, F> {
-    fn new(de: &'a mut BinaryReaderDeserializer<'r, 'res, RES, F>, root: bool) -> Self {
-        BinaryReaderMap { de, root }
-    }
-}
-
-impl<'de, 'r, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> MapAccess<'de>
-    for BinaryReaderMap<'_, 'r, 'res, RES, F>
-{
-    type Error = Error;
-
-    #[inline]
-    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
-    where
-        K: DeserializeSeed<'de>,
-    {
-        loop {
-            match self.de.reader.next_token() {
-                Ok(Some(TokenKind::Close)) => return Ok(None),
-                Ok(Some(TokenKind::Open)) => {
-                    let _ = self.de.reader.read_token();
-                }
-                Ok(Some(token)) => {
-                    return seed
-                        .deserialize(BinaryReaderTokenDeserializer { de: self.de, token })
-                        .map(Some);
-                }
-                Ok(None) if self.root => return Ok(None),
-                Ok(None) => {
-                    return Err(LexError::Eof.at(self.de.reader.position()).into());
-                }
-                Err(e) => return Err(e.into()),
-            }
-        }
-    }
-
-    #[inline]
-    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
-    where
-        V: DeserializeSeed<'de>,
-    {
-        let mut token = self.de.reader.read_token()?;
-        if matches!(token, TokenKind::Equal) {
-            token = self.de.reader.read_token()?;
-        }
-
-        seed.deserialize(BinaryReaderTokenDeserializer { de: self.de, token })
-    }
-}
-
-struct BinaryReaderTokenDeserializer<'a, 'r, 'res, RES: 'a, F> {
-    de: &'a mut BinaryReaderDeserializer<'r, 'res, RES, F>,
-    token: TokenKind,
-}
-
-impl<'r, 'res, RES: TokenResolver, F> BinaryReaderTokenDeserializer<'_, 'r, 'res, RES, F>
-where
-    F: BinaryFlavor,
-{
-    #[inline]
-    fn deser<'de, V>(self, visitor: V) -> Result<V::Value, Error>
-    where
-        V: de::Visitor<'de>,
-        'res: 'de,
-    {
-        match self.token {
-            TokenKind::U32 => visitor.visit_u32(self.de.reader.u32_data()),
-            TokenKind::U64 => visitor.visit_u64(self.de.reader.u64_data()),
-            TokenKind::I32 => visitor.visit_i32(self.de.reader.i32_data()),
-            TokenKind::I64 => visitor.visit_i64(self.de.reader.i64_data()),
-            TokenKind::Bool => visitor.visit_bool(self.de.reader.bool_data()),
-            TokenKind::F32 => {
-                visitor.visit_f32(self.de.config.flavor.visit_f32(self.de.reader.f32_data()))
-            }
-            TokenKind::F64 => {
-                visitor.visit_f64(self.de.config.flavor.visit_f64(self.de.reader.f64_data()))
-            }
-            TokenKind::Quoted | TokenKind::Unquoted => {
-                let s = unsafe { self.de.reader.scalar_data() };
-                match self.de.config.flavor.decode(s.as_bytes()) {
-                    Cow::Borrowed(x) => visitor.visit_str(x),
-                    Cow::Owned(x) => visitor.visit_string(x),
-                }
-            }
-            TokenKind::Id => match self.de.config.resolver.resolve(self.de.reader.token_id()) {
-                Some(id) => visitor.visit_borrowed_str(id),
-                None => match self.de.config.failed_resolve_strategy {
-                    FailedResolveStrategy::Error => Err(Error::from(DeserializeError {
-                        kind: DeserializeErrorKind::UnknownToken {
-                            token_id: self.de.reader.token_id() as u32,
-                        },
-                    })),
-                    FailedResolveStrategy::Stringify => {
-                        visitor.visit_string(format!("0x{:x}", self.de.reader.token_id()))
-                    }
-                    FailedResolveStrategy::Ignore => {
-                        visitor.visit_borrowed_str("__internal_identifier_ignore")
-                    }
-                },
-            },
-            TokenKind::Close => Err(Error::invalid_syntax(
-                "did not expect end",
-                self.de.reader.position(),
-            )),
-            TokenKind::Equal => Err(Error::invalid_syntax(
-                "did not expect equal",
-                self.de.reader.position(),
-            )),
-            TokenKind::Open => visitor.visit_seq(BinaryReaderSeq::new(self.de)),
-            TokenKind::Rgb => visitor.visit_seq(ColorSequence::new(self.de.reader.rgb_data())),
-            TokenKind::Lookup => {
-                let index = self.de.reader.lookup_data();
-                match self.de.config.resolver.lookup(index) {
-                    Some(value) => visitor.visit_borrowed_str(value),
-                    None => match self.de.config.failed_resolve_strategy {
-                        FailedResolveStrategy::Error => Err(Error::from(DeserializeError {
-                            kind: DeserializeErrorKind::UnknownToken { token_id: index },
-                        })),
-                        FailedResolveStrategy::Stringify => {
-                            visitor.visit_string(format!("{}", index))
-                        }
-                        FailedResolveStrategy::Ignore => {
-                            visitor.visit_borrowed_str("__internal_identifier_ignore")
-                        }
-                    },
-                }
-            }
-        }
-    }
-}
-
-macro_rules! deserialize_scalar {
-    ($method:ident) => {
-        #[inline]
-        fn $method<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-        where
-            V: de::Visitor<'de>,
-        {
-            self.deser(visitor)
-        }
-    };
-}
-
-impl<'a, 'de: 'a, 'r, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::Deserializer<'de>
-    for BinaryReaderTokenDeserializer<'a, 'r, 'res, RES, F>
-{
-    type Error = Error;
-
-    deserialize_scalar!(deserialize_any);
-    deserialize_scalar!(deserialize_i8);
-    deserialize_scalar!(deserialize_i16);
-    deserialize_scalar!(deserialize_u8);
-    deserialize_scalar!(deserialize_char);
-    deserialize_scalar!(deserialize_identifier);
-
-    #[inline]
-    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: de::Visitor<'de>,
-    {
-        match self.token {
-            TokenKind::Quoted | TokenKind::Unquoted => {
-                visitor.visit_bytes(unsafe { self.de.reader.scalar_data() }.as_bytes())
-            }
-            _ => self.deser(visitor),
-        }
-    }
-
-    #[inline]
-    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: de::Visitor<'de>,
-    {
-        self.deserialize_bytes(visitor)
-    }
-
-    #[inline]
-    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if matches!(self.token, TokenKind::Bool) {
-            visitor.visit_bool(self.de.reader.bool_data())
-        } else {
-            self.deser(visitor)
-        }
-    }
-
-    #[inline]
-    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        match self.token {
-            TokenKind::Id => visitor.visit_u16(self.de.reader.token_id()),
-            _ => self.deser(visitor),
-        }
-    }
-
-    #[inline]
-    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if matches!(self.token, TokenKind::I32) {
-            visitor.visit_i32(self.de.reader.i32_data())
-        } else {
-            self.deser(visitor)
-        }
-    }
-
-    #[inline]
-    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        match self.token {
-            TokenKind::U32 => visitor.visit_u32(self.de.reader.u32_data()),
-            TokenKind::Lookup => visitor.visit_u32(self.de.reader.lookup_data()),
-            _ => self.deser(visitor),
-        }
-    }
-
-    #[inline]
-    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if matches!(self.token, TokenKind::U64) {
-            visitor.visit_u64(self.de.reader.u64_data())
-        } else {
-            self.deser(visitor)
-        }
-    }
-
-    #[inline]
-    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if matches!(self.token, TokenKind::I64) {
-            visitor.visit_i64(self.de.reader.i64_data())
-        } else {
-            self.deser(visitor)
-        }
-    }
-
-    #[inline]
-    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if matches!(self.token, TokenKind::F32) {
-            visitor.visit_f32(self.de.config.flavor.visit_f32(self.de.reader.f32_data()))
-        } else {
-            self.deser(visitor)
-        }
-    }
-
-    #[inline]
-    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if matches!(self.token, TokenKind::F64) {
-            visitor.visit_f64(self.de.config.flavor.visit_f64(self.de.reader.f64_data()))
-        } else {
-            self.deser(visitor)
-        }
-    }
-
-    #[inline]
-    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_string(visitor)
-    }
-
-    #[inline]
-    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        match self.token {
-            TokenKind::Quoted | TokenKind::Unquoted => {
-                match self
-                    .de
-                    .config
-                    .flavor
-                    .decode(unsafe { self.de.reader.scalar_data() }.as_bytes())
-                {
-                    Cow::Borrowed(x) => visitor.visit_str(x),
-                    Cow::Owned(x) => visitor.visit_string(x),
-                }
-            }
-            _ => self.deser(visitor),
-        }
-    }
-
-    #[inline]
-    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_some(self)
-    }
-
-    #[inline]
-    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_ignored_any(visitor)
-    }
-
-    #[inline]
-    fn deserialize_unit_struct<V>(
-        self,
-        _name: &'static str,
-        visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_ignored_any(visitor)
-    }
-
-    #[inline]
-    fn deserialize_newtype_struct<V>(
-        self,
-        _name: &'static str,
-        visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_newtype_struct(self)
-    }
-
-    #[inline]
-    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        match self.token {
-            TokenKind::Open => {
-                let mut seq = BinaryReaderSeq::new(self.de);
-                let result = visitor.visit_seq(&mut seq)?;
-                if !seq.hit_end {
-                    // For when we are deserializing an array that doesn't read
-                    // the closing token
-                    if !matches!(self.de.reader.read_token()?, TokenKind::Close) {
-                        return Err(Error::invalid_syntax(
-                            "Expected sequence to be terminated with an end token",
-                            self.de.reader.position(),
-                        ));
-                    }
-                }
-                Ok(result)
-            }
-            TokenKind::Rgb => visitor.visit_seq(ColorSequence::new(self.de.reader.rgb_data())),
-            _ => self.deser(visitor),
-        }
-    }
-
-    #[inline]
-    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_seq(visitor)
-    }
-
-    #[inline]
-    fn deserialize_tuple_struct<V>(
-        self,
-        _name: &'static str,
-        _len: usize,
-        visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_seq(visitor)
-    }
-
-    #[inline]
-    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if matches!(self.token, TokenKind::Open) {
-            visitor.visit_map(BinaryReaderMap::new(self.de, false))
-        } else {
-            self.deser(visitor)
-        }
-    }
-
-    #[inline]
-    fn deserialize_struct<V>(
-        self,
-        _name: &'static str,
-        _fields: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_map(visitor)
-    }
-
-    #[inline]
-    fn deserialize_enum<V>(
-        self,
-        _name: &'static str,
-        _variants: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_enum(BinaryReaderEnum::new(self.de, self.token))
-    }
-
-    #[inline]
-    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if matches!(self.token, TokenKind::Open) {
-            self.de.reader.skip_container()?;
-        }
-
-        visitor.visit_unit()
-    }
-}
-
-struct BinaryReaderSeq<'a: 'a, 'r, 'res, RES: 'a, F> {
-    de: &'a mut BinaryReaderDeserializer<'r, 'res, RES, F>,
-    hit_end: bool,
-}
-
-impl<'a, 'r, 'res, RES: 'a, F> BinaryReaderSeq<'a, 'r, 'res, RES, F> {
-    fn new(de: &'a mut BinaryReaderDeserializer<'r, 'res, RES, F>) -> Self {
-        BinaryReaderSeq { de, hit_end: false }
-    }
-}
-
-impl<'de, 'r, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> SeqAccess<'de>
-    for BinaryReaderSeq<'_, 'r, 'res, RES, F>
-{
-    type Error = Error;
-
-    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
-    where
-        T: DeserializeSeed<'de>,
-    {
-        let mut token = self.de.reader.read_token()?;
-        if matches!(token, TokenKind::Close) {
-            self.hit_end = true;
-            return Ok(None);
-        } else if matches!(token, TokenKind::Equal) {
-            // This is a standalone Equal token from object template syntax
-            token = self.de.reader.read_token()?;
-        }
-
-        seed.deserialize(BinaryReaderTokenDeserializer { de: self.de, token })
-            .map(Some)
-    }
-}
-
-struct BinaryReaderEnum<'a, 'r, 'res, RES: 'a, F> {
-    de: &'a mut BinaryReaderDeserializer<'r, 'res, RES, F>,
-    token: TokenKind,
-}
-
-impl<'a, 'r, 'res, RES: 'a, F> BinaryReaderEnum<'a, 'r, 'res, RES, F> {
-    fn new(de: &'a mut BinaryReaderDeserializer<'r, 'res, RES, F>, token: TokenKind) -> Self {
-        BinaryReaderEnum { de, token }
-    }
-}
-
-impl<'de, 'r, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::EnumAccess<'de>
-    for BinaryReaderEnum<'_, 'r, 'res, RES, F>
-{
-    type Error = Error;
-    type Variant = Self;
-
-    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self), Self::Error>
-    where
-        V: de::DeserializeSeed<'de>,
-    {
-        let variant = seed.deserialize(BinaryReaderTokenDeserializer {
-            de: self.de,
-            token: self.token,
-        })?;
-        Ok((variant, self))
-    }
-}
-
-impl<'de, 'r, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::VariantAccess<'de>
-    for BinaryReaderEnum<'_, 'r, 'res, RES, F>
-{
-    type Error = Error;
-
-    fn unit_variant(self) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
-    fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value, Self::Error>
-    where
-        T: DeserializeSeed<'de>,
-    {
-        Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(
-                "unsupported enum deserialization. Please file issue",
-            ),
-        }))
-    }
-
-    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(
-                "unsupported enum deserialization. Please file issue",
-            ),
-        }))
-    }
-
-    fn struct_variant<V>(
-        self,
-        _fields: &'static [&'static str],
-        _visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        Err(Error::from(DeserializeError {
-            kind: DeserializeErrorKind::Unsupported(
-                "unsupported enum deserialization. Please file issue",
-            ),
-        }))
     }
 }
 
@@ -1366,17 +812,17 @@ where
         RES: TokenResolver,
         R: Read + 'r,
     {
-        let reader = match self.reader_buffer {
-            Some(buffer) => TokenReader::from_reader_with_buf(reader, buffer),
-            None => TokenReader::new(reader),
-        };
-        let config = BinaryConfig {
+        let format = FlavorFormat {
+            flavor: self.flavor,
             resolver,
             failed_resolve_strategy: self.failed_resolve_strategy,
-            flavor: self.flavor,
+        };
+        let de = match self.reader_buffer {
+            Some(buffer) => BinaryFormatDeserializer::from_reader_with_buf(reader, format, buffer),
+            None => BinaryFormatDeserializer::from_reader(reader, format),
         };
 
-        BinaryReaderDeserializer { reader, config }
+        BinaryReaderDeserializer { de }
     }
 
     /// Deserialize value from reader
@@ -1428,6 +874,595 @@ struct BinaryConfig<'res, RES, F> {
     resolver: &'res RES,
     failed_resolve_strategy: FailedResolveStrategy,
     flavor: F,
+}
+
+/// A binary deserializer generic over a [`BinaryFormat`].
+///
+/// Owns a [`ParserSource`] and a game-specific format. The deserializer handles
+/// map, sequence, struct, enum, option, and structural delimiter traversal; the
+/// format handles scalar and identifier decoding.
+pub struct BinaryFormatDeserializer<'de, F> {
+    source: ParserSource<'de>,
+    format: F,
+}
+
+/// Context passed to [`BinaryFormat`] implementations while decoding values.
+///
+/// The context exposes the parser source and format state without exposing the
+/// deserializer's internal access types. Implementations that consume an
+/// opening delimiter should advance the source past `OPEN`, then call
+/// [`BinaryFormatContext::visit_open_seq`] to run the format hook and hand the
+/// container to the visitor.
+pub struct BinaryFormatContext<'a, 'de, F> {
+    de: &'a mut BinaryFormatDeserializer<'de, F>,
+}
+
+impl<'a, 'de, F> BinaryFormatContext<'a, 'de, F> {
+    #[inline]
+    pub(crate) fn new(de: &'a mut BinaryFormatDeserializer<'de, F>) -> Self {
+        Self { de }
+    }
+
+    /// Return the underlying parser source.
+    #[inline]
+    pub fn source(&mut self) -> &mut ParserSource<'de> {
+        &mut self.de.source
+    }
+
+    /// Return shared access to the format state.
+    #[inline]
+    pub fn format(&self) -> &F {
+        &self.de.format
+    }
+
+    /// Return mutable access to the format state.
+    #[inline]
+    pub fn format_mut(&mut self) -> &mut F {
+        &mut self.de.format
+    }
+
+    /// Return mutable access to both the format state and parser source.
+    #[inline]
+    pub fn parts(&mut self) -> (&mut F, &mut ParserSource<'de>) {
+        (&mut self.de.format, &mut self.de.source)
+    }
+}
+
+impl<'a, 'de, F> BinaryFormatContext<'a, 'de, F>
+where
+    F: BinaryFormat,
+{
+    /// Visit a sequence after the caller has consumed the `OPEN` delimiter.
+    ///
+    /// This method calls [`BinaryFormat::on_open`] before visiting the
+    /// sequence, and consumes the closing delimiter when the visitor stops
+    /// before the end of the container.
+    #[inline]
+    pub fn visit_open_seq<V>(&mut self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.de.format.on_open();
+        let mut seq = BinarySeqAccess::new(self.de);
+        let result = visitor.visit_seq(&mut seq)?;
+        seq.finish()?;
+        Ok(result)
+    }
+}
+
+impl<'de, F> BinaryFormatDeserializer<'de, F> {
+    /// Construct a deserializer from an existing parser source and format.
+    pub fn from_source(source: ParserSource<'de>, format: F) -> Self {
+        Self { source, format }
+    }
+
+    /// Construct a deserializer over an in-memory slice.
+    pub fn from_slice(data: &'de [u8], format: F) -> Self {
+        Self::from_source(ParserSource::from_slice(data), format)
+    }
+
+    /// Construct a deserializer over a streaming reader.
+    pub fn from_reader<R: Read + 'de>(reader: R, format: F) -> Self {
+        Self::from_source(ParserSource::from_reader(reader), format)
+    }
+
+    /// Construct a deserializer over a streaming reader with a caller-provided
+    /// buffer.
+    pub fn from_reader_with_buf<R: Read + 'de>(reader: R, format: F, buffer: Vec<u8>) -> Self {
+        Self::from_source(ParserSource::from_reader_with_buf(reader, buffer), format)
+    }
+}
+
+impl<'de, F: BinaryFormat> BinaryFormatDeserializer<'de, F> {
+    /// Deserialize a value from this deserializer.
+    pub fn deserialize<T>(&mut self) -> Result<T, Error>
+    where
+        T: Deserialize<'de>,
+    {
+        T::deserialize(self)
+    }
+
+    #[inline]
+    fn peek_lexeme_id(&mut self) -> Result<Option<LexemeId>, Error> {
+        Ok(self.source.peek_lexeme_id()?)
+    }
+
+    fn maybe_open_container(&mut self) -> Result<bool, Error> {
+        match self.peek_lexeme_id()? {
+            Some(LexemeId::OPEN) => {
+                self.source.take::<2>()?;
+                self.format.on_open();
+                Ok(true)
+            }
+            Some(_) => Ok(false),
+            None => Err(Error::eof()),
+        }
+    }
+
+    fn skip_value(&mut self) -> Result<(), Error> {
+        let mut cx = BinaryFormatContext::new(self);
+        F::skip_value(&mut cx)
+    }
+}
+
+impl<'de, F> de::Deserializer<'de> for &mut BinaryFormatDeserializer<'de, F>
+where
+    F: BinaryFormat,
+{
+    type Error = Error;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::deserialize_msg(
+            "root deserializer can only work with key value pairs",
+        ))
+    }
+
+    #[inline]
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_map(BinaryMapAccess::new(self, true))
+    }
+
+    #[inline]
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct enum ignored_any identifier
+    }
+}
+
+struct BinaryValueDeserializer<'a, 'de, F> {
+    de: &'a mut BinaryFormatDeserializer<'de, F>,
+}
+
+impl<'de, F> BinaryValueDeserializer<'_, 'de, F>
+where
+    F: BinaryFormat,
+{
+    fn visit_container_seq<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let mut seq = BinarySeqAccess::new(self.de);
+        let result = visitor.visit_seq(&mut seq)?;
+        seq.finish()?;
+        Ok(result)
+    }
+}
+
+macro_rules! value_method {
+    ($name:ident, $format_method:ident) => {
+        #[inline]
+        fn $name<V>(self, visitor: V) -> Result<V::Value, Error>
+        where
+            V: Visitor<'de>,
+        {
+            let mut cx = BinaryFormatContext::new(self.de);
+            F::$format_method(&mut cx, visitor)
+        }
+    };
+}
+
+impl<'de, F> de::Deserializer<'de> for BinaryValueDeserializer<'_, 'de, F>
+where
+    F: BinaryFormat,
+{
+    type Error = Error;
+
+    value_method!(deserialize_any, deserialize_any);
+    value_method!(deserialize_i32, deserialize_i32);
+    value_method!(deserialize_u32, deserialize_u32);
+    value_method!(deserialize_i64, deserialize_i64);
+    value_method!(deserialize_u64, deserialize_u64);
+    value_method!(deserialize_f32, deserialize_f32);
+    value_method!(deserialize_f64, deserialize_f64);
+    value_method!(deserialize_bool, deserialize_bool);
+    value_method!(deserialize_str, deserialize_str);
+    value_method!(deserialize_identifier, deserialize_identifier);
+
+    #[inline]
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    #[inline]
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let mut cx = BinaryFormatContext::new(self.de);
+        F::deserialize_bytes(&mut cx, visitor)
+    }
+
+    #[inline]
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_bytes(visitor)
+    }
+
+    /// A bare identifier token decodes to its raw 16-bit value, enabling the
+    /// derive macro's `#[jomini(token = ...)]` fast match.
+    #[inline]
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        if let Some(id) = self.de.peek_lexeme_id()?
+            && id.is_id()
+        {
+            self.de.source.take::<2>()?;
+            return visitor.visit_u16(id.0);
+        }
+        let mut cx = BinaryFormatContext::new(self.de);
+        F::deserialize_any(&mut cx, visitor)
+    }
+
+    #[inline]
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.de.maybe_open_container()? {
+            visitor.visit_map(BinaryMapAccess::new(self.de, false))
+        } else {
+            let mut cx = BinaryFormatContext::new(self.de);
+            F::deserialize_any(&mut cx, visitor)
+        }
+    }
+
+    #[inline]
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+
+    #[inline]
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_enum(BinaryEnumAccess::new(self.de))
+    }
+
+    #[inline]
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.de.maybe_open_container()? {
+            self.visit_container_seq(visitor)
+        } else {
+            let mut cx = BinaryFormatContext::new(self.de);
+            F::deserialize_any(&mut cx, visitor)
+        }
+    }
+
+    #[inline]
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    #[inline]
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    #[inline]
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_some(self)
+    }
+
+    #[inline]
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    #[inline]
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.de.skip_value()?;
+        visitor.visit_unit()
+    }
+
+    #[inline]
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_ignored_any(visitor)
+    }
+
+    #[inline]
+    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_ignored_any(visitor)
+    }
+
+    serde::forward_to_deserialize_any! {
+        i8 i16 i128 u8 u128 char
+    }
+}
+
+struct BinaryMapAccess<'a, 'de, F> {
+    de: &'a mut BinaryFormatDeserializer<'de, F>,
+    root: bool,
+}
+
+impl<'a, 'de, F> BinaryMapAccess<'a, 'de, F> {
+    fn new(de: &'a mut BinaryFormatDeserializer<'de, F>, root: bool) -> Self {
+        Self { de, root }
+    }
+}
+
+impl<'de, F> MapAccess<'de> for BinaryMapAccess<'_, 'de, F>
+where
+    F: BinaryFormat,
+{
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        loop {
+            let Some(id) = self.de.peek_lexeme_id()? else {
+                return if self.root {
+                    Ok(None)
+                } else {
+                    Err(Error::eof())
+                };
+            };
+
+            match id {
+                LexemeId::CLOSE => {
+                    self.de.source.take::<2>()?;
+                    self.de.format.on_close();
+                    return Ok(None);
+                }
+                LexemeId::OPEN => {
+                    // Ghost object: consume open, skip the contained value
+                    self.de.source.take::<2>()?;
+                    self.de.format.on_open();
+                    self.de.skip_value()?;
+                }
+                _ => {
+                    self.de.format.on_key(id);
+                    return seed
+                        .deserialize(BinaryValueDeserializer { de: self.de })
+                        .map(Some);
+                }
+            }
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        if matches!(self.de.peek_lexeme_id()?, Some(LexemeId::EQUAL)) {
+            self.de.source.take::<2>()?;
+            self.de.format.on_equal();
+        }
+        seed.deserialize(BinaryValueDeserializer { de: self.de })
+    }
+}
+
+struct BinarySeqAccess<'a, 'de, F> {
+    de: &'a mut BinaryFormatDeserializer<'de, F>,
+    hit_end: bool,
+    elements_read: usize,
+}
+
+impl<'a, 'de, F> BinarySeqAccess<'a, 'de, F> {
+    fn new(de: &'a mut BinaryFormatDeserializer<'de, F>) -> Self {
+        Self {
+            de,
+            hit_end: false,
+            elements_read: 0,
+        }
+    }
+
+    fn finish(self) -> Result<(), Error>
+    where
+        F: BinaryFormat,
+    {
+        if self.hit_end {
+            return Ok(());
+        }
+
+        match self.de.peek_lexeme_id()? {
+            Some(LexemeId::CLOSE) => {
+                self.de.source.take::<2>()?;
+                self.de.format.on_close();
+                Ok(())
+            }
+            Some(_) => Err(<Error as de::Error>::invalid_length(
+                self.elements_read,
+                &"end of sequence",
+            )),
+            None => Err(Error::eof()),
+        }
+    }
+}
+
+impl<'de, F> SeqAccess<'de> for BinarySeqAccess<'_, 'de, F>
+where
+    F: BinaryFormat,
+{
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let Some(id) = self.de.peek_lexeme_id()? else {
+            return Err(Error::eof());
+        };
+
+        if id == LexemeId::CLOSE {
+            self.de.source.take::<2>()?;
+            self.de.format.on_close();
+            self.hit_end = true;
+            return Ok(None);
+        }
+
+        if id == LexemeId::EQUAL {
+            self.de.source.take::<2>()?;
+            self.de.format.on_equal();
+        }
+
+        let value = seed.deserialize(BinaryValueDeserializer { de: self.de })?;
+        self.elements_read += 1;
+
+        Ok(Some(value))
+    }
+}
+
+struct BinaryEnumAccess<'a, 'de, F> {
+    de: &'a mut BinaryFormatDeserializer<'de, F>,
+}
+
+impl<'a, 'de, F> BinaryEnumAccess<'a, 'de, F> {
+    fn new(de: &'a mut BinaryFormatDeserializer<'de, F>) -> Self {
+        Self { de }
+    }
+}
+
+impl<'de, F> de::EnumAccess<'de> for BinaryEnumAccess<'_, 'de, F>
+where
+    F: BinaryFormat,
+{
+    type Error = Error;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self), Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let variant = seed.deserialize(BinaryValueDeserializer { de: self.de })?;
+        Ok((variant, self))
+    }
+}
+
+impl<'de, F> de::VariantAccess<'de> for BinaryEnumAccess<'_, 'de, F>
+where
+    F: BinaryFormat,
+{
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        Err(Error::deserialize_msg(
+            "unsupported enum deserialization. Please file issue",
+        ))
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::deserialize_msg(
+            "unsupported enum deserialization. Please file issue",
+        ))
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::deserialize_msg(
+            "unsupported enum deserialization. Please file issue",
+        ))
+    }
 }
 
 #[cfg(all(test, feature = "derive"))]

--- a/src/binary/format.rs
+++ b/src/binary/format.rs
@@ -1,0 +1,792 @@
+use crate::{
+    BinarySourceExt, DeserializeErrorKind, Error, ParserSource,
+    binary::de::BinaryFormatContext,
+    binary::{BinaryFlavor, FailedResolveStrategy, LexemeId, Rgb, TokenResolver},
+    de::ColorSequence,
+};
+use serde::de::Visitor;
+use std::borrow::Cow;
+
+/// Extension of Serde's [`Visitor`] trait with Jomini-specific binary values.
+///
+/// The default `visit_rgb` forwards to `visit_seq` via [`ColorSequence`], so
+/// existing Serde visitors automatically receive RGB support.
+pub trait PdxVisitor<'de>: Visitor<'de> {
+    /// Visit an RGB color value. Defaults to a 3- or 4-element sequence.
+    #[inline]
+    fn visit_rgb(self, rgb: Rgb) -> Result<Self::Value, Error>
+    where
+        Self: Sized,
+    {
+        self.visit_seq(ColorSequence::new(rgb))
+    }
+}
+
+impl<'de, V> PdxVisitor<'de> for V where V: Visitor<'de> {}
+
+/// Semantic decoding for a game-specific binary format.
+///
+/// A [`BinaryFormat`] is the extension point for deserializing the binary
+/// formats of individual games and patches. The
+/// [`BinaryFormatDeserializer`](crate::binary::BinaryFormatDeserializer) handles
+/// structural traversal (maps, sequences, enums, and the `{`, `}`, `=`
+/// delimiters) while the format decodes the value and identifier lexemes.
+///
+/// Implementations receive a [`BinaryFormatContext`], which exposes source
+/// access and the format state while keeping deserializer traversal internals
+/// private.
+///
+/// Structural delimiters (`{`, `}`, `=`) are coordinated with the
+/// deserializer. Formats that consume `OPEN` should call
+/// [`BinaryFormatContext::visit_open_seq`] after advancing the source so the
+/// deserializer can drive container traversal. `EQUAL` and `CLOSE` remain part
+/// of map and sequence traversal.
+pub trait BinaryFormat: Sized {
+    /// Decode raw scalar bytes into text.
+    fn decode_scalar<'a>(&self, data: &'a [u8]) -> Cow<'a, str>;
+
+    /// Reports a map key's lexeme id, letting a stateful format remember the
+    /// previous field so later values can be decoded accordingly.
+    ///
+    /// Called before the key is consumed, so do not advance the source. The id
+    /// is the raw token for token keys, or `QUOTED`/`UNQUOTED` for string keys.
+    #[inline]
+    fn on_key(&mut self, _id: LexemeId) {}
+
+    /// Called after the deserializer consumes a structural opening delimiter.
+    #[inline]
+    fn on_open(&mut self) {}
+
+    /// Called after the deserializer consumes a structural `=`.
+    #[inline]
+    fn on_equal(&mut self) {}
+
+    /// Called after the deserializer consumes a structural closing delimiter.
+    #[inline]
+    fn on_close(&mut self) {}
+
+    /// Skip the next semantic value without decoding it.
+    fn skip_value(cx: &mut BinaryFormatContext<'_, '_, Self>) -> Result<(), Error>;
+
+    /// Attempt to deserialize the next value as `i32`.
+    #[inline]
+    fn deserialize_i32<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        Self::deserialize_any(cx, visitor)
+    }
+
+    /// Attempt to deserialize the next value as `u32`.
+    #[inline]
+    fn deserialize_u32<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        Self::deserialize_any(cx, visitor)
+    }
+
+    /// Attempt to deserialize the next value as `i64`.
+    #[inline]
+    fn deserialize_i64<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        Self::deserialize_any(cx, visitor)
+    }
+
+    /// Attempt to deserialize the next value as `u64`.
+    #[inline]
+    fn deserialize_u64<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        Self::deserialize_any(cx, visitor)
+    }
+
+    /// Attempt to deserialize the next value as `f32`.
+    #[inline]
+    fn deserialize_f32<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        Self::deserialize_any(cx, visitor)
+    }
+
+    /// Attempt to deserialize the next value as `f64`.
+    #[inline]
+    fn deserialize_f64<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        Self::deserialize_any(cx, visitor)
+    }
+
+    /// Attempt to deserialize the next value as `bool`.
+    #[inline]
+    fn deserialize_bool<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        Self::deserialize_any(cx, visitor)
+    }
+
+    /// Attempt to deserialize the next value as a string-like scalar.
+    fn deserialize_str<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        Self::deserialize_any(cx, visitor)
+    }
+
+    /// Attempt to deserialize the next value as raw bytes.
+    #[inline]
+    fn deserialize_bytes<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        Self::deserialize_any(cx, visitor)
+    }
+
+    /// Attempt to deserialize the next value as an identifier.
+    #[inline]
+    fn deserialize_identifier<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        Self::deserialize_any(cx, visitor)
+    }
+
+    /// Deserialize the next value without a type hint.
+    fn deserialize_any<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>;
+}
+
+// --- ParserSource value readers shared by the built-in format ---------------
+
+#[inline]
+fn read_u32(source: &mut ParserSource<'_>) -> Result<u32, Error> {
+    Ok(u32::from_le_bytes(*source.take::<4>()?))
+}
+
+#[inline]
+fn read_i32(source: &mut ParserSource<'_>) -> Result<i32, Error> {
+    Ok(i32::from_le_bytes(*source.take::<4>()?))
+}
+
+#[inline]
+fn read_u64(source: &mut ParserSource<'_>) -> Result<u64, Error> {
+    Ok(u64::from_le_bytes(*source.take::<8>()?))
+}
+
+#[inline]
+fn read_i64(source: &mut ParserSource<'_>) -> Result<i64, Error> {
+    Ok(i64::from_le_bytes(*source.take::<8>()?))
+}
+
+#[inline]
+fn read_bool(source: &mut ParserSource<'_>) -> Result<bool, Error> {
+    Ok(source.take::<1>()?[0] != 0)
+}
+
+#[inline]
+fn read_f32_bytes(source: &mut ParserSource<'_>) -> Result<[u8; 4], Error> {
+    Ok(*source.take::<4>()?)
+}
+
+#[inline]
+fn read_f64_bytes(source: &mut ParserSource<'_>) -> Result<[u8; 8], Error> {
+    Ok(*source.take::<8>()?)
+}
+
+/// Decode a variable-length compact f64 (`FIXED5_*`) into its i64 little-endian
+/// byte representation, mirroring [`crate::binary::lexer::read_compact_f64`].
+#[inline]
+fn read_compact_f64(source: &mut ParserSource<'_>, lexeme: LexemeId) -> Result<[u8; 8], Error> {
+    let offset = lexeme.0 - LexemeId::FIXED5_ZERO.0;
+    let is_negative = offset > 7;
+    let byte_count = (offset - (is_negative as u16 * 7)) as usize;
+    let mut buf = [0u8; 8];
+    buf[..byte_count].copy_from_slice(source.take_bytes(byte_count)?);
+    let sign = 1i64 - (is_negative as i64) * 2;
+    Ok((u64::from_le_bytes(buf) as i64 * sign).to_le_bytes())
+}
+
+/// Skip the payload of a single non-structural lexeme.
+fn skip_payload(source: &mut ParserSource<'_>, id: LexemeId) -> Result<(), Error> {
+    match id {
+        LexemeId::QUOTED | LexemeId::UNQUOTED => {
+            source.read_bstr()?;
+        }
+        LexemeId::U32 | LexemeId::I32 | LexemeId::F32 => {
+            source.take::<4>()?;
+        }
+        LexemeId::U64 | LexemeId::I64 | LexemeId::F64 => {
+            source.take::<8>()?;
+        }
+        LexemeId::BOOL => {
+            source.take::<1>()?;
+        }
+        LexemeId::RGB => {
+            source.read_rgb()?;
+        }
+        LexemeId::LOOKUP_U8 | LexemeId::LOOKUP_U8_ALT => {
+            source.take::<1>()?;
+        }
+        LexemeId::LOOKUP_U16 | LexemeId::LOOKUP_U16_ALT => {
+            source.take::<2>()?;
+        }
+        LexemeId::LOOKUP_U24 | LexemeId::LOOKUP_U24_ALT => {
+            source.take::<3>()?;
+        }
+        LexemeId::LOOKUP_U32 | LexemeId::LOOKUP_U32_ALT => {
+            source.take::<4>()?;
+        }
+        lexeme if (LexemeId::FIXED5_ZERO..=LexemeId::FIXED5_I56).contains(&lexeme) => {
+            read_compact_f64(source, lexeme)?;
+        }
+        // Bare identifier tokens and equals carry no payload.
+        _ => {}
+    }
+    Ok(())
+}
+
+// --- Built-in format bridging BinaryFlavor + TokenResolver ------------------
+
+/// The crate's built-in [`BinaryFormat`], decoding the standard Paradox binary
+/// lexemes using a [`BinaryFlavor`] for floats and text and a separate
+/// [`TokenResolver`] for identifier and lookup resolution.
+pub(crate) struct FlavorFormat<F, R> {
+    pub(crate) flavor: F,
+    pub(crate) resolver: R,
+    pub(crate) failed_resolve_strategy: FailedResolveStrategy,
+}
+
+impl<F, R> FlavorFormat<F, R>
+where
+    F: BinaryFlavor,
+    R: TokenResolver,
+{
+    fn resolve_token<'de, V>(&self, token: u16, visitor: V) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        match self.resolver.resolve(token) {
+            Some(id) => visitor.visit_str(id),
+            None => match self.failed_resolve_strategy {
+                FailedResolveStrategy::Error => {
+                    Err(Error::deserialize(DeserializeErrorKind::UnknownToken {
+                        token_id: token as u32,
+                    }))
+                }
+                FailedResolveStrategy::Stringify => visitor.visit_string(format!("0x{:x}", token)),
+                FailedResolveStrategy::Ignore => {
+                    visitor.visit_borrowed_str("__internal_identifier_ignore")
+                }
+            },
+        }
+    }
+
+    fn resolve_lookup<'de, V>(&self, index: u32, visitor: V) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        match self.resolver.lookup(index) {
+            Some(value) => visitor.visit_str(value),
+            None => match self.failed_resolve_strategy {
+                FailedResolveStrategy::Error => {
+                    Err(Error::deserialize(DeserializeErrorKind::UnknownToken {
+                        token_id: index,
+                    }))
+                }
+                FailedResolveStrategy::Stringify => visitor.visit_string(format!("{}", index)),
+                FailedResolveStrategy::Ignore => {
+                    visitor.visit_borrowed_str("__internal_identifier_ignore")
+                }
+            },
+        }
+    }
+
+    fn read_lookup(&self, source: &mut ParserSource<'_>, id: LexemeId) -> Result<u32, Error> {
+        match id {
+            LexemeId::LOOKUP_U8 | LexemeId::LOOKUP_U8_ALT => Ok(source.take::<1>()?[0] as u32),
+            LexemeId::LOOKUP_U16 | LexemeId::LOOKUP_U16_ALT => {
+                Ok(u16::from_le_bytes(*source.take::<2>()?) as u32)
+            }
+            LexemeId::LOOKUP_U24 | LexemeId::LOOKUP_U24_ALT => {
+                let b = source.take::<3>()?;
+                Ok(u32::from_le_bytes([b[0], b[1], b[2], 0]))
+            }
+            LexemeId::LOOKUP_U32 | LexemeId::LOOKUP_U32_ALT => {
+                Ok(u32::from_le_bytes(*source.take::<4>()?))
+            }
+            _ => unreachable!("read_lookup called with non-lookup lexeme"),
+        }
+    }
+
+    /// Decode the value identified by `id`, reading its payload from `source`.
+    #[inline]
+    fn dispatch<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        id: LexemeId,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        match id {
+            LexemeId::QUOTED | LexemeId::UNQUOTED => {
+                let (format, source) = cx.parts();
+                let data = source.read_bstr()?;
+                match format.flavor.decode(data) {
+                    Cow::Borrowed(x) => visitor.visit_str(x),
+                    Cow::Owned(x) => visitor.visit_string(x),
+                }
+            }
+            LexemeId::EMPTY_STRING => visitor.visit_borrowed_str(""),
+            LexemeId::U32 => visitor.visit_u32(read_u32(cx.source())?),
+            LexemeId::I32 => visitor.visit_i32(read_i32(cx.source())?),
+            LexemeId::U64 => visitor.visit_u64(read_u64(cx.source())?),
+            LexemeId::I64 => visitor.visit_i64(read_i64(cx.source())?),
+            LexemeId::BOOL => visitor.visit_bool(read_bool(cx.source())?),
+            LexemeId::F32 => {
+                let (format, source) = cx.parts();
+                visitor.visit_f32(format.flavor.visit_f32(read_f32_bytes(source)?))
+            }
+            LexemeId::F64 => {
+                let (format, source) = cx.parts();
+                visitor.visit_f64(format.flavor.visit_f64(read_f64_bytes(source)?))
+            }
+            LexemeId::RGB => visitor.visit_rgb(cx.source().read_rgb()?),
+            LexemeId::LOOKUP_U8
+            | LexemeId::LOOKUP_U8_ALT
+            | LexemeId::LOOKUP_U16
+            | LexemeId::LOOKUP_U16_ALT
+            | LexemeId::LOOKUP_U24
+            | LexemeId::LOOKUP_U24_ALT
+            | LexemeId::LOOKUP_U32
+            | LexemeId::LOOKUP_U32_ALT => {
+                let (format, source) = cx.parts();
+                let index = format.read_lookup(source, id)?;
+                format.resolve_lookup(index, visitor)
+            }
+            lexeme if (LexemeId::FIXED5_ZERO..=LexemeId::FIXED5_I56).contains(&lexeme) => {
+                let (format, source) = cx.parts();
+                visitor.visit_f64(format.flavor.visit_f64(read_compact_f64(source, lexeme)?))
+            }
+            LexemeId::OPEN => cx.visit_open_seq(visitor),
+            LexemeId::CLOSE | LexemeId::EQUAL => Err(Error::invalid_syntax(
+                "unexpected structural token",
+                cx.source().position(),
+            )),
+            LexemeId(token) => cx.format().resolve_token(token, visitor),
+        }
+    }
+}
+
+impl<F, R> BinaryFormat for FlavorFormat<F, R>
+where
+    F: BinaryFlavor,
+    R: TokenResolver,
+{
+    #[inline]
+    fn decode_scalar<'a>(&self, data: &'a [u8]) -> Cow<'a, str> {
+        self.flavor.decode(data)
+    }
+
+    fn skip_value(cx: &mut BinaryFormatContext<'_, '_, Self>) -> Result<(), Error> {
+        skip_standard(cx.source())
+    }
+
+    #[inline]
+    fn deserialize_i32<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let source = cx.source();
+        if let Some(d) = source.window().first_chunk::<6>()
+            && LexemeId::new(u16::from_le_bytes([d[0], d[1]])) == LexemeId::I32
+        {
+            let value = i32::from_le_bytes([d[2], d[3], d[4], d[5]]);
+            source.advance(6);
+            return visitor.visit_i32(value);
+        }
+
+        let id = source.read_lexeme_id()?;
+        Self::dispatch(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_u32<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let (format, source) = cx.parts();
+        if let Some(d) = source.window().first_chunk::<6>()
+            && LexemeId::new(u16::from_le_bytes([d[0], d[1]])) == LexemeId::U32
+        {
+            let value = u32::from_le_bytes([d[2], d[3], d[4], d[5]]);
+            source.advance(6);
+            return visitor.visit_u32(value);
+        }
+
+        let id = source.read_lexeme_id()?;
+        match id {
+            LexemeId::LOOKUP_U8
+            | LexemeId::LOOKUP_U8_ALT
+            | LexemeId::LOOKUP_U16
+            | LexemeId::LOOKUP_U16_ALT
+            | LexemeId::LOOKUP_U24
+            | LexemeId::LOOKUP_U24_ALT
+            | LexemeId::LOOKUP_U32
+            | LexemeId::LOOKUP_U32_ALT => visitor.visit_u32(format.read_lookup(source, id)?),
+            _ => Self::dispatch(cx, id, visitor),
+        }
+    }
+
+    #[inline]
+    fn deserialize_i64<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let source = cx.source();
+        if let Some(d) = source.window().first_chunk::<10>()
+            && LexemeId::new(u16::from_le_bytes([d[0], d[1]])) == LexemeId::I64
+        {
+            let value = i64::from_le_bytes([d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9]]);
+            source.advance(10);
+            return visitor.visit_i64(value);
+        }
+
+        let id = source.read_lexeme_id()?;
+        Self::dispatch(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_u64<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let source = cx.source();
+        if let Some(d) = source.window().first_chunk::<10>()
+            && LexemeId::new(u16::from_le_bytes([d[0], d[1]])) == LexemeId::U64
+        {
+            let value = u64::from_le_bytes([d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9]]);
+            source.advance(10);
+            return visitor.visit_u64(value);
+        }
+
+        let id = source.read_lexeme_id()?;
+        Self::dispatch(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_f32<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let (format, source) = cx.parts();
+        if let Some(d) = source.window().first_chunk::<6>()
+            && LexemeId::new(u16::from_le_bytes([d[0], d[1]])) == LexemeId::F32
+        {
+            let value = format.flavor.visit_f32([d[2], d[3], d[4], d[5]]);
+            source.advance(6);
+            return visitor.visit_f32(value);
+        }
+
+        let id = source.read_lexeme_id()?;
+        Self::dispatch(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_f64<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let (format, source) = cx.parts();
+        if let Some(d) = source.window().first_chunk::<10>()
+            && LexemeId::new(u16::from_le_bytes([d[0], d[1]])) == LexemeId::F64
+        {
+            let value = format
+                .flavor
+                .visit_f64([d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9]]);
+            source.advance(10);
+            return visitor.visit_f64(value);
+        }
+
+        let id = source.read_lexeme_id()?;
+        Self::dispatch(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_bool<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let source = cx.source();
+        if let Some(d) = source.window().first_chunk::<3>()
+            && LexemeId::new(u16::from_le_bytes([d[0], d[1]])) == LexemeId::BOOL
+        {
+            let value = d[2] != 0;
+            source.advance(3);
+            return visitor.visit_bool(value);
+        }
+
+        let id = source.read_lexeme_id()?;
+        Self::dispatch(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_str<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let (format, source) = cx.parts();
+        let id = source.read_lexeme_id()?;
+        match id {
+            LexemeId::QUOTED | LexemeId::UNQUOTED => {
+                let data = source.read_bstr()?;
+                match format.flavor.decode(data) {
+                    Cow::Borrowed(x) => visitor.visit_str(x),
+                    Cow::Owned(x) => visitor.visit_string(x),
+                }
+            }
+            _ => Self::dispatch(cx, id, visitor),
+        }
+    }
+
+    #[inline]
+    fn deserialize_bytes<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let source = cx.source();
+        let id = source.read_lexeme_id()?;
+        match id {
+            LexemeId::QUOTED | LexemeId::UNQUOTED => visitor.visit_bytes(source.read_bstr()?),
+            _ => Self::dispatch(cx, id, visitor),
+        }
+    }
+
+    #[inline]
+    fn deserialize_any<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let source = cx.source();
+        let id = source.read_lexeme_id()?;
+        Self::dispatch(cx, id, visitor)
+    }
+}
+
+fn skip_standard(source: &mut ParserSource<'_>) -> Result<(), Error> {
+    static PAYLOAD_SIZES: [u8; (LexemeId::FIXED5_I56.0 as usize) + 1] = {
+        let mut t = [0u8; (LexemeId::FIXED5_I56.0 as usize) + 1];
+        t[LexemeId::U32.0 as usize] = 4;
+        t[LexemeId::I32.0 as usize] = 4;
+        t[LexemeId::F32.0 as usize] = 4;
+        t[LexemeId::BOOL.0 as usize] = 1;
+        t[LexemeId::U64.0 as usize] = 8;
+        t[LexemeId::I64.0 as usize] = 8;
+        t[LexemeId::F64.0 as usize] = 8;
+        t[LexemeId::LOOKUP_U8.0 as usize] = 1;
+        t[LexemeId::LOOKUP_U8_ALT.0 as usize] = 1;
+        t[LexemeId::LOOKUP_U16.0 as usize] = 2;
+        t[LexemeId::LOOKUP_U16_ALT.0 as usize] = 2;
+        t[LexemeId::LOOKUP_U24.0 as usize] = 3;
+        t[LexemeId::LOOKUP_U24_ALT.0 as usize] = 3;
+        t[LexemeId::LOOKUP_U32.0 as usize] = 4;
+        t[LexemeId::LOOKUP_U32_ALT.0 as usize] = 4;
+        t[LexemeId::FIXED5_ZERO.0 as usize] = 0;
+        t[LexemeId::FIXED5_U8.0 as usize] = 1;
+        t[LexemeId::FIXED5_U16.0 as usize] = 2;
+        t[LexemeId::FIXED5_U24.0 as usize] = 3;
+        t[LexemeId::FIXED5_U32.0 as usize] = 4;
+        t[LexemeId::FIXED5_U40.0 as usize] = 5;
+        t[LexemeId::FIXED5_U48.0 as usize] = 6;
+        t[LexemeId::FIXED5_U56.0 as usize] = 7;
+        t[LexemeId::FIXED5_I8.0 as usize] = 1;
+        t[LexemeId::FIXED5_I16.0 as usize] = 2;
+        t[LexemeId::FIXED5_I24.0 as usize] = 3;
+        t[LexemeId::FIXED5_I32.0 as usize] = 4;
+        t[LexemeId::FIXED5_I40.0 as usize] = 5;
+        t[LexemeId::FIXED5_I48.0 as usize] = 6;
+        t[LexemeId::FIXED5_I56.0 as usize] = 7;
+        t
+    };
+
+    #[cold]
+    fn single_step(source: &mut ParserSource<'_>, depth: &mut u32) -> Result<(), Error> {
+        let id = source.read_lexeme_id()?;
+        match id {
+            LexemeId::OPEN => {
+                *depth += 1;
+                Ok(())
+            }
+            LexemeId::CLOSE => {
+                *depth -= 1;
+                Ok(())
+            }
+            LexemeId::QUOTED | LexemeId::UNQUOTED => Ok(source.read_bstr().map(|_| ())?),
+            LexemeId::RGB => source.read_rgb().map(|_| ()),
+            other => {
+                let entry = PAYLOAD_SIZES.get(other.0 as usize).copied().unwrap_or(0);
+                match entry {
+                    0 => Ok(()),
+                    1 => Ok(source.take::<1>().map(|_| ())?),
+                    2 => Ok(source.take::<2>().map(|_| ())?),
+                    3 => Ok(source.take::<3>().map(|_| ())?),
+                    4 => Ok(source.take::<4>().map(|_| ())?),
+                    5 => Ok(source.take::<5>().map(|_| ())?),
+                    6 => Ok(source.take::<6>().map(|_| ())?),
+                    7 => Ok(source.take::<7>().map(|_| ())?),
+                    8 => Ok(source.take::<8>().map(|_| ())?),
+                    _ => unreachable!(), // table only holds 0..=8 now
+                }
+            }
+        }
+    }
+
+    let id = source.read_lexeme_id()?;
+    if id == LexemeId::OPEN {
+        // Save games contain large subtrees we don't care about (even in
+        // pdx.tools EU4, skipping subtrees account for 30% of all IR), so this
+        // path has been optimized.
+        //
+        // The fast loop walks the current window with a *local* cursor so that
+        // skipping a token is pure register arithmetic. Round-tripping the
+        // source pointer through memory on every token (load `ptr`/`end`, store
+        // the advanced `ptr`) dominated this loop's instruction count.
+        let mut depth = 1u32;
+        loop {
+            // Raw window pointer; the borrow ends with this statement so the
+            // `source` can be mutated again below. We never mutate `source`
+            // while reading through `base`, so the pointer stays valid.
+            let base = source.window().as_ptr();
+            let len = source.window_len();
+            let mut i = 0usize;
+
+            // A 10-byte tail margin guarantees that reading a lexeme id (2
+            // bytes) plus its largest fixed payload (8 bytes) stays in bounds,
+            // so the inner loop needs no per-token bounds checks.
+            while i + 10 <= len {
+                // SAFETY: `i + 2 <= len` from the loop condition.
+                let id = LexemeId::new(u16::from_le_bytes(unsafe {
+                    [*base.add(i), *base.add(i + 1)]
+                }));
+                match id {
+                    LexemeId::OPEN => {
+                        i += 2;
+                        depth += 1;
+                    }
+                    LexemeId::CLOSE => {
+                        i += 2;
+                        depth -= 1;
+                        if depth == 0 {
+                            unsafe { source.advance_unchecked(i) };
+                            return Ok(());
+                        }
+                    }
+                    LexemeId::QUOTED | LexemeId::UNQUOTED => {
+                        // Layout: [id:2][len:2][bytes:len]. The length is in
+                        // bounds via the margin; the bytes may not be, in which
+                        // case we defer to the slow path. Skipping strings
+                        // inline (rather than breaking) is what keeps this loop
+                        // out of a pathological refill: breaking mid-window
+                        // forces `refill` to memmove the entire remaining
+                        // window for every string in string-heavy subtrees.
+                        let str_len =
+                            u16::from_le_bytes(unsafe { [*base.add(i + 2), *base.add(i + 3)] })
+                                as usize;
+                        let total = 4 + str_len;
+                        if i + total > len {
+                            break;
+                        }
+                        i += total;
+                    }
+                    // Rare and variable-width; let the slow path handle it.
+                    LexemeId::RGB => break,
+                    _ => {
+                        let payload = PAYLOAD_SIZES.get(id.0 as usize).copied().unwrap_or(0);
+                        i += 2 + payload as usize;
+                    }
+                }
+            }
+
+            // Commit the bytes consumed by the fast loop, then take one careful
+            // step across the window boundary (refilling as needed).
+            unsafe { source.advance_unchecked(i) };
+            source.refill()?;
+            single_step(source, &mut depth)?;
+            if depth == 0 {
+                return Ok(());
+            }
+        }
+    } else {
+        skip_payload(source, id)
+    }
+}

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -69,15 +69,21 @@
 #[cfg(feature = "serde")]
 pub mod de;
 #[cfg(feature = "serde")]
-pub use self::de::{BinaryDeserializer, BinaryDeserializerBuilder};
+pub use self::de::{
+    BinaryDeserializer, BinaryDeserializerBuilder, BinaryFormatContext, BinaryFormatDeserializer,
+};
 
 mod flavor;
+#[cfg(feature = "serde")]
+mod format;
 mod lexer;
 mod reader;
 mod resolver;
 mod rgb;
 
 pub use self::flavor::BinaryFlavor;
+#[cfg(feature = "serde")]
+pub use self::format::{BinaryFormat, PdxVisitor};
 pub use self::lexer::{LexError, LexemeId, Lexer, LexerError, Token, TokenKind};
 pub use self::reader::TokenReader;
 pub use self::resolver::{BasicTokenResolver, FailedResolveStrategy, TokenResolver};

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ScalarError,
+    ParserError, ScalarError,
     binary::{LexError, LexerError},
 };
 use std::{fmt, mem::MaybeUninit};
@@ -256,6 +256,16 @@ impl fmt::Display for ReaderError {
 impl std::error::Error for ReaderError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
+    }
+}
+
+impl From<ParserError> for Error {
+    fn from(value: ParserError) -> Self {
+        match value {
+            ParserError::Io(std::io::ErrorKind::UnexpectedEof) => Error::eof(),
+            ParserError::BufferTooSmall => Error::new(ErrorKind::BufferTooSmall),
+            ParserError::Io(kind) => Error::new(ErrorKind::Io(std::io::Error::from(kind))),
+        }
     }
 }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -2,7 +2,10 @@ use std::io::{self, Read};
 use std::marker::PhantomData;
 use std::ptr;
 
-use crate::binary::LexemeId;
+use crate::{
+    Error,
+    binary::{LexemeId, Rgb},
+};
 
 const DEFAULT_CAPACITY: usize = 32 * 1024;
 
@@ -490,6 +493,12 @@ pub trait BinarySourceExt {
 
     /// Peeks at the next two bytes as a Jomini binary lexeme id without advancing.
     fn peek_lexeme_id(&mut self) -> Result<Option<LexemeId>, ParserError>;
+
+    /// Reads an [`Rgb`] value following an `RGB` lexeme.
+    ///
+    /// Expects `{ u32 u32 u32 [u32] }`, where the optional fourth channel is the
+    /// alpha.
+    fn read_rgb(&mut self) -> Result<Rgb, Error>;
 }
 
 impl BinarySourceExt for ParserSource<'_> {
@@ -516,6 +525,40 @@ impl BinarySourceExt for ParserSource<'_> {
         Ok(self
             .peek::<2>()?
             .map(|x| LexemeId::new(u16::from_le_bytes(*x))))
+    }
+
+    fn read_rgb(&mut self) -> Result<Rgb, Error> {
+        fn channel(source: &mut ParserSource<'_>) -> Result<u32, Error> {
+            if source.read_lexeme_id()? != LexemeId::U32 {
+                return Err(Error::invalid_syntax("invalid rgb", source.position()));
+            }
+            Ok(u32::from_le_bytes(*source.take::<4>()?))
+        }
+
+        if self.read_lexeme_id()? != LexemeId::OPEN {
+            return Err(Error::invalid_syntax("invalid rgb", self.position()));
+        }
+        let r = channel(self)?;
+        let g = channel(self)?;
+        let b = channel(self)?;
+
+        match self.read_lexeme_id()? {
+            LexemeId::CLOSE => Ok(Rgb { r, g, b, a: None }),
+            LexemeId::U32 => {
+                let a = u32::from_le_bytes(*self.take::<4>()?);
+                if self.read_lexeme_id()? == LexemeId::CLOSE {
+                    Ok(Rgb {
+                        r,
+                        g,
+                        b,
+                        a: Some(a),
+                    })
+                } else {
+                    Err(Error::invalid_syntax("invalid rgb", self.position()))
+                }
+            }
+            _ => Err(Error::invalid_syntax("invalid rgb", self.position())),
+        }
     }
 }
 

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -139,6 +139,184 @@ fn unified_rgb_deserializer_any_path() {
     assert_eq!(reader_out, expected);
 }
 
+/// A self-contained [`BinaryFormat`](jomini::binary::BinaryFormat) implemented
+/// only with the crate's public API, proving external crates can plug in their
+/// own format and get serde deserialization for it.
+#[test]
+fn external_binary_format() {
+    use jomini::{
+        BinarySourceExt, ParserSource,
+        binary::{
+            BinaryFormat, BinaryFormatContext, BinaryFormatDeserializer, LexemeId, PdxVisitor,
+        },
+    };
+
+    struct PlainFormat;
+
+    impl PlainFormat {
+        fn read_value<'de, V: PdxVisitor<'de>>(
+            &self,
+            id: LexemeId,
+            source: &mut ParserSource<'de>,
+            visitor: V,
+        ) -> Result<V::Value, jomini::Error> {
+            match id {
+                LexemeId::U32 => visitor.visit_u32(u32::from_le_bytes(*source.take::<4>()?)),
+                LexemeId::QUOTED | LexemeId::UNQUOTED => {
+                    match self.decode_scalar(source.read_bstr()?) {
+                        Cow::Borrowed(x) => visitor.visit_str(x),
+                        Cow::Owned(x) => visitor.visit_string(x),
+                    }
+                }
+                _ => Err(de::Error::custom("unexpected token")),
+            }
+        }
+    }
+
+    impl BinaryFormat for PlainFormat {
+        fn decode_scalar<'a>(&self, data: &'a [u8]) -> Cow<'a, str> {
+            Windows1252Encoding::decode(data)
+        }
+
+        fn skip_value(cx: &mut BinaryFormatContext<'_, '_, Self>) -> Result<(), jomini::Error> {
+            let source = cx.source();
+            match source.read_lexeme_id()? {
+                LexemeId::U32 => {
+                    source.take::<4>()?;
+                }
+                LexemeId::QUOTED | LexemeId::UNQUOTED => {
+                    source.read_bstr()?;
+                }
+                _ => return Err(de::Error::custom("cannot skip token")),
+            }
+            Ok(())
+        }
+
+        fn deserialize_any<'de, V: PdxVisitor<'de>>(
+            cx: &mut BinaryFormatContext<'_, 'de, Self>,
+            visitor: V,
+        ) -> Result<V::Value, jomini::Error> {
+            let (format, source) = cx.parts();
+            let id = source.read_lexeme_id()?;
+            format.read_value(id, source, visitor)
+        }
+    }
+
+    #[derive(JominiDeserialize, PartialEq, Debug)]
+    struct PlainData {
+        #[jomini(token = 0x2d82)]
+        field1: u32,
+        #[jomini(token = 0x2d83)]
+        field2: String,
+    }
+
+    let data = [
+        0x82, 0x2d, 0x01, 0x00, 0x14, 0x00, 0x59, 0x00, 0x00, 0x00, // field1 = 89
+        0x83, 0x2d, 0x01, 0x00, 0x0f, 0x00, 0x03, 0x00, 0x45, 0x4e, 0x47, // field2 = "ENG"
+    ];
+
+    let expected = PlainData {
+        field1: 89,
+        field2: "ENG".to_string(),
+    };
+
+    let slice_out: PlainData = BinaryFormatDeserializer::from_slice(&data[..], PlainFormat)
+        .deserialize()
+        .unwrap();
+    assert_eq!(slice_out, expected);
+
+    let reader_out: PlainData = BinaryFormatDeserializer::from_reader(&data[..], PlainFormat)
+        .deserialize()
+        .unwrap();
+    assert_eq!(reader_out, expected);
+}
+
+/// A stateful [`BinaryFormat`](jomini::binary::BinaryFormat) that decodes a
+/// value differently depending on the key that preceded it, proving the
+/// [`on_key`](jomini::binary::BinaryFormat::on_key) hook lets a format act as a
+/// state machine even when the derive macro reads token keys via its `u16`
+/// fast path.
+#[test]
+fn stateful_binary_format_keys_off_previous_field() {
+    use jomini::{
+        BinarySourceExt,
+        binary::{
+            BinaryFormat, BinaryFormatContext, BinaryFormatDeserializer, LexemeId, PdxVisitor,
+        },
+    };
+
+    // The `scaled` field is stored at a coarser fixed-point precision, so its
+    // raw integer must be multiplied by 1000. Every other u32 is passed
+    // through unchanged. The format only knows which field it is decoding by
+    // remembering the previous key.
+    const SCALED_TOKEN: u16 = 0x2d90;
+
+    #[derive(Default)]
+    struct ScaledFormat {
+        last_key: u16,
+    }
+
+    impl BinaryFormat for ScaledFormat {
+        fn decode_scalar<'a>(&self, data: &'a [u8]) -> Cow<'a, str> {
+            Windows1252Encoding::decode(data)
+        }
+
+        fn on_key(&mut self, id: LexemeId) {
+            self.last_key = id.0;
+        }
+
+        fn skip_value(cx: &mut BinaryFormatContext<'_, '_, Self>) -> Result<(), jomini::Error> {
+            cx.source().take::<4>()?;
+            Ok(())
+        }
+
+        fn deserialize_any<'de, V: PdxVisitor<'de>>(
+            cx: &mut BinaryFormatContext<'_, 'de, Self>,
+            visitor: V,
+        ) -> Result<V::Value, jomini::Error> {
+            let scaled = cx.format().last_key == SCALED_TOKEN;
+            let source = cx.source();
+            match source.read_lexeme_id()? {
+                LexemeId::U32 => {
+                    let raw = u32::from_le_bytes(*source.take::<4>()?);
+                    visitor.visit_u32(if scaled { raw * 1000 } else { raw })
+                }
+                _ => Err(de::Error::custom("unexpected token")),
+            }
+        }
+    }
+
+    #[derive(JominiDeserialize, PartialEq, Debug)]
+    struct ScaledData {
+        #[jomini(token = 0x2d82)]
+        plain: u32,
+        #[jomini(token = 0x2d90)]
+        scaled: u32,
+    }
+
+    let data = [
+        0x82, 0x2d, 0x14, 0x00, 0x05, 0x00, 0x00, 0x00, // plain = 5
+        0x90, 0x2d, 0x14, 0x00, 0x07, 0x00, 0x00, 0x00, // scaled = 7 -> 7000
+    ];
+
+    let expected = ScaledData {
+        plain: 5,
+        scaled: 7000,
+    };
+
+    let slice_out: ScaledData =
+        BinaryFormatDeserializer::from_slice(&data[..], ScaledFormat::default())
+            .deserialize()
+            .unwrap();
+    assert_eq!(slice_out, expected);
+
+    let reader_out: ScaledData =
+        BinaryFormatDeserializer::from_reader(&data[..], ScaledFormat::default())
+            .deserialize()
+            .unwrap();
+    assert_eq!(reader_out, expected);
+}
+
 #[derive(Debug, Clone, PartialEq)]
 struct SaveVersion(pub String);
 


### PR DESCRIPTION
The binary format needs 3 features:

 - **Stateful parsing**:
    - HOI4 interprets `0x000d` as 64 bits since patch 1.17, instead of 32 bits. The patch is contained within the data as an i32 value following an `0x349d` id.
    - The default f64 encoding for CK3 changed in patch 1.5 from a decimal fixed point precision of 1000 to 100000 based on the i32 value of the `0x00ee` field.
    - How individual numeric fields in CK3 are encoded can differ. For instance, some `0x0167` values are encoded as Q49.15 instead of decimal fixed point. For instance if a `gold` id field is encountered within the scope of `alive_data` then is encoded as Q49.15 unlike other `gold` instances
    - This stateful parsing can be used for streaming token use cases (like melting the save file into plaintext) and deserialization such that both use cases are yielded the same semantic values.
- **Speculative parsing**: Ultimate performance is non-negotiable as save files can be 100's of megabytes and 100 million tokens. The binary deserializer should be able to exploit the shape of the target data to drive the underlying parser. This moves the behavior from speculating on what was just parsed to what will be parsed. Like if one has been given a deserialization hint of an i32, then the parser should assume the next two bytes are `0x000c` signalling an I32 value, and only fallback to generic parsing if this assumption is not met. This should give a healthy speedup.
- **Customization**: Previously we got away with a binary parser that was a superset of all game binary formats. Thanks to HOI4 1.17, a superset is no longer possible, so it may be time to embrace the individuality of games. Like only EU5 binary format cares about string lookup tokens and compact fixed 5 tokens -- so why should other games pay the runtime cost of having branches that are never taken? 

BinaryFormat is an advanced extension point for formats whose binary representation cannot be
expressed solely through BinaryFlavor, including stateful or version-dependent decoding where a
lexeme’s payload width or interpretation may change.

Existing BinaryFlavor and TokenResolver implementations remain supported without API changes.
Internally, they are adapted through the standard FlavorFormat, so consumers only need to implement
BinaryFormat when they require greater control.

Closes #234 #233 