### PR TITLE
Support the entire gamut of EU5 lookup tokens

### DIFF
--- a/src/bin/dump.rs
+++ b/src/bin/dump.rs
@@ -142,6 +142,18 @@ fn format_lexeme(
             let value = lexer.read_lookup_u24()?;
             write!(buf, "lookup_u24:0x{:06x}", value)?;
         }
+        LexemeId::LOOKUP_U24_ALT => {
+            let value = lexer.read_lookup_u24()?;
+            write!(buf, "lookup_u24_alt:0x{:06x}", value)?;
+        }
+        LexemeId::LOOKUP_U32 => {
+            let value = lexer.read_lookup_u32()?;
+            write!(buf, "lookup_u32:0x{:08x}", value)?;
+        }
+        LexemeId::LOOKUP_U32_ALT => {
+            let value = lexer.read_lookup_u32()?;
+            write!(buf, "lookup_u32_alt:0x{:08x}", value)?;
+        }
         // Handle Fixed5 lexemes with special formatting
         lexeme if lexeme >= LexemeId::FIXED5_ZERO && lexeme <= LexemeId::FIXED5_I56 => {
             let offset = lexeme.0 - LexemeId::FIXED5_ZERO.0;

--- a/src/binary/de.rs
+++ b/src/binary/de.rs
@@ -794,7 +794,10 @@ impl<'a, 'de: 'a, 'res: 'de, RES: TokenResolver, F: BinaryFlavor>
             | LexemeId::LOOKUP_U8_ALT
             | LexemeId::LOOKUP_U16
             | LexemeId::LOOKUP_U16_ALT
-            | LexemeId::LOOKUP_U24 => {
+            | LexemeId::LOOKUP_U24
+            | LexemeId::LOOKUP_U24_ALT
+            | LexemeId::LOOKUP_U32
+            | LexemeId::LOOKUP_U32_ALT => {
                 let index = match self.token {
                     LexemeId::LOOKUP_U8 | LexemeId::LOOKUP_U8_ALT => {
                         self.de.parser.read_lookup_u8()? as u32
@@ -802,7 +805,12 @@ impl<'a, 'de: 'a, 'res: 'de, RES: TokenResolver, F: BinaryFlavor>
                     LexemeId::LOOKUP_U16 | LexemeId::LOOKUP_U16_ALT => {
                         self.de.parser.read_lookup_u16()? as u32
                     }
-                    LexemeId::LOOKUP_U24 => self.de.parser.read_lookup_u24()?,
+                    LexemeId::LOOKUP_U24 | LexemeId::LOOKUP_U24_ALT => {
+                        self.de.parser.read_lookup_u24()?
+                    }
+                    LexemeId::LOOKUP_U32 | LexemeId::LOOKUP_U32_ALT => {
+                        self.de.parser.read_lookup_u32()?
+                    }
                     _ => unreachable!(),
                 };
 
@@ -926,7 +934,12 @@ impl<'a, 'de: 'a, 'res: 'de, RES: TokenResolver, F: BinaryFlavor> de::Deserializ
             LexemeId::LOOKUP_U16 | LexemeId::LOOKUP_U16_ALT => {
                 visitor.visit_u32(self.de.parser.read_lookup_u16()? as u32)
             }
-            LexemeId::LOOKUP_U24 => visitor.visit_u32(self.de.parser.read_lookup_u24()?),
+            LexemeId::LOOKUP_U24 | LexemeId::LOOKUP_U24_ALT => {
+                visitor.visit_u32(self.de.parser.read_lookup_u24()?)
+            }
+            LexemeId::LOOKUP_U32 | LexemeId::LOOKUP_U32_ALT => {
+                visitor.visit_u32(self.de.parser.read_lookup_u32()?)
+            }
             _ => self.deser(visitor),
         }
     }
@@ -1584,6 +1597,54 @@ mod tests {
             actual,
             MyStruct {
                 field1: vec![String::new(), String::from("hello")],
+            }
+        );
+    }
+
+    #[test]
+    fn test_lookup_u32_and_alt_tokens() {
+        // EU5-only lookup widths: LOOKUP_U32 (0x0d3f), LOOKUP_U24_ALT (0x0d45),
+        // and LOOKUP_U32_ALT (0x0d46).
+        struct LookupResolver;
+        impl TokenResolver for LookupResolver {
+            fn resolve(&self, token: u16) -> Option<&str> {
+                match token {
+                    0x2d82 => Some("field1"),
+                    _ => None,
+                }
+            }
+
+            fn lookup(&self, index: u32) -> Option<&str> {
+                match index {
+                    1 => Some("a"),
+                    2 => Some("b"),
+                    3 => Some("c"),
+                    _ => None,
+                }
+            }
+        }
+
+        // field1 = { <u32 1> <u24_alt 2> <u32_alt 3> }
+        let data = [
+            0x82, 0x2d, // id 0x2d82 -> "field1"
+            0x01, 0x00, // EQUAL
+            0x03, 0x00, // OPEN
+            0x3f, 0x0d, 0x01, 0x00, 0x00, 0x00, // LOOKUP_U32(1) -> "a"
+            0x45, 0x0d, 0x02, 0x00, 0x00, // LOOKUP_U24_ALT(2) -> "b"
+            0x46, 0x0d, 0x03, 0x00, 0x00, 0x00, // LOOKUP_U32_ALT(3) -> "c"
+            0x04, 0x00, // CLOSE
+        ];
+
+        #[derive(Deserialize, PartialEq, Eq, Debug)]
+        struct MyStruct {
+            field1: Vec<String>,
+        }
+
+        let actual: MyStruct = eu5_owned(&data[..], &LookupResolver).unwrap();
+        assert_eq!(
+            actual,
+            MyStruct {
+                field1: vec![String::from("a"), String::from("b"), String::from("c")],
             }
         );
     }

--- a/src/binary/lexer.rs
+++ b/src/binary/lexer.rs
@@ -8,23 +8,20 @@ use std::fmt;
 pub struct LexemeId(pub u16);
 
 impl LexemeId {
+    /// A binary '='
+    pub const EQUAL: LexemeId = LexemeId::new(0x0001);
+
     /// A binary '{' (open bracket)
     pub const OPEN: LexemeId = LexemeId::new(0x0003);
 
     /// A binary '}' (close bracket)
     pub const CLOSE: LexemeId = LexemeId::new(0x0004);
 
-    /// A binary '='
-    pub const EQUAL: LexemeId = LexemeId::new(0x0001);
-
-    /// A binary 32 bit unsigned integer
-    pub const U32: LexemeId = LexemeId::new(0x0014);
-
-    /// A binary 64 bit unsigned integer
-    pub const U64: LexemeId = LexemeId::new(0x029c);
-
     /// A binary 32 bit signed integer
     pub const I32: LexemeId = LexemeId::new(0x000c);
+
+    /// A binary 32 bit floating point
+    pub const F32: LexemeId = LexemeId::new(0x000d);
 
     /// A binary boolean
     pub const BOOL: LexemeId = LexemeId::new(0x000e);
@@ -32,11 +29,11 @@ impl LexemeId {
     /// A binary string that is typically quoted
     pub const QUOTED: LexemeId = LexemeId::new(0x000f);
 
+    /// A binary 32 bit unsigned integer
+    pub const U32: LexemeId = LexemeId::new(0x0014);
+
     /// A binary string that is typically without quotes
     pub const UNQUOTED: LexemeId = LexemeId::new(0x0017);
-
-    /// A binary 32 bit floating point
-    pub const F32: LexemeId = LexemeId::new(0x000d);
 
     /// A binary 64 bit floating point
     pub const F64: LexemeId = LexemeId::new(0x0167);
@@ -44,17 +41,23 @@ impl LexemeId {
     /// A binary RGB value
     pub const RGB: LexemeId = LexemeId::new(0x0243);
 
+    /// A binary 64 bit unsigned integer
+    pub const U64: LexemeId = LexemeId::new(0x029c);
+
     /// A binary 64 bit signed integer
     pub const I64: LexemeId = LexemeId::new(0x0317);
+
+    /// A binary 16-bit lookup index
+    pub const LOOKUP_U16: LexemeId = LexemeId::new(0x0d3e);
+
+    /// A binary 32-bit lookup index (EU5 only)
+    pub const LOOKUP_U32: LexemeId = LexemeId::new(0x0d3f);
 
     /// A binary 8-bit lookup index
     pub const LOOKUP_U8: LexemeId = LexemeId::new(0x0d40);
 
     /// A binary 24-bit lookup index
     pub const LOOKUP_U24: LexemeId = LexemeId::new(0x0d41);
-
-    /// A binary 16-bit lookup index
-    pub const LOOKUP_U16: LexemeId = LexemeId::new(0x0d3e);
 
     /// Compact empty string/span - 0 bytes of payload (EU5 only)
     /// Space efficient encoding of an empty quoted string (`""`)
@@ -67,6 +70,14 @@ impl LexemeId {
     /// Compact 16-bit lookup index (alternative to LOOKUP_U16) (EU5 1.0.10+)
     /// Stores a u16 lookup table index in compact form
     pub const LOOKUP_U16_ALT: LexemeId = LexemeId::new(0x0d44);
+
+    /// Compact 24-bit lookup index (alternative to LOOKUP_U24) (EU5 1.0.10+)
+    /// Stores a u24 lookup table index in compact form
+    pub const LOOKUP_U24_ALT: LexemeId = LexemeId::new(0x0d45);
+
+    /// Compact 32-bit lookup index (alternative to LOOKUP_U32) (EU5 1.0.10+)
+    /// Stores a u32 lookup table index in compact form
+    pub const LOOKUP_U32_ALT: LexemeId = LexemeId::new(0x0d46);
 
     /// Fixed-point zero constant - 0 bytes of data (EU5 1.0.10+)
     /// Space efficient encoding of the value 0.0
@@ -169,7 +180,10 @@ impl LexemeId {
             | LexemeId::LOOKUP_U8_ALT
             | LexemeId::LOOKUP_U16
             | LexemeId::LOOKUP_U16_ALT
-            | LexemeId::LOOKUP_U24 => TokenKind::Lookup,
+            | LexemeId::LOOKUP_U24
+            | LexemeId::LOOKUP_U24_ALT
+            | LexemeId::LOOKUP_U32
+            | LexemeId::LOOKUP_U32_ALT => TokenKind::Lookup,
             // Fixed5 lexemes are converted to F64 tokens
             LexemeId::FIXED5_ZERO
             | LexemeId::FIXED5_U8
@@ -321,6 +335,12 @@ pub(crate) fn read_lookup_u16(data: &[u8]) -> Result<(u16, &[u8]), LexError> {
 pub(crate) fn read_lookup_u24(data: &[u8]) -> Result<(u32, &[u8]), LexError> {
     let (head, rest) = get_split::<3>(data).ok_or(LexError::Eof)?;
     Ok((u32::from_le_bytes([head[0], head[1], head[2], 0]), rest))
+}
+
+#[inline]
+pub(crate) fn read_lookup_u32(data: &[u8]) -> Result<(u32, &[u8]), LexError> {
+    let (head, rest) = get_split::<4>(data).ok_or(LexError::Eof)?;
+    Ok((u32::from_le_bytes(*head), rest))
 }
 
 #[inline]
@@ -526,7 +546,12 @@ pub(crate) fn read_token(data: &[u8]) -> Result<(Token<'_>, &[u8]), LexError> {
         LexemeId::LOOKUP_U16 | LexemeId::LOOKUP_U16_ALT => {
             read_lookup_u16(data).map(|(x, d)| (Token::Lookup(x as u32), d))
         }
-        LexemeId::LOOKUP_U24 => read_lookup_u24(data).map(|(x, d)| (Token::Lookup(x), d)),
+        LexemeId::LOOKUP_U24 | LexemeId::LOOKUP_U24_ALT => {
+            read_lookup_u24(data).map(|(x, d)| (Token::Lookup(x), d))
+        }
+        LexemeId::LOOKUP_U32 | LexemeId::LOOKUP_U32_ALT => {
+            read_lookup_u32(data).map(|(x, d)| (Token::Lookup(x), d))
+        }
         lexeme if lexeme >= LexemeId::FIXED5_ZERO && lexeme <= LexemeId::FIXED5_I56 => {
             read_compact_f64(lexeme, data).map(|(x, d)| (Token::F64(x), d))
         }
@@ -884,6 +909,14 @@ impl<'a> Lexer<'a> {
         Ok(result)
     }
 
+    /// Advance the lexer through a 32-bit lookup index
+    #[inline]
+    pub fn read_lookup_u32(&mut self) -> Result<u32, LexerError> {
+        let (result, rest) = read_lookup_u32(self.data).map_err(|e| self.err_position(e))?;
+        self.data = rest;
+        Ok(result)
+    }
+
     /// Advance the lexer through unsigned little endian 32 bit integer
     ///
     /// ```rust
@@ -1071,8 +1104,12 @@ impl<'a> Lexer<'a> {
                 self.read_lookup_u16()?;
                 Ok(())
             }
-            LexemeId::LOOKUP_U24 => {
+            LexemeId::LOOKUP_U24 | LexemeId::LOOKUP_U24_ALT => {
                 self.read_lookup_u24()?;
+                Ok(())
+            }
+            LexemeId::LOOKUP_U32 | LexemeId::LOOKUP_U32_ALT => {
+                self.read_lookup_u32()?;
                 Ok(())
             }
             lexeme if lexeme >= LexemeId::FIXED5_ZERO && lexeme <= LexemeId::FIXED5_I56 => {
@@ -1118,8 +1155,11 @@ impl<'a> Lexer<'a> {
                 LexemeId::LOOKUP_U16 | LexemeId::LOOKUP_U16_ALT => {
                     self.read_lookup_u16()?;
                 }
-                LexemeId::LOOKUP_U24 => {
+                LexemeId::LOOKUP_U24 | LexemeId::LOOKUP_U24_ALT => {
                     self.read_lookup_u24()?;
+                }
+                LexemeId::LOOKUP_U32 | LexemeId::LOOKUP_U32_ALT => {
+                    self.read_lookup_u32()?;
                 }
                 LexemeId::CLOSE => {
                     depth -= 1;

--- a/src/binary/reader.rs
+++ b/src/binary/reader.rs
@@ -304,7 +304,9 @@ impl<'a> TokenReader<'a> {
     /// Returns lookup data for the most recently decoded token.
     #[inline]
     pub fn lookup_data(&self) -> u32 {
-        u32::from_le_bytes([self.data[0], self.data[1], self.data[2], 0])
+        // Narrower lookup widths zero the unused high bytes, so reading all
+        // four bytes is correct for u8/u16/u24/u32 lookup indices alike.
+        u32::from_le_bytes([self.data[0], self.data[1], self.data[2], self.data[3]])
     }
 
     /// Returns RGB data for the most recently decoded token.
@@ -397,10 +399,16 @@ impl<'a> TokenReader<'a> {
                 self.source.advance(4);
                 Some(TokenKind::Lookup)
             }
-            LexemeId::LOOKUP_U24 => {
+            LexemeId::LOOKUP_U24 | LexemeId::LOOKUP_U24_ALT => {
                 self.data = [0; 8];
                 self.data[0..3].copy_from_slice(&rest[..3]);
                 self.source.advance(5);
+                Some(TokenKind::Lookup)
+            }
+            LexemeId::LOOKUP_U32 | LexemeId::LOOKUP_U32_ALT => {
+                self.data = [0; 8];
+                self.data[0..4].copy_from_slice(&rest[..4]);
+                self.source.advance(6);
                 Some(TokenKind::Lookup)
             }
             LexemeId::RGB => None,
@@ -517,12 +525,20 @@ impl<'a> TokenReader<'a> {
                 self.source.advance(4);
                 TokenKind::Lookup
             }
-            LexemeId::LOOKUP_U24 => {
+            LexemeId::LOOKUP_U24 | LexemeId::LOOKUP_U24_ALT => {
                 self.ensure_bytes(5)?;
                 let data = unsafe { self.source.get_window_unchecked(5) };
                 self.data = [0; 8];
                 self.data[0..3].copy_from_slice(&data[2..5]);
                 self.source.advance(5);
+                TokenKind::Lookup
+            }
+            LexemeId::LOOKUP_U32 | LexemeId::LOOKUP_U32_ALT => {
+                self.ensure_bytes(6)?;
+                let data = unsafe { self.source.get_window_unchecked(6) };
+                self.data = [0; 8];
+                self.data[0..4].copy_from_slice(&data[2..6]);
+                self.source.advance(6);
                 TokenKind::Lookup
             }
             LexemeId::RGB => {
@@ -787,6 +803,58 @@ mod tests {
         assert_tokens(
             &[0x42, 0x0d, 0x41, 0x0d, 0x01, 0x00, 0x00],
             &[Token::Quoted(Scalar::new(b"")), Token::Lookup(1)],
+        );
+    }
+
+    #[test]
+    fn test_lookup_u32_tokens() {
+        // LOOKUP_U32 (0x0d3f): 4-byte little-endian index. The high byte (0x12)
+        // exercises the full 32-bit width.
+        assert_tokens(
+            &[0x3f, 0x0d, 0x78, 0x56, 0x34, 0x12],
+            &[Token::Lookup(0x1234_5678)],
+        );
+    }
+
+    #[test]
+    fn test_lookup_alt_tokens() {
+        // The alt lookup variants decode to the same value as their non-alt
+        // counterparts. LOOKUP_U24_ALT (0x0d45): 3 bytes, LOOKUP_U32_ALT
+        // (0x0d46): 4 bytes.
+        assert_tokens(
+            &[0x45, 0x0d, 0x56, 0x34, 0x12],
+            &[Token::Lookup(0x0012_3456)],
+        );
+        assert_tokens(
+            &[0x46, 0x0d, 0xdd, 0xcc, 0xbb, 0xaa],
+            &[Token::Lookup(0xaabb_ccdd)],
+        );
+    }
+
+    #[test]
+    fn test_lookup_widths_stay_aligned() {
+        // A run of every lookup width back-to-back must keep the reader aligned.
+        assert_tokens(
+            &[
+                0x40, 0x0d, 0x01, // LOOKUP_U8(1)
+                0x43, 0x0d, 0x02, // LOOKUP_U8_ALT(2)
+                0x3e, 0x0d, 0x03, 0x00, // LOOKUP_U16(3)
+                0x44, 0x0d, 0x04, 0x00, // LOOKUP_U16_ALT(4)
+                0x41, 0x0d, 0x05, 0x00, 0x00, // LOOKUP_U24(5)
+                0x45, 0x0d, 0x06, 0x00, 0x00, // LOOKUP_U24_ALT(6)
+                0x3f, 0x0d, 0x07, 0x00, 0x00, 0x00, // LOOKUP_U32(7)
+                0x46, 0x0d, 0x08, 0x00, 0x00, 0x00, // LOOKUP_U32_ALT(8)
+            ],
+            &[
+                Token::Lookup(1),
+                Token::Lookup(2),
+                Token::Lookup(3),
+                Token::Lookup(4),
+                Token::Lookup(5),
+                Token::Lookup(6),
+                Token::Lookup(7),
+                Token::Lookup(8),
+            ],
         );
     }
 }

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -756,3 +756,128 @@ fn test_lookup_u24_in_nested_container() {
     assert_eq!(result.nested.culture, "byzantine");
     assert_eq!(result.name, "test");
 }
+
+#[test]
+fn test_lookup_u32_to_string() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Data {
+        culture: String,
+    }
+
+    let mut tokens = HashMap::new();
+    tokens.insert(0x053a, "culture".to_string());
+    let mut lookups = HashMap::new();
+    // High byte set to exercise the full 32-bit width.
+    lookups.insert(0x1234_5678u32, "imperial".to_string());
+    let resolver = TestResolver { tokens, lookups };
+
+    let bin_data = [
+        0x3a, 0x05, // Id token for "culture"
+        0x01, 0x00, // EQUAL token
+        0x3f, 0x0d, // LOOKUP_U32 token (0x0d3f)
+        0x78, 0x56, 0x34, 0x12, // 0x12345678 in little-endian 32-bit
+    ];
+
+    let result: Data = BinaryDeserializer::builder_flavor(BinaryTestFlavor)
+        .deserialize_slice(&bin_data[..], &resolver)
+        .unwrap();
+    assert_eq!(result.culture, "imperial");
+
+    let result: Data = BinaryDeserializer::builder_flavor(BinaryTestFlavor)
+        .deserialize_reader(&bin_data[..], &resolver)
+        .unwrap();
+    assert_eq!(result.culture, "imperial");
+}
+
+#[test]
+fn test_lookup_u32_raw_index() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Data {
+        culture: InternedSymbol,
+    }
+
+    let mut tokens = HashMap::new();
+    tokens.insert(0x053a, "culture".to_string());
+    let lookups = HashMap::new();
+    let resolver = TestResolver { tokens, lookups };
+
+    let bin_data = [
+        0x3a, 0x05, // Id token for "culture"
+        0x01, 0x00, // EQUAL token
+        0x3f, 0x0d, // LOOKUP_U32 token
+        0x78, 0x56, 0x34, 0x12, // 0x12345678 in little-endian
+    ];
+
+    // Verifies the high byte is not dropped when decoding a 32-bit index.
+    let result: Data = BinaryDeserializer::builder_flavor(BinaryTestFlavor)
+        .deserialize_slice(&bin_data[..], &resolver)
+        .unwrap();
+    assert_eq!(result.culture.0, 0x1234_5678);
+
+    let result: Data = BinaryDeserializer::builder_flavor(BinaryTestFlavor)
+        .deserialize_reader(&bin_data[..], &resolver)
+        .unwrap();
+    assert_eq!(result.culture.0, 0x1234_5678);
+}
+
+#[test]
+fn test_lookup_u24_alt_to_string() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Data {
+        culture: String,
+    }
+
+    let mut tokens = HashMap::new();
+    tokens.insert(0x053a, "culture".to_string());
+    let mut lookups = HashMap::new();
+    lookups.insert(100000u32, "imperial".to_string());
+    let resolver = TestResolver { tokens, lookups };
+
+    let bin_data = [
+        0x3a, 0x05, // Id token for "culture"
+        0x01, 0x00, // EQUAL token
+        0x45, 0x0d, // LOOKUP_U24_ALT token (0x0d45)
+        0xa0, 0x86, 0x01, // 100000 in little-endian 24-bit
+    ];
+
+    let result: Data = BinaryDeserializer::builder_flavor(BinaryTestFlavor)
+        .deserialize_slice(&bin_data[..], &resolver)
+        .unwrap();
+    assert_eq!(result.culture, "imperial");
+
+    let result: Data = BinaryDeserializer::builder_flavor(BinaryTestFlavor)
+        .deserialize_reader(&bin_data[..], &resolver)
+        .unwrap();
+    assert_eq!(result.culture, "imperial");
+}
+
+#[test]
+fn test_lookup_u32_alt_to_string() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Data {
+        culture: String,
+    }
+
+    let mut tokens = HashMap::new();
+    tokens.insert(0x053a, "culture".to_string());
+    let mut lookups = HashMap::new();
+    lookups.insert(0x1234_5678u32, "imperial".to_string());
+    let resolver = TestResolver { tokens, lookups };
+
+    let bin_data = [
+        0x3a, 0x05, // Id token for "culture"
+        0x01, 0x00, // EQUAL token
+        0x46, 0x0d, // LOOKUP_U32_ALT token (0x0d46)
+        0x78, 0x56, 0x34, 0x12, // 0x12345678 in little-endian 32-bit
+    ];
+
+    let result: Data = BinaryDeserializer::builder_flavor(BinaryTestFlavor)
+        .deserialize_slice(&bin_data[..], &resolver)
+        .unwrap();
+    assert_eq!(result.culture, "imperial");
+
+    let result: Data = BinaryDeserializer::builder_flavor(BinaryTestFlavor)
+        .deserialize_reader(&bin_data[..], &resolver)
+        .unwrap();
+    assert_eq!(result.culture, "imperial");
+}


### PR DESCRIPTION
Even though I have not encountered an EU5 with these tokens, they exist and should be accounted for.