### PR TITLE
Add verifying readers for envelope entries

### DIFF
--- a/src/envelope/errors.rs
+++ b/src/envelope/errors.rs
@@ -9,6 +9,11 @@ impl EnvelopeError {
     pub fn is_missing_entry(&self) -> bool {
         matches!(self.kind, EnvelopeErrorKind::ZipMissingEntry(_))
     }
+
+    /// Returns the specific kind of this error.
+    pub fn kind(&self) -> &EnvelopeErrorKind {
+        &self.kind
+    }
 }
 
 impl From<EnvelopeErrorKind> for EnvelopeError {
@@ -38,6 +43,20 @@ pub enum EnvelopeErrorKind {
     ZipMissingEntry(String),
     /// ZIP entry uses unsupported compression method
     ZipUnsupportedCompression,
+    /// Decompressed data did not match the expected CRC32 checksum
+    ChecksumMismatch {
+        /// Checksum recorded in the archive
+        expected: u32,
+        /// Checksum computed over the decompressed data
+        actual: u32,
+    },
+    /// Decompressed data did not match the expected uncompressed size
+    SizeMismatch {
+        /// Size recorded in the archive
+        expected: u64,
+        /// Number of bytes actually decompressed
+        actual: u64,
+    },
 }
 
 impl std::error::Error for EnvelopeError {
@@ -60,6 +79,16 @@ impl std::fmt::Display for EnvelopeError {
             EnvelopeErrorKind::ZipUnsupportedCompression => {
                 write!(f, "Zip unsupported compression method")
             }
+            EnvelopeErrorKind::ChecksumMismatch { expected, actual } => write!(
+                f,
+                "checksum mismatch: expected {:#010x}, computed {:#010x}",
+                expected, actual
+            ),
+            EnvelopeErrorKind::SizeMismatch { expected, actual } => write!(
+                f,
+                "size mismatch: expected {} bytes, decompressed {} bytes",
+                expected, actual
+            ),
         }
     }
 }

--- a/src/envelope/file.rs
+++ b/src/envelope/file.rs
@@ -282,21 +282,44 @@ where
         }
     }
 
-    /// Returns the gamestate reader, decompressing if necessary
-    pub fn gamestate(&self) -> Result<SaveContentKind<ZipEntry<&R>>, EnvelopeError> {
+    /// Opens the gamestate entry, returning the decompressing reader alongside
+    /// the expected verification recorded in the archive.
+    fn gamestate_entry(&self) -> Result<(ZipEntry<&R>, SaveVerification), EnvelopeError> {
         let (compression, wayfinder) = &self.gamestate;
         let zip_entry = self
             .archive
             .get_entry(*wayfinder)
             .map_err(EnvelopeErrorKind::Zip)?;
+        let expected = SaveVerification::from_zip(zip_entry.reader().claim_verifier());
         let reader = CompressedReader::from_zip(*compression, zip_entry)?;
+        Ok((ZipEntry { reader }, expected))
+    }
+
+    /// Wraps a reader in the text/binary content kind dictated by the header.
+    fn wrap_content<T>(&self, reader: T) -> SaveContentKind<T> {
         if self.header.kind().is_text() {
-            Ok(SaveContentKind::Text(SaveContent::new(ZipEntry { reader })))
+            SaveContentKind::Text(SaveContent::new(reader))
         } else {
-            Ok(SaveContentKind::Binary(SaveContent::new(ZipEntry {
-                reader,
-            })))
+            SaveContentKind::Binary(SaveContent::new(reader))
         }
+    }
+
+    /// Returns the gamestate reader, decompressing if necessary
+    pub fn gamestate(&self) -> Result<SaveContentKind<ZipEntry<&R>>, EnvelopeError> {
+        let (entry, _) = self.gamestate_entry()?;
+        Ok(self.wrap_content(entry))
+    }
+
+    /// Returns a gamestate reader that verifies the decompressed data against
+    /// the CRC32 and size recorded in the archive.
+    ///
+    /// Verification runs when the reader is read to EOF, or on demand via
+    /// [`VerifyingReader::finish`]. See [`VerifyingReader`] for the details.
+    pub fn gamestate_verified(
+        &self,
+    ) -> Result<SaveContentKind<VerifyingReader<ZipEntry<&R>>>, EnvelopeError> {
+        let (entry, expected) = self.gamestate_entry()?;
+        Ok(self.wrap_content(VerifyingReader::new(entry, expected)))
     }
 
     /// Returns a reader for a file in the ZIP archive by path
@@ -319,6 +342,35 @@ where
                     .map_err(EnvelopeErrorKind::Zip)?;
 
                 return CompressedReader::from_zip(entry.compression_method(), zip_entry);
+            }
+        }
+
+        Err(EnvelopeErrorKind::ZipMissingEntry(path.to_string()).into())
+    }
+
+    /// Returns a reader for a file in the ZIP archive by path that verifies the
+    /// decompressed data against the CRC32 and size recorded in the archive.
+    ///
+    /// Like [`JominiZip::read_entry`], but the returned [`VerifyingReader`]
+    /// validates the entry when read to EOF or via [`VerifyingReader::finish`].
+    pub fn read_entry_verified(
+        &self,
+        path: &str,
+    ) -> Result<VerifyingReader<ZipEntry<&R>>, EnvelopeError> {
+        let path_bytes = path.as_bytes();
+        let mut buf = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
+
+        let mut entries = self.archive.entries(&mut buf);
+        while let Some(entry) = entries.next_entry().map_err(EnvelopeErrorKind::Zip)? {
+            if entry.file_path().as_ref() == path_bytes {
+                let zip_entry = self
+                    .archive
+                    .get_entry(entry.wayfinder())
+                    .map_err(EnvelopeErrorKind::Zip)?;
+
+                let expected = SaveVerification::from_zip(zip_entry.reader().claim_verifier());
+                let reader = CompressedReader::from_zip(entry.compression_method(), zip_entry)?;
+                return Ok(VerifyingReader::new(ZipEntry { reader }, expected));
             }
         }
 
@@ -592,8 +644,12 @@ impl<R, E> SaveContent<E, R> {
         &self.reader
     }
 
-    /// Consumes this content and returns the inner reader
-    fn into_inner(self) -> R {
+    /// Consumes this content and returns the inner reader.
+    ///
+    /// Useful for recovering the underlying reader, e.g. to call
+    /// [`VerifyingReader::finish`] on the gamestate returned by
+    /// [`JominiZip::gamestate_verified`].
+    pub fn into_inner(self) -> R {
         self.reader
     }
 
@@ -696,6 +752,196 @@ where
 {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.reader.read(buf)
+    }
+}
+
+/// CRC32 engine selected per target.
+///
+/// On native platforms this uses flate2's `zlib-rs` backend, which has SIMD
+/// implementations on x86_64 and aarch64. On wasm, where `zlib-rs` has no SIMD
+/// path, it uses rawzip's table-based implementation instead.
+#[cfg(not(target_family = "wasm"))]
+#[derive(Debug)]
+struct CrcEngine(flate2::Crc);
+
+#[cfg(not(target_family = "wasm"))]
+impl CrcEngine {
+    fn new() -> Self {
+        CrcEngine(flate2::Crc::new())
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.0.update(data);
+    }
+
+    fn checksum(&self) -> u32 {
+        self.0.sum()
+    }
+}
+
+#[cfg(target_family = "wasm")]
+#[derive(Debug)]
+struct CrcEngine(rawzip::Crc32);
+
+#[cfg(target_family = "wasm")]
+impl CrcEngine {
+    fn new() -> Self {
+        CrcEngine(rawzip::Crc32::new())
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.0.update(data);
+    }
+
+    fn checksum(&self) -> u32 {
+        self.0.checksum()
+    }
+}
+
+/// The expected CRC32 checksum and uncompressed size of a save entry.
+///
+/// These values are recorded in the ZIP central directory and are used by
+/// [`VerifyingReader`] to validate decompressed data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SaveVerification {
+    crc: u32,
+    uncompressed_size: u64,
+}
+
+impl SaveVerification {
+    /// Creates a verification from an expected checksum and uncompressed size.
+    ///
+    /// Useful for wrapping a decompressor in a [`VerifyingReader`] when the
+    /// expected values are known from another source.
+    pub fn new(crc: u32, uncompressed_size: u64) -> Self {
+        SaveVerification {
+            crc,
+            uncompressed_size,
+        }
+    }
+
+    /// The expected CRC32 checksum of the decompressed data.
+    pub fn crc(&self) -> u32 {
+        self.crc
+    }
+
+    /// The expected size of the decompressed data in bytes.
+    pub fn uncompressed_size(&self) -> u64 {
+        self.uncompressed_size
+    }
+
+    pub(crate) fn from_zip(value: rawzip::ZipVerification) -> Self {
+        SaveVerification {
+            crc: value.crc,
+            uncompressed_size: value.uncompressed_size,
+        }
+    }
+}
+
+/// A reader that verifies decompressed data against the checksum and size
+/// recorded in the archive.
+///
+/// The check runs once the underlying stream reaches EOF, so reading the entry
+/// to completion validates it automatically. A caller that would otherwise stop
+/// early can force the check by calling [`VerifyingReader::finish`]. Note that a
+/// partially-read reader that is simply dropped performs no verification.
+#[derive(Debug)]
+pub struct VerifyingReader<R> {
+    reader: R,
+    expected: SaveVerification,
+    crc: CrcEngine,
+    size: u64,
+}
+
+impl<R> VerifyingReader<R> {
+    /// Wraps a decompressed reader with the expected verification values.
+    pub fn new(reader: R, expected: SaveVerification) -> Self {
+        VerifyingReader {
+            reader,
+            expected,
+            crc: CrcEngine::new(),
+            size: 0,
+        }
+    }
+
+    /// Returns the expected checksum and size this reader validates against.
+    pub fn verification(&self) -> SaveVerification {
+        self.expected
+    }
+
+    /// Consumes this reader, returning the inner reader without verifying.
+    pub fn into_inner(self) -> R {
+        self.reader
+    }
+
+    fn verify(&self) -> Result<(), EnvelopeError> {
+        if self.size != self.expected.uncompressed_size {
+            return Err(EnvelopeErrorKind::SizeMismatch {
+                expected: self.expected.uncompressed_size,
+                actual: self.size,
+            }
+            .into());
+        }
+
+        let actual = self.crc.checksum();
+        if actual != self.expected.crc {
+            return Err(EnvelopeErrorKind::ChecksumMismatch {
+                expected: self.expected.crc,
+                actual,
+            }
+            .into());
+        }
+
+        Ok(())
+    }
+}
+
+impl<R: Read> VerifyingReader<R> {
+    /// Reads from the inner reader, accumulating the CRC and size but performing
+    /// no validation.
+    fn fill(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.reader.read(buf)?;
+        self.crc.update(&buf[..n]);
+        self.size += n as u64;
+        Ok(n)
+    }
+
+    /// Reads any remaining data, then verifies the checksum and size.
+    ///
+    /// Returns the inner reader on success so the decompressor can be recovered.
+    /// A checksum or size mismatch is returned as an [`EnvelopeError`].
+    pub fn finish(mut self) -> Result<R, EnvelopeError> {
+        // Drain through the accumulate-only view so a genuine IO error surfaces
+        // as `EnvelopeErrorKind::Io` while the check below yields the owned
+        // checksum/size error rather than an IO-wrapped one.
+        std::io::copy(&mut Accumulate(&mut self), &mut std::io::sink())?;
+        self.verify()?;
+        Ok(self.reader)
+    }
+}
+
+/// Accumulates CRC/size without triggering the inline end-of-stream validation,
+/// letting [`VerifyingReader::finish`] surface the owned error.
+struct Accumulate<'a, R>(&'a mut VerifyingReader<R>);
+
+impl<R: Read> Read for Accumulate<'_, R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.0.fill(buf)
+    }
+}
+
+impl<R: Read> Read for VerifyingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let n = self.fill(buf)?;
+        if n == 0 || self.size >= self.expected.uncompressed_size {
+            self.verify()
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        }
+        Ok(n)
     }
 }
 

--- a/tests/envelope.rs
+++ b/tests/envelope.rs
@@ -5,8 +5,8 @@ use jomini::{
         BinaryDeserializerBuilder, BinaryFlavor, Token, TokenResolver, de::BinaryReaderDeserializer,
     },
     envelope::{
-        BinaryEncoding, JominiFile, JominiFileKind, SaveContent, SaveContentKind, SaveData,
-        SaveDataKind, SaveHeaderKind, SaveMetadata, SaveMetadataKind,
+        BinaryEncoding, EnvelopeErrorKind, JominiFile, JominiFileKind, SaveContent,
+        SaveContentKind, SaveData, SaveDataKind, SaveHeaderKind, SaveMetadata, SaveMetadataKind,
     },
 };
 use rawzip::ReaderAt;
@@ -428,6 +428,129 @@ fn zip_eu5_sav02() {
         panic!("expected missing entry error");
     };
     assert!(err.is_missing_entry());
+}
+
+/// Returns the byte offset of the central-directory file header for `name`, so
+/// a test can deterministically corrupt its metadata.
+fn find_central_directory_header(data: &[u8], name: &[u8]) -> usize {
+    let archive = rawzip::ZipArchive::from_slice(data).unwrap();
+    let mut entries = archive.entries();
+    while let Some(entry) = entries.next_entry().unwrap() {
+        if entry.file_path().as_ref() == name {
+            return entry.central_directory_offset() as usize;
+        }
+    }
+    panic!("central directory header not found for {:?}", name);
+}
+
+#[test]
+fn zip_gamestate_verified_matches_plain() {
+    let data = std::fs::read("tests/fixtures/envelopes/text.zip").unwrap();
+    let file = JominiFile::from_slice(&data).unwrap();
+    let JominiFileKind::Zip(zip) = file.kind() else {
+        panic!("expected zip text envelope");
+    };
+
+    let mut verified = String::new();
+    zip.gamestate_verified()
+        .unwrap()
+        .read_to_string(&mut verified)
+        .unwrap();
+    assert_eq!(verified, EXPECTED_TEXT_GAMESTATE);
+
+    let mut plain = String::new();
+    zip.gamestate().unwrap().read_to_string(&mut plain).unwrap();
+    assert_eq!(verified, plain);
+
+    // The finish() path drains the reader, re-verifies, and hands back the
+    // inner reader on success.
+    let SaveContentKind::Text(content) = zip.gamestate_verified().unwrap() else {
+        panic!("expected text gamestate");
+    };
+    let mut reader = content.into_inner();
+    let copied = std::io::copy(&mut reader, &mut std::io::sink()).unwrap();
+    assert_eq!(copied as usize, EXPECTED_TEXT_GAMESTATE.len());
+    reader.finish().unwrap();
+}
+
+#[test]
+fn zip_gamestate_verified_detects_bad_crc() {
+    let mut data = std::fs::read("tests/fixtures/envelopes/text.zip").unwrap();
+    let cd = find_central_directory_header(&data, b"gamestate");
+    // Flip the central-directory CRC32 (bytes 16..20) to a guaranteed-wrong value.
+    let orig = u32::from_le_bytes(data[cd + 16..cd + 20].try_into().unwrap());
+    data[cd + 16..cd + 20].copy_from_slice(&(orig ^ 0xFFFF_FFFF).to_le_bytes());
+
+    let file = JominiFile::from_slice(&data).unwrap();
+    let JominiFileKind::Zip(zip) = file.kind() else {
+        panic!("expected zip text envelope");
+    };
+
+    // Unverified read still succeeds on the same bytes.
+    let mut plain = String::new();
+    zip.gamestate().unwrap().read_to_string(&mut plain).unwrap();
+    assert_eq!(plain, EXPECTED_TEXT_GAMESTATE);
+
+    // finish() surfaces the owned ChecksumMismatch.
+    let SaveContentKind::Text(content) = zip.gamestate_verified().unwrap() else {
+        panic!("expected text gamestate");
+    };
+    let err = content.into_inner().finish().unwrap_err();
+    assert!(
+        matches!(err.kind(), EnvelopeErrorKind::ChecksumMismatch { expected, .. } if *expected == (orig ^ 0xFFFF_FFFF)),
+        "unexpected error: {err:?}"
+    );
+
+    // The inline Read path also fails (as io::ErrorKind::InvalidData).
+    let mut buf = String::new();
+    let io_err = zip
+        .gamestate_verified()
+        .unwrap()
+        .read_to_string(&mut buf)
+        .unwrap_err();
+    assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
+}
+
+#[test]
+fn zip_read_entry_verified() {
+    let data = std::fs::read("tests/fixtures/envelopes/lookup.zip").unwrap();
+    let file = JominiFile::from_slice(&data).unwrap();
+    let JominiFileKind::Zip(zip) = file.kind() else {
+        panic!("expected zip binary envelope");
+    };
+
+    let mut lookup = String::new();
+    zip.read_entry_verified("string-lookup")
+        .unwrap()
+        .read_to_string(&mut lookup)
+        .unwrap();
+    assert_eq!(lookup, "hello-world");
+
+    let err = zip.read_entry_verified("nonexistent-file").unwrap_err();
+    assert!(err.is_missing_entry());
+}
+
+#[test]
+fn zip_gamestate_verified_detects_bad_size() {
+    let mut data = std::fs::read("tests/fixtures/envelopes/text.zip").unwrap();
+    let cd = find_central_directory_header(&data, b"gamestate");
+    // Inflate the central-directory uncompressed size (bytes 24..28) so the
+    // expectation exceeds the real decompressed length -> SizeMismatch at EOF.
+    let orig = u32::from_le_bytes(data[cd + 24..cd + 28].try_into().unwrap());
+    data[cd + 24..cd + 28].copy_from_slice(&(orig + 1000).to_le_bytes());
+
+    let file = JominiFile::from_slice(&data).unwrap();
+    let JominiFileKind::Zip(zip) = file.kind() else {
+        panic!("expected zip text envelope");
+    };
+    let SaveContentKind::Text(content) = zip.gamestate_verified().unwrap() else {
+        panic!("expected text gamestate");
+    };
+    let err = content.into_inner().finish().unwrap_err();
+    assert!(
+        matches!(err.kind(), EnvelopeErrorKind::SizeMismatch { expected, actual } if *expected == u64::from(orig) + 1000 && *actual == u64::from(orig)),
+        "unexpected error: {err:?}"
+    );
 }
 
 struct TestFlavor;


### PR DESCRIPTION
zip files contain a entry integrity, so this exposes these methods for those that want it