### PR TITLE
Add arena-serde to the workspace

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,11 +33,11 @@ jobs:
         toolchain: stable
         components: clippy
     - name: Run clippy
-      run: cargo clippy -p jomini -p jomini_derive --all-features --all-targets -- -D warnings
+      run: cargo clippy -p jomini -p jomini_derive -p arena-serde -p arena-serde-derive --all-features --all-targets -- -D warnings
     # Game crates carry wasm-only features (tsify), so they are checked with
     # default features.
     - name: Run clippy (game crates)
-      run: cargo clippy --workspace --exclude jomini --exclude jomini_derive --all-targets -- -D warnings
+      run: cargo clippy --workspace --exclude jomini --exclude jomini_derive --exclude arena-serde --exclude arena-serde-derive --all-targets -- -D warnings
 
   testbench:
     name: testbench
@@ -81,8 +81,7 @@ jobs:
         toolchain: nightly
         components: miri
     - name: Run miri
-      # trybuild in jomini_derive cannot run under Miri
-      run: cargo miri test -p jomini
+      run: cargo miri test -p jomini -p jomini_derive -p arena-serde
       env:
         MIRIFLAGS: -Zmiri-tree-borrows
 
@@ -179,9 +178,9 @@ jobs:
     env:
       CARGO: cargo
       TARGET:
-      # The cross-compile and miri legs run only the published crates. Game
-      # crates get their own linux-only job.
-      PKGS: -p jomini -p jomini_derive
+      # The cross-compile legs run only the library crates. Game crates get
+      # their own linux-only job.
+      PKGS: -p jomini -p jomini_derive -p arena-serde -p arena-serde-derive
     strategy:
       matrix:
         build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rakaly/jomini"
 [workspace.dependencies]
 jomini = "0.36"
 attohttpc = { version = "0.30.1", features = ["tls-vendored"] }
+bumpalo = { version = "3.20", features = ["collections"] }
 flate2 = { version = "1.1.5", default-features = false, features = ["zlib-rs"] }
 highway = "1.3"
 memchr = "2.7"

--- a/crates/arena-serde-derive/Cargo.toml
+++ b/crates/arena-serde-derive/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "arena-serde-derive"
+version = "0.1.0"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition = "2024"
+publish = false
+description = "Implementation of `#[derive(ArenaDeserialize)]` for arena-serde"
+keywords = ["serde", "deserialization", "arena"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2.0.50", features = ["derive"] }
+quote = "1.0.34"
+proc-macro2 = "1.0"

--- a/crates/arena-serde-derive/LICENSE.txt
+++ b/crates/arena-serde-derive/LICENSE.txt
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/arena-serde-derive/src/lib.rs
+++ b/crates/arena-serde-derive/src/lib.rs
@@ -1,0 +1,905 @@
+use proc_macro::{Span, TokenStream};
+use quote::{format_ident, quote};
+use syn::{Data, DeriveInput, Fields, LifetimeParam, Lit, Meta, Type, parse_macro_input};
+
+#[proc_macro_derive(ArenaDeserialize, attributes(arena))]
+pub fn derive_arena_deserialize(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    match expand_arena_deserialize(&input) {
+        Ok(tokens) => tokens,
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+fn expand_arena_deserialize(input: &DeriveInput) -> syn::Result<TokenStream> {
+    let name = &input.ident;
+    let data = &input.data;
+
+    // Determine the arena lifetime to use
+    let arena_lifetime = determine_arena_lifetime(&input.generics);
+
+    match data {
+        Data::Struct(data_struct) => match &data_struct.fields {
+            Fields::Named(fields) => expand_struct_with_named_fields(
+                name,
+                &input.generics,
+                &fields.named,
+                &arena_lifetime,
+            ),
+            Fields::Unnamed(fields) => expand_struct_with_unnamed_fields(
+                name,
+                &input.generics,
+                &fields.unnamed,
+                &arena_lifetime,
+            ),
+            Fields::Unit => expand_unit_struct(name, &input.generics, &arena_lifetime),
+        },
+        Data::Enum(data_enum) => expand_enum(input, name, data_enum, &arena_lifetime),
+        Data::Union(_) => Err(syn::Error::new_spanned(
+            input,
+            "ArenaDeserialize does not support unions",
+        )),
+    }
+}
+
+fn expand_struct_with_named_fields(
+    name: &syn::Ident,
+    generics: &syn::Generics,
+    fields: &syn::punctuated::Punctuated<syn::Field, syn::Token![,]>,
+    arena_lifetime: &str,
+) -> syn::Result<TokenStream> {
+    let field_info: Vec<FieldInfo> = fields
+        .iter()
+        .map(parse_field_attributes)
+        .collect::<syn::Result<Vec<_>>>()?;
+
+    let visitor_name = format_ident!("{}Visitor", name);
+
+    // Generate field enum variants
+    let field_enums: Vec<_> = field_info
+        .iter()
+        .enumerate()
+        .map(|(i, _info)| {
+            let variant_name = format_ident!("Field{}", i);
+            quote! { #variant_name }
+        })
+        .collect();
+
+    // Generate field name array for deserialization
+    let field_names: Vec<_> = field_info.iter().map(|info| &info.name).collect();
+
+    // Generate field enum match patterns
+    let field_enum_match: Vec<_> = field_info
+        .iter()
+        .enumerate()
+        .flat_map(|(i, info)| {
+            let variant_name = format_ident!("Field{}", i);
+            let field_name = &info.name;
+            let mut matches = vec![quote! { #field_name => Ok(__Field::#variant_name) }];
+
+            // Add aliases
+            for alias in &info.aliases {
+                matches.push(quote! { #alias => Ok(__Field::#variant_name) });
+            }
+
+            matches
+        })
+        .collect();
+
+    // Generate field initialization for the visitor
+    let field_initializations: Vec<_> = field_info
+        .iter()
+        .map(|info| {
+            let field_name = &info.ident;
+            if info.duplicated {
+                quote! {
+                    let mut #field_name = arena_serde::ArenaVec::new_in(__allocator);
+                }
+            } else {
+                quote! {
+                    let mut #field_name = None;
+                }
+            }
+        })
+        .collect();
+
+    // Generate field handling using enum variants
+    let field_handling: Vec<_> = field_info
+        .iter()
+        .enumerate()
+        .map(|(i, info)| -> syn::Result<_> {
+            let field_name = &info.ident;
+            let field_type = &info.ty;
+            let field_str = &info.name;
+            let variant_name = format_ident!("Field{}", i);
+
+            if info.duplicated {
+                if info.deserialize_with.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        &info.ident,
+                        "duplicated attribute cannot be combined with deserialize_with",
+                    ));
+                }
+                if !is_slice_reference(field_type, arena_lifetime) {
+                    return Err(syn::Error::new_spanned(
+                        field_type,
+                        "duplicated attribute requires a slice reference field like &'arena [T]",
+                    ));
+                }
+                let element_type = get_slice_element_type(field_type).ok_or_else(|| {
+                    syn::Error::new_spanned(
+                        field_type,
+                        "duplicated attribute requires a slice element type",
+                    )
+                })?;
+
+                Ok(quote! {
+                    __Field::#variant_name => {
+                        #field_name.push(
+                            __map.next_value_seed(
+                                arena_serde::ArenaSeed::<#element_type>::new(__allocator)
+                            )?
+                        );
+                    }
+                })
+            } else {
+                let deserialize_logic = if let Some(deserialize_with) = &info.deserialize_with {
+                    quote! {
+                        #field_name = Some({
+                            struct CustomFieldSeed<'bump> {
+                                allocator: &'bump arena_serde::Arena,
+                            }
+
+                            impl<'de, 'bump> serde::de::DeserializeSeed<'de> for CustomFieldSeed<'bump> {
+                                type Value = #field_type;
+
+                                fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+                                where
+                                    D: serde::Deserializer<'de>,
+                                {
+                                    #deserialize_with(deserializer, self.allocator)
+                                }
+                            }
+
+                            __map.next_value_seed(CustomFieldSeed { allocator: __allocator })?
+                        });
+                    }
+                } else {
+                    // Every field goes through ArenaDeserialize. Owned types
+                    // implement it by forwarding to Deserialize.
+                    quote! {
+                        #field_name = Some(__map.next_value_seed(
+                            arena_serde::ArenaSeed::<#field_type>::new(__allocator)
+                        )?);
+                    }
+                };
+
+                Ok(quote! {
+                    __Field::#variant_name => {
+                        if #field_name.is_some() {
+                            return Err(serde::de::Error::duplicate_field(#field_str));
+                        }
+                        #deserialize_logic
+                    }
+                })
+            }
+        })
+        .collect::<syn::Result<Vec<_>>>()?;
+
+    // Generate field extraction with defaults
+    let field_extractions: Vec<_> = field_info
+        .iter()
+        .map(|info| {
+            let field_name = &info.ident;
+            if info.duplicated {
+                quote! {
+                    let #field_name = #field_name.into_bump_slice();
+                }
+            } else if info.has_default {
+                quote! {
+                    let #field_name = #field_name.unwrap_or_default();
+                }
+            } else if is_option_type(&info.ty) {
+                // For Option types without default, None is a valid value
+                quote! {
+                    let #field_name = #field_name.unwrap_or(None);
+                }
+            } else {
+                quote! {
+                    let #field_name = #field_name.ok_or_else(|| serde::de::Error::missing_field(stringify!(#field_name)))?;
+                }
+            }
+        })
+        .collect();
+
+    // Generate struct construction
+    let field_assignments: Vec<_> = field_info
+        .iter()
+        .map(|info| {
+            let field_name = &info.ident;
+            quote! { #field_name }
+        })
+        .collect();
+
+    // Handle generics and lifetime
+    let ImplGenerics {
+        arena_lifetime: arena_lifetime_syn,
+        impl_generics: new_impl_generics,
+        ty_generics,
+        where_clause: new_where_clause,
+    } = ImplGenerics::new(generics, arena_lifetime);
+
+    let deser_request = quote! {
+        __deserializer.deserialize_identifier(__FieldVisitor)
+    };
+
+    let output = quote! {
+        impl #new_impl_generics arena_serde::ArenaDeserialize<#arena_lifetime_syn> for #name #ty_generics #new_where_clause {
+            fn deserialize_in_arena<'de, D>(deserializer: D, allocator: &#arena_lifetime_syn arena_serde::Arena) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                #[allow(non_camel_case_types)]
+                enum __Field {
+                    #(#field_enums),* ,
+                    __ignore,
+                }
+
+                struct __FieldVisitor;
+                impl<'de> ::serde::de::Visitor<'de> for __FieldVisitor {
+                    type Value = __Field;
+                    fn expecting(
+                        &self,
+                        __formatter: &mut ::std::fmt::Formatter,
+                    ) -> ::std::fmt::Result {
+                        write!(__formatter, "field identifier")
+                    }
+                    fn visit_str<__E>(
+                        self,
+                        __value: &str,
+                    ) -> ::std::result::Result<Self::Value, __E>
+                    where
+                        __E: ::serde::de::Error,
+                    {
+                        match __value {
+                            #(#field_enum_match),* ,
+                            _ => Ok(__Field::__ignore),
+                        }
+                    }
+
+                }
+
+                impl<'de> serde::Deserialize<'de> for __Field {
+                    #[inline]
+                    fn deserialize<__D>(
+                        __deserializer: __D,
+                    ) -> std::result::Result<Self, __D::Error>
+                    where
+                        __D: ::serde::Deserializer<'de>,
+                    {
+                        #deser_request
+                    }
+                }
+
+                struct #visitor_name<#arena_lifetime_syn> {
+                    allocator: &#arena_lifetime_syn arena_serde::Arena,
+                }
+
+                impl<'de, #arena_lifetime_syn> serde::de::Visitor<'de> for #visitor_name<#arena_lifetime_syn> {
+                    type Value = #name #ty_generics;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str(concat!("struct ", stringify!(#name)))
+                    }
+
+                    fn visit_map<V>(self, mut __map: V) -> Result<#name #ty_generics, V::Error>
+                    where
+                        V: serde::de::MapAccess<'de>,
+                    {
+                        let __allocator = self.allocator;
+                        #(
+                            #field_initializations
+                        )*
+
+                        while let Some(__key) = __map.next_key::<__Field>()? {
+                            match __key {
+                                #(#field_handling)*
+                                __Field::__ignore => {
+                                    // Skip unknown fields
+                                    __map.next_value::<serde::de::IgnoredAny>()?;
+                                }
+                            }
+                        }
+
+                        #(#field_extractions)*
+
+                        Ok(#name {
+                            #(#field_assignments,)*
+                        })
+                    }
+                }
+
+                const FIELDS: &'static [&'static str] = &[#(stringify!(#field_names)),*];
+                deserializer.deserialize_struct(
+                    stringify!(#name),
+                    FIELDS,
+                    #visitor_name { allocator }
+                )
+            }
+        }
+    };
+
+    Ok(output.into())
+}
+
+fn expand_struct_with_unnamed_fields(
+    name: &syn::Ident,
+    generics: &syn::Generics,
+    fields: &syn::punctuated::Punctuated<syn::Field, syn::Token![,]>,
+    arena_lifetime: &str,
+) -> syn::Result<TokenStream> {
+    if fields.len() != 1 {
+        return Err(syn::Error::new_spanned(
+            fields,
+            "Tuple structs with multiple fields are not supported",
+        ));
+    }
+
+    let field = fields.first().unwrap();
+    let field_type = &field.ty;
+    let ImplGenerics {
+        arena_lifetime: arena_lifetime_syn,
+        impl_generics: new_impl_generics,
+        ty_generics,
+        where_clause: new_where_clause,
+    } = ImplGenerics::new(generics, arena_lifetime);
+
+    let deserialize_impl = quote! {
+        let inner = <#field_type as arena_serde::ArenaDeserialize<#arena_lifetime_syn>>::deserialize_in_arena(deserializer, allocator)?;
+        Ok(#name(inner))
+    };
+
+    let output = quote! {
+            impl #new_impl_generics arena_serde::ArenaDeserialize<#arena_lifetime_syn> for #name #ty_generics #new_where_clause {
+            fn deserialize_in_arena<'de, D>(deserializer: D, allocator: &#arena_lifetime_syn arena_serde::Arena) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                #deserialize_impl
+            }
+        }
+    };
+    Ok(output.into())
+}
+
+fn expand_unit_struct(
+    name: &syn::Ident,
+    generics: &syn::Generics,
+    arena_lifetime: &str,
+) -> syn::Result<TokenStream> {
+    let ImplGenerics {
+        arena_lifetime: arena_lifetime_syn,
+        impl_generics: new_impl_generics,
+        ty_generics,
+        where_clause: new_where_clause,
+    } = ImplGenerics::new(generics, arena_lifetime);
+
+    let output = quote! {
+        impl #new_impl_generics arena_serde::ArenaDeserialize<#arena_lifetime_syn> for #name #ty_generics #new_where_clause {
+            fn deserialize_in_arena<'de, D>(deserializer: D, _allocator: &#arena_lifetime_syn arena_serde::Arena) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                serde::Deserialize::deserialize(deserializer).map(|_: ()| #name)
+            }
+        }
+    };
+
+    Ok(output.into())
+}
+
+/// Expand an enum with only unit variants.
+///
+/// The generated impl reads a variant identifier and maps it to a variant.
+/// Supported attributes:
+///
+/// - `#[arena(rename_all = "...")]` on the enum
+/// - `#[arena(rename = "...")]` on a variant
+/// - `#[arena(other)]` on one variant, which receives unknown identifiers
+///
+/// Enums with data-carrying variants are not supported. Write the
+/// `ArenaDeserialize` impl by hand for those.
+fn expand_enum(
+    input: &DeriveInput,
+    name: &syn::Ident,
+    data_enum: &syn::DataEnum,
+    arena_lifetime: &str,
+) -> syn::Result<TokenStream> {
+    let rename_all = parse_enum_attributes(input)?;
+
+    let mut variants = Vec::new();
+    let mut other_variant: Option<syn::Ident> = None;
+    for variant in &data_enum.variants {
+        if !matches!(variant.fields, Fields::Unit) {
+            return Err(syn::Error::new_spanned(
+                variant,
+                "ArenaDeserialize supports only unit variants in enums. \
+                 Implement ArenaDeserialize by hand for enums that carry data.",
+            ));
+        }
+
+        let attrs = parse_variant_attributes(variant)?;
+        if attrs.other {
+            if other_variant.is_some() {
+                return Err(syn::Error::new_spanned(
+                    variant,
+                    "Only one variant can have the `other` attribute",
+                ));
+            }
+            other_variant = Some(variant.ident.clone());
+        }
+
+        let serialized = attrs.rename.unwrap_or_else(|| {
+            let ident = variant.ident.to_string();
+            match rename_all {
+                Some(rule) => rule.apply(&ident),
+                None => ident,
+            }
+        });
+        variants.push((variant.ident.clone(), serialized));
+    }
+
+    let ImplGenerics {
+        arena_lifetime: arena_lifetime_syn,
+        impl_generics: new_impl_generics,
+        ty_generics,
+        where_clause: new_where_clause,
+    } = ImplGenerics::new(&input.generics, arena_lifetime);
+
+    let name_str = name.to_string();
+    let variant_idents: Vec<_> = variants.iter().map(|(ident, _)| ident).collect();
+    let variant_names: Vec<_> = variants.iter().map(|(_, s)| s.as_str()).collect();
+    let variant_bytes: Vec<_> = variants
+        .iter()
+        .map(|(_, s)| syn::LitByteStr::new(s.as_bytes(), Span::call_site().into()))
+        .collect();
+    let tags: Vec<_> = (0..variants.len())
+        .map(|i| format_ident!("Variant{}", i))
+        .collect();
+
+    let unknown_arm = match &other_variant {
+        Some(_) => quote! { _ => Ok(__Variant::__Other) },
+        None => quote! {
+            _ => Err(serde::de::Error::unknown_variant(__value, VARIANTS))
+        },
+    };
+    let unknown_bytes_arm = match &other_variant {
+        Some(_) => quote! { _ => Ok(__Variant::__Other) },
+        None => quote! {
+            _ => {
+                let __value = String::from_utf8_lossy(__value);
+                Err(serde::de::Error::unknown_variant(&__value, VARIANTS))
+            }
+        },
+    };
+    let other_match_arm = other_variant
+        .as_ref()
+        .map(|ident| quote! { __Variant::__Other => #name::#ident, });
+
+    let output = quote! {
+        impl #new_impl_generics arena_serde::ArenaDeserialize<#arena_lifetime_syn> for #name #ty_generics #new_where_clause {
+            fn deserialize_in_arena<'de, D>(deserializer: D, _allocator: &#arena_lifetime_syn arena_serde::Arena) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                const VARIANTS: &[&str] = &[#(#variant_names),*];
+
+                enum __Variant {
+                    #(#tags,)*
+                    __Other,
+                }
+
+                struct __VariantVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for __VariantVisitor {
+                    type Value = __Variant;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str("variant identifier")
+                    }
+
+                    fn visit_str<E>(self, __value: &str) -> Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match __value {
+                            #(#variant_names => Ok(__Variant::#tags),)*
+                            #unknown_arm
+                        }
+                    }
+
+                    fn visit_bytes<E>(self, __value: &[u8]) -> Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match __value {
+                            #(#variant_bytes => Ok(__Variant::#tags),)*
+                            #unknown_bytes_arm
+                        }
+                    }
+                }
+
+                impl<'de> serde::Deserialize<'de> for __Variant {
+                    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                    where
+                        D: serde::Deserializer<'de>,
+                    {
+                        deserializer.deserialize_identifier(__VariantVisitor)
+                    }
+                }
+
+                struct __Visitor;
+
+                impl<'de> serde::de::Visitor<'de> for __Visitor {
+                    type Value = #name;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str(concat!("enum ", #name_str))
+                    }
+
+                    fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+                    where
+                        A: serde::de::EnumAccess<'de>,
+                    {
+                        let (variant, access) = serde::de::EnumAccess::variant::<__Variant>(data)?;
+                        serde::de::VariantAccess::unit_variant(access)?;
+                        Ok(match variant {
+                            #(__Variant::#tags => #name::#variant_idents,)*
+                            #other_match_arm
+                            // Unreachable when no variant is marked `other`:
+                            // the identifier visitor returns an error instead.
+                            #[allow(unreachable_patterns)]
+                            __Variant::__Other => unreachable!(),
+                        })
+                    }
+                }
+
+                deserializer.deserialize_enum(#name_str, VARIANTS, __Visitor)
+            }
+        }
+    };
+
+    Ok(output.into())
+}
+
+#[derive(Clone, Copy)]
+enum RenameRule {
+    Lowercase,
+    Uppercase,
+    PascalCase,
+    CamelCase,
+    SnakeCase,
+    ScreamingSnakeCase,
+    KebabCase,
+    ScreamingKebabCase,
+}
+
+impl RenameRule {
+    fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "lowercase" => Self::Lowercase,
+            "UPPERCASE" => Self::Uppercase,
+            "PascalCase" => Self::PascalCase,
+            "camelCase" => Self::CamelCase,
+            "snake_case" => Self::SnakeCase,
+            "SCREAMING_SNAKE_CASE" => Self::ScreamingSnakeCase,
+            "kebab-case" => Self::KebabCase,
+            "SCREAMING-KEBAB-CASE" => Self::ScreamingKebabCase,
+            _ => return None,
+        })
+    }
+
+    /// Apply the rule to a variant name written in PascalCase.
+    fn apply(self, variant: &str) -> String {
+        match self {
+            Self::Lowercase => variant.to_ascii_lowercase(),
+            Self::Uppercase => variant.to_ascii_uppercase(),
+            Self::PascalCase => variant.to_owned(),
+            Self::CamelCase => {
+                let mut chars = variant.chars();
+                match chars.next() {
+                    Some(first) => first.to_ascii_lowercase().to_string() + chars.as_str(),
+                    None => String::new(),
+                }
+            }
+            Self::SnakeCase => join_words(variant, '_', false),
+            Self::ScreamingSnakeCase => join_words(variant, '_', true),
+            Self::KebabCase => join_words(variant, '-', false),
+            Self::ScreamingKebabCase => join_words(variant, '-', true),
+        }
+    }
+}
+
+/// Split a PascalCase name at each uppercase letter and join the words.
+fn join_words(variant: &str, separator: char, upper: bool) -> String {
+    let mut out = String::with_capacity(variant.len() + 4);
+    for (i, ch) in variant.char_indices() {
+        if ch.is_ascii_uppercase() && i > 0 {
+            out.push(separator);
+        }
+        out.push(if upper {
+            ch.to_ascii_uppercase()
+        } else {
+            ch.to_ascii_lowercase()
+        });
+    }
+    out
+}
+
+fn parse_enum_attributes(input: &DeriveInput) -> syn::Result<Option<RenameRule>> {
+    let mut rename_all = None;
+    for attr in &input.attrs {
+        if !attr.path().is_ident("arena") {
+            continue;
+        }
+        let Meta::List(meta_list) = &attr.meta else {
+            return Err(syn::Error::new_spanned(
+                attr,
+                "Invalid arena attribute format",
+            ));
+        };
+        let nested = meta_list.parse_args_with(
+            syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated,
+        )?;
+        for meta in nested {
+            match &meta {
+                Meta::NameValue(nv) if nv.path.is_ident("rename_all") => {
+                    let syn::Expr::Lit(syn::ExprLit {
+                        lit: Lit::Str(s), ..
+                    }) = &nv.value
+                    else {
+                        return Err(syn::Error::new_spanned(
+                            &nv.value,
+                            "rename_all expects a string literal",
+                        ));
+                    };
+                    rename_all =
+                        Some(RenameRule::parse(&s.value()).ok_or_else(|| {
+                            syn::Error::new_spanned(s, "Unknown rename_all rule")
+                        })?);
+                }
+                _ => {
+                    return Err(syn::Error::new_spanned(meta, "Unknown arena attribute"));
+                }
+            }
+        }
+    }
+    Ok(rename_all)
+}
+
+struct VariantAttributes {
+    rename: Option<String>,
+    other: bool,
+}
+
+fn parse_variant_attributes(variant: &syn::Variant) -> syn::Result<VariantAttributes> {
+    let mut rename = None;
+    let mut other = false;
+    for attr in &variant.attrs {
+        if !attr.path().is_ident("arena") {
+            continue;
+        }
+        let Meta::List(meta_list) = &attr.meta else {
+            return Err(syn::Error::new_spanned(
+                attr,
+                "Invalid arena attribute format",
+            ));
+        };
+        let nested = meta_list.parse_args_with(
+            syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated,
+        )?;
+        for meta in nested {
+            match &meta {
+                Meta::NameValue(nv) if nv.path.is_ident("rename") => {
+                    let syn::Expr::Lit(syn::ExprLit {
+                        lit: Lit::Str(s), ..
+                    }) = &nv.value
+                    else {
+                        return Err(syn::Error::new_spanned(
+                            &nv.value,
+                            "rename expects a string literal",
+                        ));
+                    };
+                    rename = Some(s.value());
+                }
+                Meta::Path(path) if path.is_ident("other") => {
+                    other = true;
+                }
+                _ => {
+                    return Err(syn::Error::new_spanned(meta, "Unknown arena attribute"));
+                }
+            }
+        }
+    }
+    Ok(VariantAttributes { rename, other })
+}
+
+/// The generics of the generated `ArenaDeserialize` impl.
+struct ImplGenerics {
+    arena_lifetime: syn::Lifetime,
+    impl_generics: proc_macro2::TokenStream,
+    ty_generics: proc_macro2::TokenStream,
+    where_clause: proc_macro2::TokenStream,
+}
+
+impl ImplGenerics {
+    /// Add the arena lifetime to the impl generics when the type does not
+    /// declare it.
+    fn new(generics: &syn::Generics, arena_lifetime: &str) -> Self {
+        let lifetime = syn::Lifetime::new(&format!("'{arena_lifetime}"), Span::call_site().into());
+        let (_, ty_generics, _) = generics.split_for_impl();
+
+        let mut impl_generics = generics.clone();
+        if !generics
+            .lifetimes()
+            .any(|lt| lt.lifetime.ident == arena_lifetime)
+        {
+            impl_generics.params.insert(
+                0,
+                syn::GenericParam::Lifetime(LifetimeParam::new(lifetime.clone())),
+            );
+        }
+        let (impl_generics, _, where_clause) = impl_generics.split_for_impl();
+
+        Self {
+            arena_lifetime: lifetime,
+            impl_generics: quote!(#impl_generics),
+            ty_generics: quote!(#ty_generics),
+            where_clause: quote!(#where_clause),
+        }
+    }
+}
+
+struct FieldInfo {
+    ident: syn::Ident,
+    name: String,
+    ty: syn::Type,
+    aliases: Vec<String>,
+    has_default: bool,
+    deserialize_with: Option<syn::Path>,
+    duplicated: bool,
+}
+
+fn parse_field_attributes(field: &syn::Field) -> syn::Result<FieldInfo> {
+    let ident = field.ident.as_ref().unwrap().clone();
+    let name = ident.to_string();
+    let ty = field.ty.clone();
+    let mut aliases = Vec::new();
+    let mut has_default = false;
+    let mut deserialize_with = None;
+    let mut duplicated = false;
+
+    for attr in &field.attrs {
+        if attr.path().is_ident("arena") {
+            match &attr.meta {
+                Meta::List(meta_list) => {
+                    let nested = meta_list.parse_args_with(
+                        syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated,
+                    )?;
+
+                    for meta in nested {
+                        match meta {
+                            Meta::NameValue(nv) if nv.path.is_ident("alias") => {
+                                if let syn::Expr::Lit(syn::ExprLit {
+                                    lit: Lit::Str(s), ..
+                                }) = &nv.value
+                                {
+                                    aliases.push(s.value());
+                                }
+                            }
+                            Meta::Path(path) if path.is_ident("default") => {
+                                has_default = true;
+                            }
+                            Meta::NameValue(nv) if nv.path.is_ident("deserialize_with") => {
+                                if let syn::Expr::Lit(syn::ExprLit {
+                                    lit: Lit::Str(s), ..
+                                }) = &nv.value
+                                {
+                                    deserialize_with =
+                                        Some(syn::parse_str::<syn::Path>(&s.value())?);
+                                }
+                            }
+                            Meta::Path(path) if path.is_ident("duplicated") => {
+                                duplicated = true;
+                            }
+                            _ => {
+                                return Err(syn::Error::new_spanned(
+                                    meta,
+                                    "Unknown arena attribute",
+                                ));
+                            }
+                        }
+                    }
+                }
+                Meta::Path(path) if path.is_ident("default") => {
+                    has_default = true;
+                }
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        attr,
+                        "Invalid arena attribute format",
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(FieldInfo {
+        ident,
+        name,
+        ty,
+        aliases,
+        has_default,
+        deserialize_with,
+        duplicated,
+    })
+}
+
+/// Determine the arena lifetime for the struct.
+/// Returns the lifetime identifier string (e.g., "bump", "a", "arena").
+///
+/// If the struct has existing lifetime parameters, uses the first one as the arena lifetime.
+/// Otherwise, creates and returns "bump".
+fn determine_arena_lifetime(generics: &syn::Generics) -> String {
+    // Check if there's an existing lifetime parameter
+    if let Some(lifetime_param) = generics.lifetimes().next() {
+        lifetime_param.lifetime.ident.to_string()
+    } else {
+        "bump".to_string()
+    }
+}
+
+fn is_option_type(ty: &Type) -> bool {
+    match ty {
+        Type::Path(type_path) => {
+            if let Some(segment) = type_path.path.segments.last() {
+                segment.ident == "Option"
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn is_slice_reference(ty: &Type, arena_lifetime: &str) -> bool {
+    match ty {
+        Type::Reference(type_ref) => {
+            // Check if it's a reference to a slice with arena lifetime
+            if let Some(lifetime) = &type_ref.lifetime {
+                if lifetime.ident == arena_lifetime {
+                    matches!(*type_ref.elem, Type::Slice(_))
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn get_slice_element_type(ty: &Type) -> Option<&Type> {
+    match ty {
+        Type::Reference(type_ref) => {
+            if let Type::Slice(slice_type) = &*type_ref.elem {
+                Some(&*slice_type.elem)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}

--- a/crates/arena-serde/Cargo.toml
+++ b/crates/arena-serde/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "arena-serde"
+version = "0.1.0"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition = "2024"
+publish = false
+readme = "README.md"
+description = "Serde deserialization into an arena allocator"
+keywords = ["serde", "deserialization", "arena", "bumpalo"]
+categories = ["encoding"]
+
+[dependencies]
+arena-serde-derive = { path = "../arena-serde-derive", version = "^0.1.0" }
+bumpalo = { workspace = true }
+serde = { workspace = true }
+
+[dev-dependencies]
+serde_json = "1.0.114"
+trybuild = { version = "1.0.104", features = ["diff"] }

--- a/crates/arena-serde/LICENSE.txt
+++ b/crates/arena-serde/LICENSE.txt
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/arena-serde/README.md
+++ b/crates/arena-serde/README.md
@@ -1,0 +1,77 @@
+![ci](https://github.com/rakaly/jomini/workflows/ci/badge.svg)
+
+# Arena serde
+
+Arena serde extends [serde](https://serde.rs/)'s deserialization to allocate into an arena. It provides an `ArenaDeserialize` trait, which is similar to serde's `Deserialize`, but places data in a provided arena (currently [bumpalo](https://github.com/fitzgen/bumpalo)) instead of the global heap allocator.
+
+Arenas and deserialization are a natural fit:
+
+- A single drop for the deserialized model: no matter how many strings a model has, it takes constant time to free the data.
+- The arena can pre-allocate the capacity expected for deserialization.
+- Amortizes the allocation cost of many fields that need allocations.
+- Minimizes the volatility of the system allocator. Especially well suited for Wasm, where one has minimal control of the underlying allocator.
+- Allows efficient views into the underlying data without keeping the entire input around, unlike borrowed deserialization.
+- Less brittle in performance than serde's `deserialize_in_place`.
+
+This crate is experimental and is not published on crates.io.
+
+## Quick example
+
+```rust
+use arena_serde::{Arena, ArenaDeserialize, ArenaSeed};
+use serde::de::DeserializeSeed;
+
+#[derive(ArenaDeserialize)]
+struct User<'bump> {
+    name: &'bump str,
+    tags: &'bump [&'bump str],
+    id: u64,
+}
+
+let arena = Arena::new();
+let json = r#"{"name": "Alice", "email": "alice@example.com", "tags": ["admin", "verified"], "id": 42}"#;
+let mut deserializer = serde_json::Deserializer::from_str(json);
+
+let user: User = ArenaSeed::new(&arena)
+    .deserialize(&mut deserializer)
+    .unwrap();
+
+assert_eq!(user.name, "Alice");
+assert_eq!(user.tags, ["admin", "verified"]);
+// All string data is allocated in the arena and freed when `arena` is dropped
+```
+
+## How the derive decides what to do
+
+The derive does not guess from a field's type. Every field is deserialized through `ArenaDeserialize`, whether or not the struct has a lifetime parameter. Owned types (`String`, `Vec<T>`, the primitives, `Option<T>`, ...) implement the trait by forwarding to `Deserialize`, so they can appear as fields next to arena data. A `&'bump T` field puts the nested value in the arena, which permits recursive models without a `Box`.
+
+A type with a hand written `Deserialize` impl does not get `ArenaDeserialize` for free. Write a short impl that forwards to it:
+
+```rust
+use arena_serde::{Arena, ArenaDeserialize};
+
+# #[derive(serde::Deserialize)] struct Color;
+impl<'bump> ArenaDeserialize<'bump> for Color {
+    fn deserialize_in_arena<'de, D>(deserializer: D, _arena: &'bump Arena) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        serde::Deserialize::deserialize(deserializer)
+    }
+}
+```
+
+Field attributes:
+
+- `#[arena(alias = "name")]`: accept another key for the field.
+- `#[arena(default)]`: use `Default` when the key is missing.
+- `#[arena(deserialize_with = "path")]`: call `path(deserializer, &arena)` for the field.
+- `#[arena(duplicated)]`: collect every occurrence of the key into a `&'bump [T]` field.
+
+Enums with only unit variants can also derive `ArenaDeserialize`:
+
+- `#[arena(rename_all = "snake_case")]` on the enum, with the same rules as serde.
+- `#[arena(rename = "name")]` on a variant.
+- `#[arena(other)]` on one variant, which receives unknown identifiers.
+
+Enums with data-carrying variants need a hand written impl.

--- a/crates/arena-serde/src/lib.rs
+++ b/crates/arena-serde/src/lib.rs
@@ -1,0 +1,1055 @@
+//! Serde deserialization into an arena.
+//!
+//! [`ArenaDeserialize`] is the arena counterpart of serde's `Deserialize`.
+//! Data that needs an allocation (strings, sequences) is placed in the
+//! [`Arena`] the caller supplies instead of the global heap, so a model with
+//! many small allocations is freed in constant time when the arena drops.
+//!
+//! Types that own their data (`String`, `Vec<T>`, the primitives, ...)
+//! implement the trait by forwarding to `Deserialize`, so they can appear as
+//! fields next to arena-allocated ones.
+#![doc = include_str!("../README.md")]
+
+pub use arena_serde_derive::ArenaDeserialize;
+pub use bumpalo::collections::{String as ArenaString, Vec as ArenaVec};
+
+pub mod tracked;
+
+use bumpalo::collections::{String as BumpString, Vec as BumpVec};
+use serde::de::{DeserializeSeed, Deserializer, SeqAccess, Visitor};
+use serde::{Deserialize, de};
+use std::marker::PhantomData;
+
+/// The arena that [`ArenaDeserialize`] allocates into.
+///
+/// Signatures name this alias rather than the concrete allocator so that the
+/// allocator can change in one place.
+pub type Arena = bumpalo::Bump;
+
+/// A trait for types that can be deserialized using an arena.
+pub trait ArenaDeserialize<'bump>: Sized {
+    /// Deserialize this value from the given deserializer, allocating into
+    /// the provided arena.
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>;
+}
+
+/// A seed for deserializing values into an arena.
+#[derive(Clone, Copy)]
+pub struct ArenaSeed<'bump, T> {
+    pub allocator: &'bump Arena,
+    pub marker: PhantomData<fn() -> T>,
+}
+
+impl<'bump, T> ArenaSeed<'bump, T> {
+    /// Create a new ArenaSeed with the given arena.
+    pub fn new(allocator: &'bump Arena) -> Self {
+        Self {
+            allocator,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'de, 'bump, T> DeserializeSeed<'de> for ArenaSeed<'bump, T>
+where
+    T: ArenaDeserialize<'bump>,
+{
+    type Value = T;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        T::deserialize_in_arena(deserializer, self.allocator)
+    }
+}
+
+// Macro to generate ArenaDeserialize implementations for types that just use regular Deserialize
+macro_rules! impl_arena_deserialize_passthrough {
+    ($($t:ty),* $(,)?) => {
+        $(
+            impl<'bump> ArenaDeserialize<'bump> for $t {
+                fn deserialize_in_arena<'de, D>(deserializer: D, _allocator: &'bump Arena) -> Result<Self, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    Self::deserialize(deserializer)
+                }
+            }
+        )*
+    };
+}
+
+// Implement ArenaDeserialize for common types that don't need arena allocation
+impl_arena_deserialize_passthrough! {
+    String,
+    i8, i16, i32, i64, i128, isize,
+    u8, u16, u32, u64, u128, usize,
+    f32, f64,
+    bool,
+    char,
+}
+
+// Generic implementations for collections where the element types implement Deserialize
+impl<'bump, T> ArenaDeserialize<'bump> for Vec<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Vec::<T>::deserialize(deserializer)
+    }
+}
+
+impl<'bump, K, V> ArenaDeserialize<'bump> for std::collections::HashMap<K, V>
+where
+    K: for<'de> Deserialize<'de> + Eq + std::hash::Hash,
+    V: for<'de> Deserialize<'de>,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        std::collections::HashMap::<K, V>::deserialize(deserializer)
+    }
+}
+
+impl<'bump, K, V> ArenaDeserialize<'bump> for std::collections::BTreeMap<K, V>
+where
+    K: for<'de> Deserialize<'de> + Ord,
+    V: for<'de> Deserialize<'de>,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        std::collections::BTreeMap::<K, V>::deserialize(deserializer)
+    }
+}
+
+impl<'bump, T> ArenaDeserialize<'bump> for std::collections::HashSet<T>
+where
+    T: for<'de> Deserialize<'de> + Eq + std::hash::Hash,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        std::collections::HashSet::<T>::deserialize(deserializer)
+    }
+}
+
+impl<'bump, T> ArenaDeserialize<'bump> for std::collections::BTreeSet<T>
+where
+    T: for<'de> Deserialize<'de> + Ord,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        std::collections::BTreeSet::<T>::deserialize(deserializer)
+    }
+}
+
+impl<'bump, T, const N: usize> ArenaDeserialize<'bump> for [T; N]
+where
+    [T; N]: for<'de> Deserialize<'de>,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        <[T; N]>::deserialize(deserializer)
+    }
+}
+
+impl<'bump> ArenaDeserialize<'bump> for () {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        <()>::deserialize(deserializer)
+    }
+}
+
+impl<'bump, T> ArenaDeserialize<'bump> for Option<T>
+where
+    T: ArenaDeserialize<'bump>,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct OptionVisitor<'a, T> {
+            allocator: &'a Arena,
+            marker: PhantomData<T>,
+        }
+
+        impl<'de, 'a, T> Visitor<'de> for OptionVisitor<'a, T>
+        where
+            T: ArenaDeserialize<'a>,
+        {
+            type Value = Option<T>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("option")
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(None)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                T::deserialize_in_arena(deserializer, self.allocator).map(Some)
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(None)
+            }
+        }
+
+        deserializer.deserialize_option(OptionVisitor {
+            allocator,
+            marker: PhantomData,
+        })
+    }
+}
+
+// Implementation for bumpalo::collections::String
+impl<'bump> ArenaDeserialize<'bump> for BumpString<'bump> {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StringVisitor<'a>(&'a Arena);
+
+        impl<'de, 'a> Visitor<'de> for StringVisitor<'a> {
+            type Value = BumpString<'a>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string for BumpString")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(BumpString::from_str_in(v, self.0))
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(BumpString::from_str_in(&v, self.0))
+            }
+        }
+
+        deserializer.deserialize_string(StringVisitor(allocator))
+    }
+}
+
+// Implementation for &'bump str
+impl<'bump> ArenaDeserialize<'bump> for &'bump str {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StrVisitor<'a>(&'a Arena);
+
+        impl<'de, 'a> Visitor<'de> for StrVisitor<'a> {
+            type Value = &'a str;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string slice string")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(self.0.alloc_str(v))
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(self.0.alloc_str(&v))
+            }
+        }
+
+        deserializer.deserialize_str(StrVisitor(allocator))
+    }
+}
+
+// Implementation for &'bump T, which puts a nested value in the arena. This
+// permits recursive models, such as a tweet that contains a retweeted tweet.
+impl<'bump, T> ArenaDeserialize<'bump> for &'bump T
+where
+    T: ArenaDeserialize<'bump> + 'bump,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = T::deserialize_in_arena(deserializer, allocator)?;
+        Ok(allocator.alloc(value))
+    }
+}
+
+// Implementation for &'bump [T]
+impl<'bump, T> ArenaDeserialize<'bump> for &'bump [T]
+where
+    T: ArenaDeserialize<'bump> + 'bump,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let vec = BumpVec::<T>::deserialize_in_arena(deserializer, allocator)?;
+        Ok(vec.into_bump_slice())
+    }
+}
+
+// Implementation for bumpalo::collections::Vec
+impl<'bump, T> ArenaDeserialize<'bump> for BumpVec<'bump, T>
+where
+    T: ArenaDeserialize<'bump>,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct VecVisitor<'a, T>(&'a Arena, PhantomData<T>);
+
+        impl<'de, 'a, T> Visitor<'de> for VecVisitor<'a, T>
+        where
+            T: ArenaDeserialize<'a> + 'a,
+        {
+            type Value = BumpVec<'a, T>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a sequence")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut vec = BumpVec::new_in(self.0);
+
+                while let Some(element) = seq.next_element_seed(ArenaSeed::new(self.0))? {
+                    vec.push(element);
+                }
+
+                Ok(vec)
+            }
+        }
+
+        deserializer.deserialize_seq(VecVisitor(allocator, PhantomData))
+    }
+}
+
+// Implementation for tuples
+impl<'bump, A, B> ArenaDeserialize<'bump> for (A, B)
+where
+    A: ArenaDeserialize<'bump>,
+    B: ArenaDeserialize<'bump>,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TupleVisitor<'a, A, B>(&'a Arena, PhantomData<(A, B)>);
+
+        impl<'de, 'a, A, B> Visitor<'de> for TupleVisitor<'a, A, B>
+        where
+            A: ArenaDeserialize<'a>,
+            B: ArenaDeserialize<'a>,
+        {
+            type Value = (A, B);
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a tuple")
+            }
+
+            fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
+            where
+                S: SeqAccess<'de>,
+            {
+                let first = seq
+                    .next_element_seed(ArenaSeed::new(self.0))?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let second = seq
+                    .next_element_seed(ArenaSeed::new(self.0))?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+
+                Ok((first, second))
+            }
+        }
+
+        deserializer.deserialize_tuple(2, TupleVisitor(allocator, PhantomData))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The derive macro names this crate as `arena_serde`.
+    use crate as arena_serde;
+
+    // Example custom deserializer function
+    fn deserialize_map_as_pair_seq<'de, 'bump, D>(
+        deserializer: D,
+        allocator: &'bump Arena,
+    ) -> Result<BumpVec<'bump, (u16, &'bump str)>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // This is a simplified version - in real implementation would parse map differently
+        // For demonstration, just return an empty vector
+        let _: serde::de::IgnoredAny = serde::Deserialize::deserialize(deserializer)?;
+        Ok(BumpVec::new_in(allocator))
+    }
+
+    #[derive(ArenaDeserialize)]
+    struct City<'bump> {
+        #[arena(alias = "n")]
+        name: bumpalo::collections::String<'bump>,
+        citizens: bumpalo::collections::Vec<'bump, Citizen<'bump>>,
+    }
+
+    #[derive(ArenaDeserialize)]
+    struct Citizen<'bump> {
+        first_name: &'bump str,
+        last_name: String, // Deserializing with global allocator
+        #[arena(default)] // Support for "default" field attribute
+        age: i16,
+        data: CitizenData<'bump>,
+        #[arena(deserialize_with = "deserialize_map_as_pair_seq")]
+        tags: bumpalo::collections::Vec<'bump, (u16, &'bump str)>,
+    }
+
+    #[derive(ArenaDeserialize)]
+    struct CitizenData<'bump>(&'bump [u8]);
+
+    #[derive(ArenaDeserialize)]
+    struct DuplicatedHolder<'bump> {
+        flag: bool,
+        #[arena(duplicated)]
+        values: &'bump [u32],
+        #[arena(duplicated)]
+        names: &'bump [&'bump str],
+    }
+
+    #[test]
+    fn test_basic_struct_deserialization() {
+        let allocator = Arena::new();
+
+        let json = r#"{"first_name": "John", "last_name": "Doe", "age": 25, "data": [1, 2, 3], "tags": [[1, "tag1"], [2, "tag2"]]}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let citizen: Citizen =
+            Citizen::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(citizen.first_name, "John");
+        assert_eq!(citizen.last_name, "Doe");
+        assert_eq!(citizen.age, 25);
+        assert_eq!(citizen.data.0, &[1, 2, 3]);
+        assert_eq!(citizen.tags.len(), 0); // Empty tags array
+    }
+
+    #[test]
+    fn test_alias_support() {
+        let allocator = Arena::new();
+
+        let json = r#"{"n": "New York", "citizens": []}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let city: City = City::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(city.name.as_str(), "New York");
+    }
+
+    #[test]
+    fn test_default_field() {
+        let allocator = Arena::new();
+
+        let json = r#"{"first_name": "Jane", "last_name": "Smith", "data": [4, 5, 6], "tags": []}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let citizen: Citizen =
+            Citizen::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(citizen.first_name, "Jane");
+        assert_eq!(citizen.last_name, "Smith");
+        assert_eq!(citizen.age, 0); // Default value for i16
+        assert_eq!(citizen.data.0, &[4, 5, 6]);
+        assert_eq!(citizen.tags.len(), 0); // Empty tags array
+    }
+
+    #[test]
+    fn test_duplicated_fields_collect_values() {
+        let allocator = Arena::new();
+
+        let json = r#"{
+            "flag": true,
+            "values": 10,
+            "names": "alpha",
+            "values": 20,
+            "names": "beta",
+            "names": "gamma"
+        }"#;
+
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let holder: DuplicatedHolder =
+            DuplicatedHolder::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert!(holder.flag);
+        assert_eq!(holder.values, &[10, 20]);
+        assert_eq!(holder.names, &["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
+    fn test_duplicated_fields_default_empty_slice() {
+        let allocator = Arena::new();
+
+        let json = r#"{
+            "flag": false
+        }"#;
+
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let holder: DuplicatedHolder =
+            DuplicatedHolder::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert!(!holder.flag);
+        assert!(holder.values.is_empty());
+        assert!(holder.names.is_empty());
+    }
+
+    #[test]
+    fn test_nested_structs() {
+        let allocator = Arena::new();
+
+        let json = r#"{
+            "name": "Boston",
+            "citizens": [
+                {"first_name": "Alice", "last_name": "Wonder", "age": 30, "data": [7, 8, 9], "tags": []},
+                {"first_name": "Bob", "last_name": "Builder", "data": [10, 11, 12], "tags": []}
+            ]
+        }"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let city: City = City::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(city.name.as_str(), "Boston");
+        assert_eq!(city.citizens.len(), 2);
+        assert_eq!(city.citizens[0].first_name, "Alice");
+        assert_eq!(city.citizens[0].age, 30);
+        assert_eq!(city.citizens[0].data.0, &[7, 8, 9]);
+        assert_eq!(city.citizens[0].tags.len(), 0);
+        assert_eq!(city.citizens[1].first_name, "Bob");
+        assert_eq!(city.citizens[1].age, 0); // Default value
+        assert_eq!(city.citizens[1].data.0, &[10, 11, 12]);
+        assert_eq!(city.citizens[1].tags.len(), 0);
+    }
+
+    #[test]
+    fn test_transparent_newtype() {
+        let allocator = Arena::new();
+
+        let json = r#"[1, 2, 3, 4, 5]"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let data: CitizenData =
+            CitizenData::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(data.0, &[1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_bumpalo_string() {
+        let allocator = Arena::new();
+
+        let json = r#""Hello, World!""#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let s: BumpString =
+            BumpString::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(s.as_str(), "Hello, World!");
+    }
+
+    #[test]
+    fn test_borrowed_str() {
+        let allocator = Arena::new();
+
+        let json = r#""Borrowed string""#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let s: &str = <&str>::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(s, "Borrowed string");
+    }
+
+    #[derive(ArenaDeserialize)]
+    struct Node<'bump> {
+        value: u32,
+        next: Option<&'bump Node<'bump>>,
+    }
+
+    #[test]
+    fn test_arena_reference() {
+        let allocator = Arena::new();
+
+        let json = r#"{"value": 1, "next": {"value": 2, "next": {"value": 3, "next": null}}}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let head: Node = Node::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(head.value, 1);
+        let second = head.next.unwrap();
+        assert_eq!(second.value, 2);
+        let third = second.next.unwrap();
+        assert_eq!(third.value, 3);
+        assert!(third.next.is_none());
+
+        // The nested nodes live in the arena, not on the heap.
+        let node_size = std::mem::size_of::<Node>();
+        assert!(allocator.allocated_bytes() >= 2 * node_size);
+    }
+
+    #[test]
+    fn test_bumpalo_vec() {
+        let allocator = Arena::new();
+
+        let json = r#"["one", "two", "three"]"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let v: BumpVec<&str> =
+            BumpVec::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(v.len(), 3);
+        assert_eq!(v[0], "one");
+        assert_eq!(v[1], "two");
+        assert_eq!(v[2], "three");
+    }
+
+    #[test]
+    fn test_generic_collections() {
+        let allocator = Arena::new();
+
+        // Test Vec<i32>
+        let json = r#"[1, 2, 3, 4, 5]"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let v: Vec<i32> = Vec::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+        assert_eq!(v, vec![1, 2, 3, 4, 5]);
+
+        // Test HashMap<String, i32>
+        let json = r#"{"a": 1, "b": 2, "c": 3}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let map: std::collections::HashMap<String, i32> =
+            std::collections::HashMap::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+        assert_eq!(map.len(), 3);
+        assert_eq!(map.get("a"), Some(&1));
+        assert_eq!(map.get("b"), Some(&2));
+        assert_eq!(map.get("c"), Some(&3));
+
+        // Test Option<String>
+        let json = r#""hello""#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let opt: Option<String> =
+            Option::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+        assert_eq!(opt, Some("hello".to_string()));
+
+        // Test None case
+        let json = r#"null"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let opt: Option<String> =
+            Option::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+        assert_eq!(opt, None);
+    }
+
+    #[test]
+    fn test_struct_with_generic_collections() {
+        let allocator = Arena::new();
+
+        #[derive(ArenaDeserialize)]
+        struct ComplexStruct<'bump> {
+            name: String,
+            scores: Vec<i32>,
+            metadata: std::collections::HashMap<String, String>,
+            arena_string: bumpalo::collections::String<'bump>,
+            optional_value: Option<i32>,
+        }
+
+        let json = r#"{
+            "name": "test",
+            "scores": [10, 20, 30],
+            "metadata": {"key1": "value1", "key2": "value2"},
+            "arena_string": "arena allocated",
+            "optional_value": 42
+        }"#;
+
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let complex: ComplexStruct =
+            ComplexStruct::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(complex.name, "test");
+        assert_eq!(complex.scores, vec![10, 20, 30]);
+        assert_eq!(complex.metadata.len(), 2);
+        assert_eq!(complex.metadata.get("key1"), Some(&"value1".to_string()));
+        assert_eq!(complex.metadata.get("key2"), Some(&"value2".to_string()));
+        assert_eq!(complex.arena_string.as_str(), "arena allocated");
+        assert_eq!(complex.optional_value, Some(42));
+    }
+
+    #[test]
+    fn test_owned_type() {
+        let allocator = Arena::new();
+
+        #[derive(ArenaDeserialize, Debug, PartialEq)]
+        struct OwnedStruct {
+            id: u32,
+            name: String,
+            values: Vec<i32>,
+        }
+
+        let json = r#"{"id": 42, "name": "test", "values": [1, 2, 3]}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let result: OwnedStruct =
+            OwnedStruct::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(result.id, 42);
+        assert_eq!(result.name, "test");
+        assert_eq!(result.values, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_optional_fields_without_default() {
+        let allocator = Arena::new();
+
+        #[derive(ArenaDeserialize)]
+        struct StructWithOptionalFields<'bump> {
+            required_field: String,
+            optional_field1: Option<i32>,
+            optional_field2: Option<bumpalo::collections::String<'bump>>,
+            optional_field3: Option<Vec<String>>,
+        }
+
+        // Test with all optional fields present
+        let json_with_options = r#"{
+            "required_field": "required",
+            "optional_field1": 42,
+            "optional_field2": "arena string",
+            "optional_field3": ["item1", "item2"]
+        }"#;
+
+        let mut deserializer = serde_json::Deserializer::from_str(json_with_options);
+        let result: StructWithOptionalFields =
+            StructWithOptionalFields::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(result.required_field, "required");
+        assert_eq!(result.optional_field1, Some(42));
+        assert_eq!(
+            result.optional_field2.as_ref().map(|s| s.as_str()),
+            Some("arena string")
+        );
+        assert_eq!(
+            result.optional_field3,
+            Some(vec!["item1".to_string(), "item2".to_string()])
+        );
+
+        // Test with optional fields missing (should be None)
+        let json_without_options = r#"{
+            "required_field": "required"
+        }"#;
+
+        let mut deserializer = serde_json::Deserializer::from_str(json_without_options);
+        let result: StructWithOptionalFields =
+            StructWithOptionalFields::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(result.required_field, "required");
+        assert_eq!(result.optional_field1, None);
+        assert_eq!(result.optional_field2, None);
+        assert_eq!(result.optional_field3, None);
+
+        // Test with explicit null values
+        let json_with_nulls = r#"{
+            "required_field": "required",
+            "optional_field1": null,
+            "optional_field2": null,
+            "optional_field3": null
+        }"#;
+
+        let mut deserializer = serde_json::Deserializer::from_str(json_with_nulls);
+        let result: StructWithOptionalFields =
+            StructWithOptionalFields::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(result.required_field, "required");
+        assert_eq!(result.optional_field1, None);
+        assert_eq!(result.optional_field2, None);
+        assert_eq!(result.optional_field3, None);
+    }
+
+    #[test]
+    fn test_struct_with_custom_lifetime_a() {
+        let allocator = Arena::new();
+
+        #[derive(ArenaDeserialize)]
+        struct CustomLifetimeStruct<'a> {
+            data: &'a str,
+            items: bumpalo::collections::Vec<'a, i32>,
+        }
+
+        let json = r#"{"data": "hello", "items": [1, 2, 3]}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let result: CustomLifetimeStruct =
+            CustomLifetimeStruct::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(result.data, "hello");
+        assert_eq!(result.items.len(), 3);
+        assert_eq!(result.items[0], 1);
+        assert_eq!(result.items[1], 2);
+        assert_eq!(result.items[2], 3);
+    }
+
+    /// Test nested structs with custom lifetime parameters
+    #[test]
+    fn test_nested_structs_with_custom_lifetimes() {
+        let allocator = Arena::new();
+
+        #[derive(ArenaDeserialize)]
+        struct Inner<'a> {
+            value: &'a str,
+            number: i32,
+        }
+
+        #[derive(ArenaDeserialize)]
+        struct Outer<'a> {
+            inner: Inner<'a>,
+            outer_data: &'a str,
+        }
+
+        let json = r#"{
+            "inner": {"value": "inner", "number": 42},
+            "outer_data": "outer"
+        }"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let result: Outer = Outer::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(result.inner.value, "inner");
+        assert_eq!(result.inner.number, 42);
+        assert_eq!(result.outer_data, "outer");
+    }
+
+    /// Test that field named 'key' doesn't cause shadowing issues
+    #[test]
+    fn test_field_named_key() {
+        let allocator = Arena::new();
+
+        #[derive(ArenaDeserialize)]
+        struct WithKey<'bump> {
+            key: &'bump str,
+            value: i32,
+        }
+
+        let json = r#"{"key": "my_key", "value": 42}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let result: WithKey = WithKey::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(result.key, "my_key");
+        assert_eq!(result.value, 42);
+    }
+
+    /// Test that field named 'allocator' doesn't cause shadowing issues
+    #[test]
+    fn test_field_named_allocator() {
+        let allocator = Arena::new();
+
+        #[derive(ArenaDeserialize)]
+        struct WithAllocator<'bump> {
+            allocator: &'bump str,
+            name: String,
+        }
+
+        let json = r#"{"allocator": "bump_allocator", "name": "test"}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let result: WithAllocator =
+            WithAllocator::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(result.allocator, "bump_allocator");
+        assert_eq!(result.name, "test");
+    }
+
+    /// Every field is dispatched through ArenaDeserialize, so an Option
+    /// around an arena reference is handled like the reference itself.
+    #[test]
+    fn test_option_of_arena_reference() {
+        let allocator = Arena::new();
+
+        #[derive(ArenaDeserialize)]
+        struct Holder<'bump> {
+            name: Option<&'bump str>,
+            values: Option<&'bump [u32]>,
+            fixed: [u8; 3],
+        }
+
+        let json = r#"{"name": "abc", "values": [1, 2], "fixed": [7, 8, 9]}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let holder: Holder = Holder::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+        assert_eq!(holder.name, Some("abc"));
+        assert_eq!(holder.values, Some(&[1, 2][..]));
+        assert_eq!(holder.fixed, [7, 8, 9]);
+
+        let json = r#"{"fixed": [0, 0, 0]}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let holder: Holder = Holder::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+        assert_eq!(holder.name, None);
+        assert_eq!(holder.values, None);
+    }
+
+    /// A type without a lifetime gets the same generated impl as one with a
+    /// lifetime, so `#[arena]` attributes apply to it. A type with a hand
+    /// written `Deserialize` impl forwards to it by hand.
+    #[test]
+    fn test_owned_field_attributes() {
+        let allocator = Arena::new();
+
+        #[derive(ArenaDeserialize, Debug, PartialEq)]
+        struct Rating {
+            #[arena(default, alias = "ADM")]
+            adm: f64,
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct Doubled(u32);
+
+        impl<'de> serde::Deserialize<'de> for Doubled {
+            fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                u32::deserialize(deserializer).map(|x| Doubled(x * 2))
+            }
+        }
+
+        impl<'bump> ArenaDeserialize<'bump> for Doubled {
+            fn deserialize_in_arena<'de, D>(
+                deserializer: D,
+                _allocator: &'bump Arena,
+            ) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                Self::deserialize(deserializer)
+            }
+        }
+
+        #[derive(ArenaDeserialize)]
+        struct Wrapper(Doubled);
+
+        #[derive(ArenaDeserialize)]
+        struct Country<'bump> {
+            name: &'bump str,
+            rating: Rating,
+            doubled: Wrapper,
+        }
+
+        let json = r#"{"name": "FRA", "rating": {"ADM": 1.5}, "doubled": 21}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let country: Country =
+            Country::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+        assert_eq!(country.name, "FRA");
+        assert_eq!(country.rating, Rating { adm: 1.5 });
+        assert_eq!(country.doubled.0, Doubled(42));
+
+        let json = r#"{"name": "FRA", "rating": {}, "doubled": 0}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let country: Country =
+            Country::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+        assert_eq!(country.rating, Rating { adm: 0.0 });
+    }
+
+    /// Test that field named 'map' doesn't cause shadowing issues
+    #[test]
+    fn test_field_named_map() {
+        let allocator = Arena::new();
+
+        #[derive(ArenaDeserialize)]
+        struct WithMap<'bump> {
+            map: &'bump str,
+            count: u32,
+        }
+
+        let json = r#"{"map": "some_map", "count": 99}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let result: WithMap = WithMap::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(result.map, "some_map");
+        assert_eq!(result.count, 99);
+    }
+}

--- a/crates/arena-serde/src/tracked/de.rs
+++ b/crates/arena-serde/src/tracked/de.rs
@@ -1,0 +1,1537 @@
+use super::wrap::{Wrap, WrapVariant};
+use super::{Chain, Error, Track};
+use core::fmt;
+use serde::de::{self, Deserialize, DeserializeSeed, Visitor};
+
+/// Entry point for tracked deserialization.
+pub fn deserialize<'de, D, T>(deserializer: D, path_buf: &mut Vec<u8>) -> Result<T, Error<D::Error>>
+where
+    D: de::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    let track = Track::new_with(path_buf);
+    match T::deserialize(Deserializer::new(deserializer, &track)) {
+        Ok(t) => Ok(t),
+        Err(err) => Err(Error {
+            path: track.path(),
+            original: err,
+        }),
+    }
+}
+
+/// Deserializer adapter that records path to deserialization errors.
+///
+/// # Example
+///
+/// When deserialization fails, the error includes the path to the field that caused the error:
+///
+/// ```
+/// use arena_serde::tracked;
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct MyType {
+///     count: i32,
+/// }
+///
+/// let json = r#"{"count": "not a number"}"#;
+/// let mut deserializer = serde_json::Deserializer::from_str(json);
+/// let mut path_buf = Vec::new();
+/// match tracked::deserialize::<_, MyType>(&mut deserializer, &mut path_buf) {
+///     Ok(_) => panic!("Expected deserialization to fail"),
+///     Err(err) => {
+///         let path = err.path().to_string();
+///         assert_eq!(path, "count");
+///     }
+/// }
+/// ```
+pub struct Deserializer<'a, 'b, 'buf, D> {
+    de: D,
+    chain: Chain<'a>,
+    track: &'b Track<'buf>,
+}
+
+impl<'a, 'b, 'buf, D> Deserializer<'a, 'b, 'buf, D> {
+    pub fn new(de: D, track: &'b Track<'buf>) -> Self {
+        Deserializer {
+            de,
+            chain: Chain::Root,
+            track,
+        }
+    }
+}
+
+// Plain old forwarding impl.
+impl<'a, 'b, 'buf, 'de, D> de::Deserializer<'de> for Deserializer<'a, 'b, 'buf, D>
+where
+    D: de::Deserializer<'de>,
+{
+    type Error = D::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_any(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_bool(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_u8(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_u16(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_u32(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_u64(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_u128(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_i8(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_i16(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_i32(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_i64(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_i128(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_f32(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_f64(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_char(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_str(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_string(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_bytes(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_byte_buf(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_option(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_unit(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_unit_struct(name, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_newtype_struct(name, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_seq(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_tuple(len, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_tuple_struct(name, len, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_map(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_struct(name, fields, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_enum(name, variants, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_ignored_any(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_identifier(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.de.is_human_readable()
+    }
+}
+
+// Forwarding impl to preserve context.
+impl<'a, 'b, 'buf, 'de, X> Visitor<'de> for Wrap<'a, 'b, 'buf, X>
+where
+    X: Visitor<'de>,
+{
+    type Value = X::Value;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        self.delegate.expecting(formatter)
+    }
+
+    fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_bool(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_i8(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_i16(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_i32(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_i64(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_i128(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_u8(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_u16(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_u32(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_u64(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_u128(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_f32(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_f64(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_char<E>(self, v: char) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_char(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_str(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_borrowed_str(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_string(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_unit()
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_none()
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_some(Deserializer {
+                de: deserializer,
+                chain: Chain::Some { parent: chain },
+                track,
+            })
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_newtype_struct(Deserializer {
+                de: deserializer,
+                chain: Chain::NewtypeStruct { parent: chain },
+                track,
+            })
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_seq<V>(self, visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: de::SeqAccess<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_seq(SeqAccess::new(visitor, chain, track))
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_map<V>(self, visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: de::MapAccess<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_map(MapAccess::new(visitor, chain, track))
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_enum<V>(self, visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: de::EnumAccess<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_enum(Wrap::new(visitor, chain, track))
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_bytes(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_borrowed_bytes(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_byte_buf(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+}
+
+// Forwarding impl to preserve context.
+impl<'a, 'b, 'buf, 'de, X> de::EnumAccess<'de> for Wrap<'a, 'b, 'buf, X>
+where
+    X: de::EnumAccess<'de> + 'a,
+{
+    type Error = X::Error;
+    type Variant = WrapVariant<'a, 'b, 'buf, X::Variant>;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), X::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        let mut variant = None;
+        self.delegate
+            .variant_seed(CaptureKey::new(seed, &mut variant, track))
+            .map_err(|err| track.trigger(chain, err))
+            .map(move |(v, vis)| {
+                let chain = match variant {
+                    Some((start, len)) => Chain::Enum {
+                        parent: chain,
+                        start,
+                        len,
+                    },
+                    None => Chain::NonStringKey { parent: chain },
+                };
+                (v, WrapVariant::new(vis, chain, track))
+            })
+    }
+}
+
+// Forwarding impl to preserve context.
+impl<'a, 'b, 'buf, 'de, X> de::VariantAccess<'de> for WrapVariant<'a, 'b, 'buf, X>
+where
+    X: de::VariantAccess<'de>,
+{
+    type Error = X::Error;
+
+    fn unit_variant(self) -> Result<(), X::Error> {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .unit_variant()
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, X::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        let nested = Chain::NewtypeVariant { parent: &chain };
+        self.delegate
+            .newtype_variant_seed(TrackedSeed::new(seed, nested, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .tuple_variant(len, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn struct_variant<V>(
+        self,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .struct_variant(fields, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+}
+
+// Seed that saves the string into the given optional during `visit_str` and
+// `visit_string`.
+struct CaptureKey<'a, 'b, 'buf, X> {
+    delegate: X,
+    key: &'a mut Option<(usize, u8)>,
+    track: &'b Track<'buf>,
+}
+
+impl<'a, 'b, 'buf, X> CaptureKey<'a, 'b, 'buf, X> {
+    fn new(delegate: X, key: &'a mut Option<(usize, u8)>, track: &'b Track<'buf>) -> Self {
+        CaptureKey {
+            delegate,
+            key,
+            track,
+        }
+    }
+
+    // Helper to push a string to the path buffer and return (start, len)
+    fn push_str(&self, s: &str) -> (usize, u8) {
+        self.track.push_bytes(s.as_bytes())
+    }
+}
+
+// Forwarding impl.
+impl<'a, 'b, 'buf, 'de, X> DeserializeSeed<'de> for CaptureKey<'a, 'b, 'buf, X>
+where
+    X: DeserializeSeed<'de>,
+{
+    type Value = X::Value;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<X::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        self.delegate
+            .deserialize(CaptureKey::new(deserializer, self.key, self.track))
+    }
+}
+
+// Forwarding impl.
+impl<'a, 'b, 'buf, 'de, X> de::Deserializer<'de> for CaptureKey<'a, 'b, 'buf, X>
+where
+    X: de::Deserializer<'de>,
+{
+    type Error = X::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_any(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_bool(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_u8(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_u16(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_u32(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_u64(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_u128(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_i8(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_i16(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_i32(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_i64(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_i128(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_f32(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_f64(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_char(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_str(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_string(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_bytes(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_byte_buf(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_option(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_unit(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_unit_struct(name, CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_newtype_struct(name, CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_seq(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_tuple(len, CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate.deserialize_tuple_struct(
+            name,
+            len,
+            CaptureKey::new(visitor, self.key, self.track),
+        )
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_map(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate.deserialize_struct(
+            name,
+            fields,
+            CaptureKey::new(visitor, self.key, self.track),
+        )
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate.deserialize_enum(
+            name,
+            variants,
+            CaptureKey::new(visitor, self.key, self.track),
+        )
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_ignored_any(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_identifier(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.delegate.is_human_readable()
+    }
+}
+
+// Forwarding impl except `visit_str` and `visit_string` which save the string.
+impl<'a, 'b, 'buf, 'de, X> Visitor<'de> for CaptureKey<'a, 'b, 'buf, X>
+where
+    X: Visitor<'de>,
+{
+    type Value = X::Value;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        self.delegate.expecting(formatter)
+    }
+
+    fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let string = if v { "true" } else { "false" };
+        *self.key = Some(self.push_str(string));
+        self.delegate.visit_bool(v)
+    }
+
+    fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_i8(v)
+    }
+
+    fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_i16(v)
+    }
+
+    fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_i32(v)
+    }
+
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_i64(v)
+    }
+
+    fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_i128(v)
+    }
+
+    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_u8(v)
+    }
+
+    fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_u16(v)
+    }
+
+    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_u32(v)
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_u64(v)
+    }
+
+    fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_u128(v)
+    }
+
+    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_f32(v)
+    }
+
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_f64(v)
+    }
+
+    fn visit_char<E>(self, v: char) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_char(v)
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        *self.key = Some(self.push_str(v));
+        self.delegate.visit_str(v)
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        *self.key = Some(self.push_str(v));
+        self.delegate.visit_borrowed_str(v)
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        *self.key = Some(self.push_str(&v));
+        self.delegate.visit_string(v)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_unit()
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_none()
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        self.delegate.visit_some(deserializer)
+    }
+
+    fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        self.delegate.visit_newtype_struct(deserializer)
+    }
+
+    fn visit_seq<V>(self, visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: de::SeqAccess<'de>,
+    {
+        self.delegate.visit_seq(visitor)
+    }
+
+    fn visit_map<V>(self, visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: de::MapAccess<'de>,
+    {
+        self.delegate.visit_map(visitor)
+    }
+
+    fn visit_enum<V>(self, visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: de::EnumAccess<'de>,
+    {
+        self.delegate.visit_enum(visitor)
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_bytes(v)
+    }
+
+    fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_borrowed_bytes(v)
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_byte_buf(v)
+    }
+}
+
+// Seed used for map values, sequence elements and newtype variants to track
+// their path.
+struct TrackedSeed<'a, 'b, 'buf, X> {
+    seed: X,
+    chain: Chain<'a>,
+    track: &'b Track<'buf>,
+}
+
+impl<'a, 'b, 'buf, X> TrackedSeed<'a, 'b, 'buf, X> {
+    fn new(seed: X, chain: Chain<'a>, track: &'b Track<'buf>) -> Self {
+        TrackedSeed { seed, chain, track }
+    }
+}
+
+impl<'a, 'b, 'buf, 'de, X> DeserializeSeed<'de> for TrackedSeed<'a, 'b, 'buf, X>
+where
+    X: DeserializeSeed<'de>,
+{
+    type Value = X::Value;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<X::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.seed
+            .deserialize(Deserializer {
+                de: deserializer,
+                chain: chain.clone(),
+                track,
+            })
+            .map_err(|err| track.trigger(&chain, err))
+    }
+}
+
+// Seq visitor that tracks the index of its elements.
+struct SeqAccess<'a, 'b, 'buf, X> {
+    delegate: X,
+    chain: &'a Chain<'a>,
+    index: usize,
+    track: &'b Track<'buf>,
+}
+
+impl<'a, 'b, 'buf, X> SeqAccess<'a, 'b, 'buf, X> {
+    fn new(delegate: X, chain: &'a Chain<'a>, track: &'b Track<'buf>) -> Self {
+        SeqAccess {
+            delegate,
+            chain,
+            index: 0,
+            track,
+        }
+    }
+}
+
+// Forwarding impl to preserve context.
+impl<'a, 'b, 'buf, 'de, X> de::SeqAccess<'de> for SeqAccess<'a, 'b, 'buf, X>
+where
+    X: de::SeqAccess<'de>,
+{
+    type Error = X::Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, X::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let parent = self.chain;
+        let chain = Chain::Seq {
+            parent,
+            index: self.index,
+        };
+        let track = self.track;
+        self.index += 1;
+        self.delegate
+            .next_element_seed(TrackedSeed::new(seed, chain, track))
+            .map_err(|err| track.trigger(parent, err))
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        self.delegate.size_hint()
+    }
+}
+
+// Map visitor that captures the string value of its keys and uses that to track
+// the path to its values.
+struct MapAccess<'a, 'b, 'buf, X> {
+    delegate: X,
+    chain: &'a Chain<'a>,
+    key: Option<(usize, u8)>,
+    track: &'b Track<'buf>,
+}
+
+impl<'a, 'b, 'buf, X> MapAccess<'a, 'b, 'buf, X> {
+    fn new(delegate: X, chain: &'a Chain<'a>, track: &'b Track<'buf>) -> Self {
+        MapAccess {
+            delegate,
+            chain,
+            key: None,
+            track,
+        }
+    }
+}
+
+impl<'a, 'b, 'buf, 'de, X> de::MapAccess<'de> for MapAccess<'a, 'b, 'buf, X>
+where
+    X: de::MapAccess<'de>,
+{
+    type Error = X::Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, X::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        let key = &mut self.key;
+        self.delegate
+            .next_key_seed(CaptureKey::new(seed, key, track))
+            .map_err(|err| {
+                let chain = match key.take() {
+                    Some((start, len)) => Chain::Map {
+                        parent: chain,
+                        start,
+                        len,
+                    },
+                    None => Chain::NonStringKey { parent: chain },
+                };
+                track.trigger(&chain, err)
+            })
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, X::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let parent = self.chain;
+        let (chain, len_to_pop) = match self.key.take() {
+            Some((start, len)) => (Chain::Map { parent, start, len }, Some(len)),
+            None => (Chain::NonStringKey { parent }, None),
+        };
+        let track = self.track;
+        let result = self
+            .delegate
+            .next_value_seed(TrackedSeed::new(seed, chain, track))
+            .map_err(|err| track.trigger(parent, err));
+
+        // Pop the key bytes after deserialization completes (whether success or error)
+        if let Some(len) = len_to_pop {
+            track.pop_bytes(len);
+        }
+
+        result
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        self.delegate.size_hint()
+    }
+}

--- a/crates/arena-serde/src/tracked/mod.rs
+++ b/crates/arena-serde/src/tracked/mod.rs
@@ -1,0 +1,176 @@
+// Path tracking for arena deserialization errors.
+//
+// Ported from serde_path_to_error v0.1.20 with modified path tracking to use a
+// single buffer that amortizes allocations.
+
+mod de;
+mod path;
+mod wrap;
+
+pub use de::{Deserializer, deserialize};
+pub use path::{Path, Segment, Segments};
+
+use core::cell::Cell;
+use core::fmt::{self, Display};
+use serde::ser::StdError;
+
+/// Original deserializer error together with the path at which it occurred.
+#[derive(Clone, Debug)]
+pub struct Error<E> {
+    path: Path,
+    original: E,
+}
+
+impl<E> Error<E> {
+    pub fn new(path: Path, inner: E) -> Self {
+        Error {
+            path,
+            original: inner,
+        }
+    }
+
+    /// Element path at which this deserialization error occurred.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// The Deserializer's underlying error that occurred.
+    pub fn into_inner(self) -> E {
+        self.original
+    }
+
+    /// Reference to the Deserializer's underlying error that occurred.
+    pub fn inner(&self) -> &E {
+        &self.original
+    }
+}
+
+impl<E: Display> Display for Error<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if !self.path.is_only_unknown() {
+            write!(f, "{}: ", self.path)?;
+        }
+        write!(f, "{}", self.original)
+    }
+}
+
+impl<E: StdError> StdError for Error<E> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.original.source()
+    }
+}
+
+/// State for bookkeeping across nested deserializer calls.
+///
+/// Uses a mutable byte vector for efficient path tracking that truncates on backtrack.
+pub struct Track<'buf> {
+    path_buf: core::cell::UnsafeCell<&'buf mut Vec<u8>>,
+    path: Cell<Option<Path>>,
+}
+
+impl<'buf> Track<'buf> {
+    /// Create a new tracker with a mutable byte vector for path tracking.
+    pub fn new_with(buf: &'buf mut Vec<u8>) -> Self {
+        Track {
+            path_buf: core::cell::UnsafeCell::new(buf),
+            path: Cell::new(None),
+        }
+    }
+
+    /// Append bytes to the path buffer and return (start_position, length).
+    ///
+    /// Only pushes up to 255 bytes.
+    ///
+    /// # Safety
+    ///
+    /// This is safe to call from &self because the mutations follow a stack discipline:
+    /// bytes pushed during deserialization are popped when unwinding back up the tree.
+    pub fn push_bytes(&self, bytes: &[u8]) -> (usize, u8) {
+        unsafe {
+            let vec = &mut *self.path_buf.get();
+            let start = vec.len();
+            let bytes_to_push = bytes.len().min(u8::MAX as usize);
+            let len = bytes_to_push as u8;
+            vec.extend_from_slice(&bytes[..bytes_to_push]);
+            (start, len)
+        }
+    }
+
+    /// Remove `len` bytes from the end of the path buffer (used when unwinding).
+    ///
+    /// # Safety
+    ///
+    /// This is safe to call from &self because the mutations follow a stack discipline.
+    pub fn pop_bytes(&self, len: u8) {
+        unsafe {
+            let vec = &mut *self.path_buf.get();
+            let new_len = vec.len().saturating_sub(len as usize);
+            vec.truncate(new_len);
+        }
+    }
+
+    /// Get bytes from the path buffer at absolute position (start, len).
+    ///
+    /// Used during error path construction to read the bytes before they're popped.
+    pub fn get_bytes(&self, start: usize, len: u8) -> &[u8] {
+        unsafe {
+            let vec = &*self.path_buf.get();
+            let end = start + (len as usize);
+            if end <= vec.len() {
+                &vec[start..end]
+            } else {
+                &[] // Return empty slice if the bytes have been removed
+            }
+        }
+    }
+
+    /// Gets path at which the error occurred. Only meaningful after we know
+    /// that an error has occurred. Returns an empty path otherwise.
+    pub fn path(self) -> Path {
+        self.path.into_inner().unwrap_or_else(Path::empty)
+    }
+
+    #[inline]
+    pub(crate) fn trigger<'a, E>(&self, chain: &Chain<'a>, err: E) -> E {
+        self.trigger_impl(chain);
+        err
+    }
+
+    pub(crate) fn trigger_impl<'a>(&self, chain: &Chain<'a>) {
+        self.path.set(Some(match self.path.take() {
+            Some(already_set) => already_set,
+            None => Path::from_chain(chain, self),
+        }));
+    }
+}
+
+#[derive(Clone)]
+pub(crate) enum Chain<'a> {
+    Root,
+    Seq {
+        parent: &'a Chain<'a>,
+        index: usize,
+    },
+    Map {
+        parent: &'a Chain<'a>,
+        start: usize, // Absolute start position in path_buf
+        len: u8,      // Length of this key
+    },
+    Enum {
+        parent: &'a Chain<'a>,
+        start: usize, // Absolute start position in path_buf
+        len: u8,      // Length of this variant
+    },
+    Some {
+        parent: &'a Chain<'a>,
+    },
+    NewtypeStruct {
+        parent: &'a Chain<'a>,
+    },
+    NewtypeVariant {
+        parent: &'a Chain<'a>,
+    },
+    NonStringKey {
+        parent: &'a Chain<'a>,
+    },
+}

--- a/crates/arena-serde/src/tracked/path.rs
+++ b/crates/arena-serde/src/tracked/path.rs
@@ -1,0 +1,154 @@
+use super::Chain;
+use core::fmt::{self, Display};
+use core::slice;
+
+/// Path to the error value in the input, like `dependencies.serde.typo1`.
+///
+/// Use `path.to_string()` to get a string representation of the path with
+/// segments separated by periods, or use `path.iter()` to iterate over
+/// individual segments of the path.
+#[derive(Clone, Debug)]
+pub struct Path {
+    segments: Vec<Segment>,
+}
+
+/// Single segment of a path.
+#[derive(Clone, Debug)]
+pub enum Segment {
+    Seq { index: usize },
+    Map { key: String },
+    Enum { variant: String },
+    Unknown,
+}
+
+impl Path {
+    /// Returns an iterator with element type [`&Segment`][Segment].
+    pub fn iter(&self) -> Segments<'_> {
+        Segments {
+            iter: self.segments.iter(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Path {
+    type Item = &'a Segment;
+    type IntoIter = Segments<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Iterator over segments of a path.
+pub struct Segments<'a> {
+    iter: slice::Iter<'a, Segment>,
+}
+
+impl<'a> Iterator for Segments<'a> {
+    type Item = &'a Segment;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a> DoubleEndedIterator for Segments<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back()
+    }
+}
+
+impl<'a> ExactSizeIterator for Segments<'a> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+impl Display for Path {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        if self.segments.is_empty() {
+            return formatter.write_str(".");
+        }
+
+        let mut separator = "";
+        for segment in self {
+            if !matches!(segment, Segment::Seq { .. }) {
+                formatter.write_str(separator)?;
+            }
+            write!(formatter, "{}", segment)?;
+            separator = ".";
+        }
+
+        Ok(())
+    }
+}
+
+impl Path {
+    pub(crate) fn empty() -> Self {
+        Path {
+            segments: Vec::new(),
+        }
+    }
+
+    pub(crate) fn from_chain<'a, 'buf>(mut chain: &Chain<'a>, track: &super::Track<'buf>) -> Self {
+        let mut segments = Vec::new();
+        loop {
+            match chain {
+                Chain::Root => break,
+                Chain::Seq { parent, index } => {
+                    segments.push(Segment::Seq { index: *index });
+                    chain = parent;
+                }
+                Chain::Map { parent, start, len } => {
+                    let bytes = track.get_bytes(*start, *len);
+                    let key = std::str::from_utf8(bytes).unwrap_or("?").to_string();
+                    segments.push(Segment::Map { key });
+                    chain = parent;
+                }
+                Chain::Enum { parent, start, len } => {
+                    let bytes = track.get_bytes(*start, *len);
+                    let variant = std::str::from_utf8(bytes).unwrap_or("?").to_string();
+                    segments.push(Segment::Enum { variant });
+                    chain = parent;
+                }
+                Chain::Some { parent }
+                | Chain::NewtypeStruct { parent }
+                | Chain::NewtypeVariant { parent } => {
+                    chain = parent;
+                }
+                Chain::NonStringKey { parent } => {
+                    segments.push(Segment::Unknown);
+                    chain = parent;
+                }
+            }
+        }
+        segments.reverse();
+        Path { segments }
+    }
+
+    pub(crate) fn is_only_unknown(&self) -> bool {
+        self.segments.iter().all(Segment::is_unknown)
+    }
+}
+
+impl Display for Segment {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Segment::Seq { index } => write!(formatter, "[{}]", index),
+            Segment::Map { key } | Segment::Enum { variant: key } => {
+                write!(formatter, "{}", key)
+            }
+            Segment::Unknown => formatter.write_str("?"),
+        }
+    }
+}
+
+impl Segment {
+    fn is_unknown(&self) -> bool {
+        matches!(self, Segment::Unknown)
+    }
+}

--- a/crates/arena-serde/src/tracked/wrap.rs
+++ b/crates/arena-serde/src/tracked/wrap.rs
@@ -1,0 +1,35 @@
+use super::{Chain, Track};
+
+// Wrapper that attaches context to a `Visitor`, `SeqAccess` or `EnumAccess`.
+pub struct Wrap<'a, 'b, 'buf, X> {
+    pub(crate) delegate: X,
+    pub(crate) chain: &'a Chain<'a>,
+    pub(crate) track: &'b Track<'buf>,
+}
+
+// Wrapper that attaches context to a `VariantAccess`.
+pub struct WrapVariant<'a, 'b, 'buf, X> {
+    pub(crate) delegate: X,
+    pub(crate) chain: Chain<'a>,
+    pub(crate) track: &'b Track<'buf>,
+}
+
+impl<'a, 'b, 'buf, X> Wrap<'a, 'b, 'buf, X> {
+    pub(crate) fn new(delegate: X, chain: &'a Chain<'a>, track: &'b Track<'buf>) -> Self {
+        Wrap {
+            delegate,
+            chain,
+            track,
+        }
+    }
+}
+
+impl<'a, 'b, 'buf, X> WrapVariant<'a, 'b, 'buf, X> {
+    pub(crate) fn new(delegate: X, chain: Chain<'a>, track: &'b Track<'buf>) -> Self {
+        WrapVariant {
+            delegate,
+            chain,
+            track,
+        }
+    }
+}

--- a/crates/arena-serde/tests/derive_enum.rs
+++ b/crates/arena-serde/tests/derive_enum.rs
@@ -1,0 +1,123 @@
+use arena_serde::Arena as Bump;
+use arena_serde::{ArenaDeserialize, ArenaSeed};
+use serde::de::DeserializeSeed;
+
+fn parse<'bump, T: ArenaDeserialize<'bump>>(bump: &'bump Bump, json: &str) -> Result<T, String> {
+    let mut de = serde_json::Deserializer::from_str(json);
+    ArenaSeed::<T>::new(bump)
+        .deserialize(&mut de)
+        .map_err(|e| e.to_string())
+}
+
+#[derive(Debug, PartialEq, ArenaDeserialize)]
+enum Plain {
+    Alpha,
+    Beta,
+}
+
+#[test]
+fn plain_variant_names() {
+    let bump = Bump::new();
+    assert_eq!(parse::<Plain>(&bump, r#""Alpha""#), Ok(Plain::Alpha));
+    assert_eq!(parse::<Plain>(&bump, r#""Beta""#), Ok(Plain::Beta));
+}
+
+#[test]
+fn unknown_variant_is_an_error() {
+    let bump = Bump::new();
+    let err = parse::<Plain>(&bump, r#""Gamma""#).unwrap_err();
+    assert!(err.contains("unknown variant `Gamma`"), "{err}");
+    assert!(err.contains("`Alpha`"), "{err}");
+}
+
+#[derive(Debug, PartialEq, ArenaDeserialize)]
+#[arena(rename_all = "snake_case")]
+enum Snake {
+    RuralSettlement,
+    Town,
+    #[arena(rename = "big-city")]
+    City,
+    #[arena(other)]
+    Other,
+}
+
+#[test]
+fn rename_all_and_rename() {
+    let bump = Bump::new();
+    assert_eq!(
+        parse::<Snake>(&bump, r#""rural_settlement""#),
+        Ok(Snake::RuralSettlement)
+    );
+    assert_eq!(parse::<Snake>(&bump, r#""town""#), Ok(Snake::Town));
+    assert_eq!(parse::<Snake>(&bump, r#""big-city""#), Ok(Snake::City));
+}
+
+#[test]
+fn other_receives_unknown_identifiers() {
+    let bump = Bump::new();
+    assert_eq!(parse::<Snake>(&bump, r#""megalopolis""#), Ok(Snake::Other));
+    // The pre-rename name is not accepted once rename_all applies.
+    assert_eq!(parse::<Snake>(&bump, r#""Town""#), Ok(Snake::Other));
+}
+
+#[derive(Debug, PartialEq, ArenaDeserialize)]
+#[arena(rename_all = "SCREAMING_SNAKE_CASE")]
+enum Screaming {
+    HalfLife,
+}
+
+#[derive(Debug, PartialEq, ArenaDeserialize)]
+#[arena(rename_all = "kebab-case")]
+enum Kebab {
+    HalfLife,
+}
+
+#[derive(Debug, PartialEq, ArenaDeserialize)]
+#[arena(rename_all = "camelCase")]
+enum Camel {
+    HalfLife,
+}
+
+#[derive(Debug, PartialEq, ArenaDeserialize)]
+#[arena(rename_all = "lowercase")]
+enum Lower {
+    HalfLife,
+}
+
+#[test]
+fn other_rename_rules() {
+    let bump = Bump::new();
+    assert_eq!(
+        parse::<Screaming>(&bump, r#""HALF_LIFE""#),
+        Ok(Screaming::HalfLife)
+    );
+    assert_eq!(parse::<Kebab>(&bump, r#""half-life""#), Ok(Kebab::HalfLife));
+    assert_eq!(parse::<Camel>(&bump, r#""halfLife""#), Ok(Camel::HalfLife));
+    assert_eq!(parse::<Lower>(&bump, r#""halflife""#), Ok(Lower::HalfLife));
+}
+
+#[derive(Debug, PartialEq, ArenaDeserialize)]
+struct Holder<'bump> {
+    name: &'bump str,
+    kind: Snake,
+    #[arena(default)]
+    fallback: Option<Plain>,
+}
+
+#[test]
+fn enum_as_struct_field() {
+    let bump = Bump::new();
+    let holder = parse::<Holder>(&bump, r#"{"name": "x", "kind": "town"}"#).unwrap();
+    assert_eq!(
+        holder,
+        Holder {
+            name: "x",
+            kind: Snake::Town,
+            fallback: None
+        }
+    );
+    let holder =
+        parse::<Holder>(&bump, r#"{"name": "y", "kind": "?", "fallback": "Beta"}"#).unwrap();
+    assert_eq!(holder.kind, Snake::Other);
+    assert_eq!(holder.fallback, Some(Plain::Beta));
+}

--- a/crates/arena-serde/tests/tracked_deserializer.rs
+++ b/crates/arena-serde/tests/tracked_deserializer.rs
@@ -1,0 +1,400 @@
+#![allow(dead_code)]
+use serde::Deserialize;
+
+/// Helper to run tracked deserialization with serde_json
+fn deserialize_tracked<T: for<'de> Deserialize<'de>>(json: &str) -> Result<T, String> {
+    let mut path_buf = Vec::new();
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    arena_serde::tracked::deserialize(&mut deserializer, &mut path_buf)
+        .map_err(|err| err.path().to_string())
+}
+
+#[test]
+fn test_simple_field_error() {
+    #[derive(Deserialize, Debug)]
+    struct TestStruct {
+        name: String,
+    }
+
+    let json = r#"{"name": 123}"#; // Type error: expected string
+    let err = deserialize_tracked::<TestStruct>(json).unwrap_err();
+    assert_eq!(err, "name");
+}
+
+#[test]
+fn test_missing_required_field() {
+    #[derive(Deserialize, Debug)]
+    struct TestStruct {
+        name: String,
+    }
+
+    let json = r#"{}"#;
+    let err = deserialize_tracked::<TestStruct>(json).unwrap_err();
+    // Missing field error occurs at root level
+    assert_eq!(err, ".");
+}
+
+#[test]
+fn test_nested_struct_error() {
+    #[derive(Deserialize, Debug)]
+    struct Inner {
+        value: i32,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct Outer {
+        inner: Inner,
+    }
+
+    let json = r#"{"inner": {"value": "not an int"}}"#;
+    let err = deserialize_tracked::<Outer>(json).unwrap_err();
+    assert_eq!(err, "inner.value");
+}
+
+#[test]
+fn test_deeply_nested_path() {
+    #[derive(Deserialize, Debug)]
+    struct L5 {
+        val: i32,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct L4 {
+        l5: L5,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct L3 {
+        l4: L4,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct L2 {
+        l3: L3,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct L1 {
+        l2: L2,
+    }
+
+    let json = r#"{"l2": {"l3": {"l4": {"l5": {"val": "wrong"}}}}}"#;
+    let err = deserialize_tracked::<L1>(json).unwrap_err();
+    assert_eq!(err, "l2.l3.l4.l5.val");
+}
+
+#[test]
+fn test_root_level_error() {
+    let json = r#""not a number""#;
+    let err = deserialize_tracked::<i32>(json).unwrap_err();
+    // Root level errors show as "."
+    assert_eq!(err, ".");
+}
+
+#[test]
+fn test_sequence_error() {
+    let json = r#"[1, 2, "three", 4]"#;
+    let err = deserialize_tracked::<Vec<i32>>(json).unwrap_err();
+    assert_eq!(err, "[2]");
+}
+
+#[test]
+fn test_sequence_nested_error() {
+    #[derive(Deserialize, Debug)]
+    struct Item {
+        id: i32,
+    }
+
+    let json = r#"[{"id": 1}, {"id": "wrong"}]"#;
+    let err = deserialize_tracked::<Vec<Item>>(json).unwrap_err();
+    assert_eq!(err, "[1].id");
+}
+
+#[test]
+fn test_empty_sequence() {
+    let vec: Vec<i32> = deserialize_tracked::<Vec<i32>>(r#"[]"#).unwrap();
+    assert!(vec.is_empty());
+}
+
+#[test]
+fn test_tuple_error() {
+    let json = r#"["string", 123, "not an int"]"#;
+    let err = deserialize_tracked::<(String, i32, i32)>(json).unwrap_err();
+    assert_eq!(err, "[2]");
+}
+
+#[test]
+fn test_map_error() {
+    let json = r#"{"key1": 10, "key2": "not an int"}"#;
+    let err = deserialize_tracked::<std::collections::HashMap<String, i32>>(json).unwrap_err();
+    assert_eq!(err, "key2");
+}
+
+#[test]
+fn test_struct_map_error() {
+    #[derive(Deserialize, Debug)]
+    struct Config {
+        timeout: u32,
+        debug: bool,
+    }
+
+    let json = r#"{"timeout": 30, "debug": "not a bool"}"#;
+    let err = deserialize_tracked::<Config>(json).unwrap_err();
+    assert_eq!(err, "debug");
+}
+
+#[test]
+fn test_multiple_map_keys() {
+    #[derive(Deserialize, Debug)]
+    struct Config {
+        host: String,
+        port: u16,
+        timeout: u32,
+    }
+
+    let json = r#"{"host": "localhost", "port": 8080, "timeout": "not an int"}"#;
+    let err = deserialize_tracked::<Config>(json).unwrap_err();
+    assert_eq!(err, "timeout");
+}
+
+#[test]
+fn test_enum_variant_error() {
+    #[derive(Deserialize, Debug)]
+    #[serde(tag = "type")]
+    enum Status {
+        Active { timestamp: i64 },
+        Inactive,
+    }
+
+    let json = r#"{"type": "Active", "timestamp": "not a number"}"#;
+    let err = deserialize_tracked::<Status>(json).unwrap_err();
+    assert_eq!(err, ".");
+}
+
+#[test]
+fn test_enum_newtype_variant() {
+    #[derive(Deserialize, Debug)]
+    enum Message {
+        #[serde(rename = "text")]
+        Text(String),
+        #[serde(rename = "number")]
+        Number(i32),
+    }
+
+    let json = r#"{"number": "not a number"}"#;
+    let err = deserialize_tracked::<Message>(json).unwrap_err();
+    assert_eq!(err, "number");
+}
+
+#[test]
+fn test_option_some_with_error() {
+    #[derive(Deserialize, Debug)]
+    struct Config {
+        timeout: Option<i32>,
+    }
+
+    let json = r#"{"timeout": "not an int"}"#;
+    let err = deserialize_tracked::<Config>(json).unwrap_err();
+    assert_eq!(err, "timeout");
+}
+
+#[test]
+fn test_option_none() {
+    #[derive(Deserialize, Debug)]
+    struct Config {
+        timeout: Option<i32>,
+    }
+
+    let config: Config = deserialize_tracked(r#"{"timeout": null}"#).unwrap();
+    assert_eq!(config.timeout, None);
+}
+
+#[test]
+fn test_option_missing() {
+    #[derive(Deserialize, Debug)]
+    struct Config {
+        #[serde(default)]
+        timeout: Option<i32>,
+    }
+
+    let config: Config = deserialize_tracked(r#"{}"#).unwrap();
+    assert_eq!(config.timeout, None);
+}
+
+#[test]
+fn test_mixed_nesting_map_and_array() {
+    #[derive(Deserialize, Debug)]
+    struct Item {
+        id: i32,
+    }
+
+    let json = r#"{"items": [{"id": 1}, {"id": "wrong"}]}"#;
+    let err =
+        deserialize_tracked::<std::collections::HashMap<String, Vec<Item>>>(json).unwrap_err();
+    assert_eq!(err, "items[1].id");
+}
+
+#[test]
+fn test_mixed_nesting_array_and_map() {
+    let json = r#"[{"a": 1}, {"a": "wrong"}]"#;
+    let err = deserialize_tracked::<Vec<std::collections::HashMap<String, i32>>>(json).unwrap_err();
+    assert_eq!(err, "[1].a");
+}
+
+#[test]
+fn test_struct_with_vec_with_struct() {
+    #[derive(Deserialize, Debug)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct Shape {
+        points: Vec<Point>,
+    }
+
+    let json = r#"{"points": [{"x": 1, "y": 2}, {"x": "wrong", "y": 3}]}"#;
+    let err = deserialize_tracked::<Shape>(json).unwrap_err();
+    assert_eq!(err, "points[1].x");
+}
+
+#[test]
+fn test_long_key_name() {
+    // Test with a key longer than 255 bytes
+    // Keys are capped at u8::MAX (255 bytes) due to the length field being a u8
+    let long_key = "a".repeat(300);
+    let expected_key = "a".repeat(255); // Capped at u8::MAX
+    let json = format!(r#"{{"{}": "not an int"}}"#, long_key);
+    let err = deserialize_tracked::<std::collections::HashMap<String, i32>>(&json).unwrap_err();
+    // The error path contains the key, truncated to 255 bytes
+    assert_eq!(
+        err, expected_key,
+        "Keys longer than 255 bytes are truncated"
+    );
+}
+
+#[test]
+fn test_deeply_nested_arrays() {
+    let json = r#"[[[[[1, 2, "wrong"]]]]]]"#;
+    let err = deserialize_tracked::<Vec<Vec<Vec<Vec<Vec<i32>>>>>>(json).unwrap_err();
+    assert_eq!(err, "[0][0][0][0][2]");
+}
+
+#[test]
+fn test_newtype_struct() {
+    #[derive(Deserialize, Debug)]
+    struct UserId(i32);
+
+    #[derive(Deserialize, Debug)]
+    struct User {
+        id: UserId,
+    }
+
+    let json = r#"{"id": "not an int"}"#;
+    let err = deserialize_tracked::<User>(json).unwrap_err();
+    assert_eq!(err, "id");
+}
+
+#[test]
+fn test_tuple_struct() {
+    #[derive(Deserialize, Debug)]
+    struct Point(i32, i32, i32);
+
+    let json = r#"[1, 2, "wrong"]"#;
+    let err = deserialize_tracked::<Point>(json).unwrap_err();
+    assert_eq!(err, "[2]");
+}
+
+#[test]
+fn test_buffer_push_pop_symmetry() {
+    // This test exercises the stack discipline of push_bytes and pop_bytes
+    // by deserializing multiple sequential map entries
+    let json = r#"{
+        "first": 1,
+        "second": 2,
+        "third": "wrong"
+    }"#;
+
+    let err = deserialize_tracked::<std::collections::HashMap<String, i32>>(json).unwrap_err();
+    assert_eq!(err, "third");
+}
+
+#[test]
+fn test_sequential_arrays() {
+    // Tests buffer cleanup between array elements
+    let json = r#"[[1, 2], [3, 4], [5, "wrong"]]"#;
+    let err = deserialize_tracked::<Vec<Vec<i32>>>(json).unwrap_err();
+    assert_eq!(err, "[2][1]");
+}
+
+#[test]
+fn test_interleaved_maps_and_arrays() {
+    // Complex scenario testing buffer management
+    #[derive(Deserialize, Debug)]
+    struct Item {
+        id: i32,
+        tags: Vec<String>,
+    }
+
+    let json = r#"{
+        "items": [
+            {"id": 1, "tags": ["a", "b"]},
+            {"id": 2, "tags": ["c", "d"]},
+            {"id": "wrong", "tags": []}
+        ]
+    }"#;
+
+    let err =
+        deserialize_tracked::<std::collections::HashMap<String, Vec<Item>>>(json).unwrap_err();
+    assert_eq!(err, "items[2].id");
+}
+
+#[test]
+fn test_valid_simple_struct() {
+    #[derive(Deserialize, Debug)]
+    struct Config {
+        name: String,
+        count: i32,
+    }
+
+    let json = r#"{"name": "test", "count": 42}"#;
+    let config: Config = deserialize_tracked(json).unwrap();
+    assert_eq!(config.name, "test");
+    assert_eq!(config.count, 42);
+}
+
+#[test]
+fn test_valid_nested_structure() {
+    #[derive(Deserialize, Debug)]
+    struct Inner {
+        value: String,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct Outer {
+        inner: Inner,
+        count: i32,
+    }
+
+    let json = r#"{"inner": {"value": "hello"}, "count": 10}"#;
+    let outer: Outer = deserialize_tracked(json).unwrap();
+    assert_eq!(outer.inner.value, "hello");
+    assert_eq!(outer.count, 10);
+}
+
+#[test]
+fn test_valid_array() {
+    let json = r#"[1, 2, 3, 4, 5]"#;
+    let vec: Vec<i32> = deserialize_tracked(json).unwrap();
+    assert_eq!(vec, vec![1, 2, 3, 4, 5]);
+}
+
+#[test]
+fn test_valid_map() {
+    let json = r#"{"a": 1, "b": 2, "c": 3}"#;
+    let map: std::collections::HashMap<String, i32> = deserialize_tracked(json).unwrap();
+    assert_eq!(map.get("a"), Some(&1));
+    assert_eq!(map.get("b"), Some(&2));
+    assert_eq!(map.get("c"), Some(&3));
+}

--- a/crates/arena-serde/tests/ui.rs
+++ b/crates/arena-serde/tests/ui.rs
@@ -1,8 +1,7 @@
 // trybuild runs cargo, which Miri cannot do.
 #[test]
 #[cfg_attr(miri, ignore)]
-fn tests() {
+fn ui() {
     let t = trybuild::TestCases::new();
-    t.pass("tests/01-parse.rs");
-    t.compile_fail("tests/compile-fail/*.rs");
+    t.compile_fail("tests/ui/*.rs");
 }

--- a/crates/arena-serde/tests/ui/enum_two_other.rs
+++ b/crates/arena-serde/tests/ui/enum_two_other.rs
@@ -1,0 +1,11 @@
+use arena_serde::ArenaDeserialize;
+
+#[derive(ArenaDeserialize)]
+enum Kind {
+    #[arena(other)]
+    First,
+    #[arena(other)]
+    Second,
+}
+
+fn main() {}

--- a/crates/arena-serde/tests/ui/enum_two_other.stderr
+++ b/crates/arena-serde/tests/ui/enum_two_other.stderr
@@ -1,0 +1,6 @@
+error: Only one variant can have the `other` attribute
+ --> tests/ui/enum_two_other.rs:7:5
+  |
+7 | /     #[arena(other)]
+8 | |     Second,
+  | |__________^

--- a/crates/arena-serde/tests/ui/enum_with_data.rs
+++ b/crates/arena-serde/tests/ui/enum_with_data.rs
@@ -1,0 +1,9 @@
+use arena_serde::ArenaDeserialize;
+
+#[derive(ArenaDeserialize)]
+enum Shape<'bump> {
+    Circle,
+    Label(&'bump str),
+}
+
+fn main() {}

--- a/crates/arena-serde/tests/ui/enum_with_data.stderr
+++ b/crates/arena-serde/tests/ui/enum_with_data.stderr
@@ -1,0 +1,5 @@
+error: ArenaDeserialize supports only unit variants in enums. Implement ArenaDeserialize by hand for enums that carry data.
+ --> tests/ui/enum_with_data.rs:6:5
+  |
+6 |     Label(&'bump str),
+  |     ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Stacked on #267.

Copy pdx-tools/pdx-tools@dbbad96 `src/bumpalo-serde` and `src/bumpalo-serde-derive` into `crates/arena-serde` and `crates/arena-serde-derive`, with the changes the architecture note asks for in §06:

- **Rename** to `arena-serde` / `arena-serde-derive`. `arena-serde` is free on crates.io (`arena-allocator` is taken). Both stay `publish = false` until the API settles.
- **`arena_serde::Arena` alias.** Every signature in the library and in derive-generated code names the alias rather than `bumpalo::Bump`; the bumpalo collections are re-exported as `ArenaString` and `ArenaVec`. A change of allocator is one line plus the allocation primitives.
- **Trait-based dispatch in the derive**, as upstream has since pdx-tools@2beb2f8. The derive no longer guesses per field by string matching the type. Every field goes through `ArenaDeserialize`, whether or not the struct has a lifetime parameter, so `#[arena(default, alias)]` apply uniformly; owned types implement the trait by forwarding to `Deserialize`. A `&'bump T` field puts the nested value in the arena (recursive models without `Box`, from pdx-tools@dd67cec). Unit enums derive with `#[arena(rename_all, rename, other)]`; an enum with data-carrying variants is a compile error (trybuild ui test) and needs a hand written impl.
- Replace the `&'bump [u8]` impl and `SliceDeserializer` with one `&'bump [T]` impl, so `Option<&'bump [T]>` and newtypes over slices work like any other field. Add `[T; N]` and `()` passthroughs.
- Factor the four copies of the impl-generics setup into one helper.
- CI: added to the clippy, cross-platform test, and miri jobs.

The allocator generalization over `allocator_api2` is deliberately **not** done, per the note's "deferred" decision.

Consumers in pdx-tools need one mechanical change when they switch to this crate: `bumpalo_serde` → `arena_serde` (and `SliceDeserializer<T>` → `ArenaSeed<&[T]>`). The models themselves are unchanged from pdx-tools master.

Verified locally: `cargo test -p arena-serde -p arena-serde-derive` (unit, `derive_enum`, `tracked_deserializer`, ui, doctests), clippy `-D warnings`, and `cargo miri test -p arena-serde --lib --test tracked_deserializer --test derive_enum` under `-Zmiri-tree-borrows`.
