### PR TITLE
Add eu5save to the workspace

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,6 +99,7 @@ jobs:
         - { crate: hoi4save, game: hoi4 }
         - { crate: imperator-save, game: imperator }
         - { crate: vic3save, game: vic3 }
+        - { crate: eu5save, game: eu5 }
     steps:
     - uses: actions/checkout@v7
     - name: Install Rust
@@ -142,6 +143,7 @@ jobs:
         - { crate: hoi4save, game: hoi4 }
         - { crate: imperator-save, game: imperator }
         - { crate: vic3save, game: vic3 }
+        - { crate: eu5save, game: eu5 }
     env:
       PDX_TOKENS_DIR: ${{ github.workspace }}/.tokens/tokens
       PDX_FIXTURES_LOG: ${{ github.workspace }}/fixtures.log
@@ -258,3 +260,4 @@ jobs:
         cargo fuzz build fuzz_hoi4
         cargo fuzz build fuzz_imperator
         cargo fuzz build fuzz_vic3
+        cargo fuzz build fuzz_eu5

--- a/crates/eu5save/Cargo.toml
+++ b/crates/eu5save/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "eu5save"
+version = "0.1.0"
+authors.workspace = true
+edition = "2024"
+license.workspace = true
+readme = "README.md"
+repository.workspace = true
+publish = false
+description = "Ergonomically work with Europa Universalis V saves (debug and ironman)"
+keywords = ["eu5", "ironman"]
+categories = ["parsing"]
+
+[dependencies]
+arena-serde = { path = "../arena-serde" }
+bumpalo = { workspace = true }
+jomini = { workspace = true, features = ["envelope"] }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+tsify = { version = "0.5.6", default-features = false, features = ["js"] }
+wasm-bindgen = { version = "0.2.118", default-features = false }
+
+[dev-dependencies]
+pdx-fixtures = { workspace = true }
+highway = { workspace = true }
+rstest = "0.26.1"

--- a/crates/eu5save/LICENSE.txt
+++ b/crates/eu5save/LICENSE.txt
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/eu5save/README.md
+++ b/crates/eu5save/README.md
@@ -1,0 +1,36 @@
+![ci](https://github.com/rakaly/jomini/workflows/ci/badge.svg)
+
+# EU5 Save
+
+EU5 Save is a library to ergonomically work with Europa Universalis V (EU5) saves (ironman + debug).
+
+Save models are deserialized into an arena through [arena-serde](../arena-serde), so a whole save is freed in constant time when the arena drops.
+
+```rust,ignore
+use arena_serde::{Arena, ArenaDeserialize};
+use eu5save::{models::Gamestate, BasicTokenResolver, Eu5File, SaveContentKind, SaveResolver};
+
+let file = std::fs::File::open("assets/saves/eu5/debug-1.0.eu5").unwrap();
+let file = Eu5File::from_file(file).unwrap();
+let arena = Arena::new();
+
+// Ironman saves need a token resolver. The data to construct one is not
+// distributed here.
+let tokens = std::fs::read("assets/tokens/eu5.txt").unwrap();
+let resolver = BasicTokenResolver::from_text_lines(tokens.as_slice()).unwrap();
+
+let save = match file.gamestate().unwrap() {
+    SaveContentKind::Text(mut txt) => {
+        Gamestate::deserialize_in_arena(&mut txt.deserializer(), &arena).unwrap()
+    }
+    SaveContentKind::Binary(mut bin) => {
+        let resolver = SaveResolver::from_file(&file, &resolver).unwrap();
+        Gamestate::deserialize_in_arena(&mut bin.deserializer(&resolver), &arena).unwrap()
+    }
+};
+println!("{}", save.metadata.date.game_fmt());
+```
+
+## Ironman
+
+Ironman saves are supported through a provided `TokenResolver`. Per PDS counsel, the data to construct such a `TokenResolver` is not distributed here.

--- a/crates/eu5save/src/binary.rs
+++ b/crates/eu5save/src/binary.rs
@@ -1,0 +1,1279 @@
+//! The EU5 binary format.
+//!
+//! EU5 does not write the same binary format as the other Clausewitz games:
+//!
+//! - Nearly every key and string value in the body of a save is an index into
+//!   a per save string table (the `string_lookup` zip entry) and not a game
+//!   token. A 1.4 gamestate holds 28 game tokens and 13 million lookups.
+//! - Almost every number is a variable width fixed point lexeme with five
+//!   decimal places, and not an IEEE double.
+//! - From SAV03 a color is the lookup string `rgb` followed by a block of
+//!   channels. An older save writes a dedicated `RGB` lexeme.
+//!
+//! [`Eu5BinaryFormat`] decodes these lexemes. It takes the place of the
+//! general purpose format that jomini supplies, so that the hot paths can be
+//! written for the lexemes that EU5 writes.
+//!
+//! The header version of a save does say which lexemes to expect. Measured
+//! over the gamestate of one save of each generation:
+//!
+//! | Header | Save | Keys | Numbers | Colors |
+//! | --- | --- | --- | --- | --- |
+//! | 1 | 1.0.0 | 3.8M game tokens, no lookup | 2.6M `F64` | `RGB` lexeme |
+//! | 2 | 1.3.11 | 10.4M game tokens, 3.2M lookups | 7.6M fixed point | `RGB` lexeme |
+//! | 3 | 1.4 | 28 game tokens, 13.7M lookups | 6.7M fixed point | `rgb` lookup |
+//!
+//! The format does not branch on the version, because a format that accepts
+//! every lexeme costs nothing more. Each decision reads one table that maps a
+//! lexeme to its [`Class`], so a lexeme that a generation never writes is only
+//! an unused row. A version parameter would instead double the code of the
+//! deserializer, which this crate also compiles to wasm.
+
+use crate::Eu5Flavor;
+use jomini::{
+    Encoding, Error, ParserSource,
+    binary::{
+        BinaryFlavor, BinaryFormat, BinaryFormatContext, BinarySourceExt, FailedResolveStrategy,
+        LexemeId, PdxVisitor, TokenResolver,
+    },
+};
+use serde::de::Error as _;
+use std::borrow::Cow;
+
+/// What a lexeme means.
+///
+/// The class fits in a byte so that one table read replaces a chain of
+/// comparisons against three dozen lexeme ids.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum Class {
+    /// A game token. The id is the whole value.
+    Token,
+    Open,
+    Close,
+    Equal,
+    /// A length prefixed string.
+    Str,
+    EmptyStr,
+    U32,
+    I32,
+    U64,
+    I64,
+    F32,
+    F64,
+    Bool,
+    Rgb,
+    /// An index into the string table, in one, two, three, or four bytes.
+    Lookup1,
+    Lookup2,
+    Lookup3,
+    Lookup4,
+    /// A fixed point number with five decimal places. The id holds the width
+    /// and the sign of the payload.
+    Fixed5,
+}
+
+/// The largest lexeme that EU5 writes. Anything above it is a game token.
+const MAX_LEXEME: usize = LexemeId::STR_SAV03.0 as usize;
+
+/// The class of every lexeme that EU5 writes.
+static CLASSES: [Class; MAX_LEXEME + 1] = {
+    let mut t = [Class::Token; MAX_LEXEME + 1];
+    t[LexemeId::OPEN.0 as usize] = Class::Open;
+    t[LexemeId::CLOSE.0 as usize] = Class::Close;
+    t[LexemeId::EQUAL.0 as usize] = Class::Equal;
+    t[LexemeId::QUOTED.0 as usize] = Class::Str;
+    t[LexemeId::UNQUOTED.0 as usize] = Class::Str;
+    t[LexemeId::STR_SAV03.0 as usize] = Class::Str;
+    t[LexemeId::EMPTY_STRING.0 as usize] = Class::EmptyStr;
+    t[LexemeId::U32.0 as usize] = Class::U32;
+    t[LexemeId::I32.0 as usize] = Class::I32;
+    t[LexemeId::U64.0 as usize] = Class::U64;
+    t[LexemeId::I64.0 as usize] = Class::I64;
+    t[LexemeId::F32.0 as usize] = Class::F32;
+    t[LexemeId::F64.0 as usize] = Class::F64;
+    t[LexemeId::BOOL.0 as usize] = Class::Bool;
+    t[LexemeId::RGB.0 as usize] = Class::Rgb;
+    t[LexemeId::LOOKUP_U8.0 as usize] = Class::Lookup1;
+    t[LexemeId::LOOKUP_U8_ALT.0 as usize] = Class::Lookup1;
+    t[LexemeId::LOOKUP_U8_SAV03.0 as usize] = Class::Lookup1;
+    t[LexemeId::LOOKUP_U16.0 as usize] = Class::Lookup2;
+    t[LexemeId::LOOKUP_U16_ALT.0 as usize] = Class::Lookup2;
+    t[LexemeId::LOOKUP_U16_SAV03.0 as usize] = Class::Lookup2;
+    t[LexemeId::LOOKUP_U24.0 as usize] = Class::Lookup3;
+    t[LexemeId::LOOKUP_U24_ALT.0 as usize] = Class::Lookup3;
+    t[LexemeId::LOOKUP_U24_SAV03.0 as usize] = Class::Lookup3;
+    t[LexemeId::LOOKUP_U32.0 as usize] = Class::Lookup4;
+    t[LexemeId::LOOKUP_U32_ALT.0 as usize] = Class::Lookup4;
+    t[LexemeId::LOOKUP_U32_SAV03.0 as usize] = Class::Lookup4;
+
+    let mut offset = 0;
+    while offset <= LexemeId::FIXED5_I56.0 - LexemeId::FIXED5_ZERO.0 {
+        t[(LexemeId::FIXED5_ZERO.0 + offset) as usize] = Class::Fixed5;
+        offset += 1;
+    }
+    t
+};
+
+/// The payload length of every fixed width EU5 lexeme.
+///
+/// A zero entry is a lexeme with no payload, or a lexeme whose payload has a
+/// variable length and needs a branch of its own: a string or an `RGB` block.
+/// The skip loop reads this table by lexeme id, so it is kept separate from
+/// [`CLASSES`].
+static PAYLOAD_SIZES: [u8; MAX_LEXEME + 1] = {
+    let mut t = [0u8; MAX_LEXEME + 1];
+    t[LexemeId::U32.0 as usize] = 4;
+    t[LexemeId::I32.0 as usize] = 4;
+    t[LexemeId::F32.0 as usize] = 4;
+    t[LexemeId::BOOL.0 as usize] = 1;
+    t[LexemeId::U64.0 as usize] = 8;
+    t[LexemeId::I64.0 as usize] = 8;
+    t[LexemeId::F64.0 as usize] = 8;
+    t[LexemeId::LOOKUP_U8.0 as usize] = 1;
+    t[LexemeId::LOOKUP_U8_ALT.0 as usize] = 1;
+    t[LexemeId::LOOKUP_U8_SAV03.0 as usize] = 1;
+    t[LexemeId::LOOKUP_U16.0 as usize] = 2;
+    t[LexemeId::LOOKUP_U16_ALT.0 as usize] = 2;
+    t[LexemeId::LOOKUP_U16_SAV03.0 as usize] = 2;
+    t[LexemeId::LOOKUP_U24.0 as usize] = 3;
+    t[LexemeId::LOOKUP_U24_ALT.0 as usize] = 3;
+    t[LexemeId::LOOKUP_U24_SAV03.0 as usize] = 3;
+    t[LexemeId::LOOKUP_U32.0 as usize] = 4;
+    t[LexemeId::LOOKUP_U32_ALT.0 as usize] = 4;
+    t[LexemeId::LOOKUP_U32_SAV03.0 as usize] = 4;
+
+    // A fixed point lexeme carries its width in its id: the first holds a zero
+    // with no payload, then one to seven bytes of magnitude, then the same
+    // widths again for a negative value.
+    let mut offset = 0;
+    while offset <= LexemeId::FIXED5_I56.0 - LexemeId::FIXED5_ZERO.0 {
+        let width = if offset > 7 { offset - 7 } else { offset };
+        t[(LexemeId::FIXED5_ZERO.0 + offset) as usize] = width as u8;
+        offset += 1;
+    }
+    t
+};
+
+#[inline]
+fn class(id: LexemeId) -> Class {
+    match CLASSES.get(id.0 as usize) {
+        Some(class) => *class,
+        None => Class::Token,
+    }
+}
+
+#[inline]
+fn payload_size(id: LexemeId) -> usize {
+    match PAYLOAD_SIZES.get(id.0 as usize) {
+        Some(size) => *size as usize,
+        None => 0,
+    }
+}
+
+/// The width and the sign of a fixed point lexeme.
+///
+/// Only call it for a lexeme of class [`Class::Fixed5`].
+#[inline]
+fn fixed5(id: LexemeId) -> (usize, bool) {
+    let offset = id.0.wrapping_sub(LexemeId::FIXED5_ZERO.0);
+    let negative = offset > 7;
+    let width = if negative { offset - 7 } else { offset };
+    (usize::from(width), negative)
+}
+
+/// Build the little endian `i64` of a fixed point value from the eight bytes
+/// that follow its lexeme, of which only the first `width` belong to it.
+#[inline]
+fn fixed5_value(data: [u8; 8], width: usize, negative: bool) -> [u8; 8] {
+    // A mask takes the magnitude without a variable length copy. The width is
+    // never more than seven, so the shift is always in range.
+    let mask = (1u64 << (width * 8)) - 1;
+    let magnitude = (u64::from_le_bytes(data) & mask) as i64;
+    let sign = 1i64 - i64::from(negative) * 2;
+    (magnitude * sign).to_le_bytes()
+}
+
+#[inline]
+fn read_fixed5(source: &mut ParserSource<'_>, id: LexemeId) -> Result<[u8; 8], Error> {
+    let (width, negative) = fixed5(id);
+    let mut data = [0u8; 8];
+    data[..width].copy_from_slice(source.take_bytes(width)?);
+    Ok(fixed5_value(data, width, negative))
+}
+
+/// Read the index of a lookup whose class is already known.
+#[inline]
+fn read_lookup(source: &mut ParserSource<'_>, class: Class) -> Result<u32, Error> {
+    match class {
+        Class::Lookup1 => Ok(u32::from(source.take::<1>()?[0])),
+        Class::Lookup2 => Ok(u32::from(u16::from_le_bytes(*source.take::<2>()?))),
+        Class::Lookup3 => {
+            let b = source.take::<3>()?;
+            Ok(u32::from_le_bytes([b[0], b[1], b[2], 0]))
+        }
+        _ => Ok(u32::from_le_bytes(*source.take::<4>()?)),
+    }
+}
+
+/// The lowest lookup lexeme. Every lookup is within 32 of it, so one 32 bit
+/// mask answers whether a lexeme is a lookup without a table read.
+const LOOKUP_BASE: u16 = LexemeId::LOOKUP_U16.0;
+
+const LOOKUP_MASK: u32 = {
+    let ids = [
+        LexemeId::LOOKUP_U8,
+        LexemeId::LOOKUP_U8_ALT,
+        LexemeId::LOOKUP_U8_SAV03,
+        LexemeId::LOOKUP_U16,
+        LexemeId::LOOKUP_U16_ALT,
+        LexemeId::LOOKUP_U16_SAV03,
+        LexemeId::LOOKUP_U24,
+        LexemeId::LOOKUP_U24_ALT,
+        LexemeId::LOOKUP_U24_SAV03,
+        LexemeId::LOOKUP_U32,
+        LexemeId::LOOKUP_U32_ALT,
+        LexemeId::LOOKUP_U32_SAV03,
+    ];
+
+    let mut mask = 0u32;
+    let mut i = 0;
+    while i < ids.len() {
+        mask |= 1 << (ids[i].0 - LOOKUP_BASE);
+        i += 1;
+    }
+    mask
+};
+
+/// Whether the lexeme holds an index into the string table of the save.
+#[inline]
+const fn is_lookup_id(id: LexemeId) -> bool {
+    let offset = id.0.wrapping_sub(LOOKUP_BASE);
+    offset < 32 && (LOOKUP_MASK >> offset) & 1 == 1
+}
+
+/// Whether the lexeme holds a length prefixed string.
+#[inline]
+const fn is_str_id(id: LexemeId) -> bool {
+    matches!(
+        id,
+        LexemeId::QUOTED | LexemeId::UNQUOTED | LexemeId::STR_SAV03
+    )
+}
+
+/// Whether the lexeme holds a fixed point number.
+#[inline]
+const fn is_fixed5_id(id: LexemeId) -> bool {
+    id.0 >= LexemeId::FIXED5_ZERO.0 && id.0 <= LexemeId::FIXED5_I56.0
+}
+
+#[cold]
+fn unexpected_structural(source: &ParserSource<'_>) -> Error {
+    Error::custom(format_args!(
+        "unexpected structural token at offset {}",
+        source.position()
+    ))
+}
+
+/// The value of [`Eu5BinaryFormat::rgb_index`] when the save has no `rgb` entry
+/// in its string table. No real index can collide with it, because a table
+/// never holds four billion entries.
+const NO_RGB: u32 = u32::MAX;
+
+/// The EU5 binary format.
+///
+/// Create one for each save and hand it to a
+/// [`BinaryFormatDeserializer`](jomini::binary::BinaryFormatDeserializer).
+#[derive(Debug, Clone)]
+pub struct Eu5BinaryFormat<'res, RES> {
+    resolver: &'res RES,
+    flavor: Eu5Flavor,
+    on_failed_resolve: FailedResolveStrategy,
+    rgb_index: u32,
+}
+
+impl<'res, RES> Eu5BinaryFormat<'res, RES>
+where
+    RES: TokenResolver,
+{
+    /// Create a format that ignores a token it cannot resolve.
+    pub fn new(resolver: &'res RES) -> Self {
+        Self::with_failed_resolve(resolver, FailedResolveStrategy::Ignore)
+    }
+
+    /// Create a format with a given behavior for a token it cannot resolve.
+    pub fn with_failed_resolve(
+        resolver: &'res RES,
+        on_failed_resolve: FailedResolveStrategy,
+    ) -> Self {
+        Self {
+            resolver,
+            flavor: Eu5Flavor::new(),
+            on_failed_resolve,
+            rgb_index: find_rgb(resolver),
+        }
+    }
+
+    #[inline]
+    fn resolve_token<'de, V>(&self, token: u16, visitor: V) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        match self.resolver.resolve(token) {
+            Some(id) => visitor.visit_str(id),
+            None => self.unresolved(u32::from(token), visitor),
+        }
+    }
+
+    #[inline]
+    fn resolve_lookup<'de, V>(&self, index: u32, visitor: V) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        match self.resolver.lookup(index) {
+            Some(value) => visitor.visit_str(value),
+            None => self.unresolved(index, visitor),
+        }
+    }
+
+    #[cold]
+    fn unresolved<'de, V>(&self, id: u32, visitor: V) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        match self.on_failed_resolve {
+            FailedResolveStrategy::Error => Err(Error::custom(format_args!(
+                "unable to resolve binary id: 0x{id:x}"
+            ))),
+            FailedResolveStrategy::Stringify => visitor.visit_string(format!("0x{id:x}")),
+            FailedResolveStrategy::Ignore => {
+                visitor.visit_borrowed_str("__internal_identifier_ignore")
+            }
+        }
+    }
+}
+
+/// Find the index of `rgb` in the string table of the save, so that a color
+/// costs no string comparison while the body is read.
+///
+/// A table holds tens of thousands of entries against the tens of millions of
+/// lookups in the body, so one scan is free.
+fn find_rgb(resolver: &impl TokenResolver) -> u32 {
+    let mut index = 0u32;
+    while let Some(value) = resolver.lookup(index) {
+        if value == "rgb" {
+            return index;
+        }
+        index += 1;
+    }
+
+    NO_RGB
+}
+
+/// An identifier that the fast path read from the window.
+enum FastIdentifier {
+    /// An index into the string table of the save.
+    Lookup(u32),
+    /// A game token.
+    Token(u16),
+}
+
+/// Read an identifier that fits in the window, without the general dispatch.
+///
+/// A key is a game token or a lookup and nothing else. Over 95% of the keys of
+/// a 1.4 save are an 8 or 16 bit lookup, and nearly every key of an older
+/// save is a game token, so both earn a path that takes the lexeme and its
+/// payload from one window chunk.
+#[inline]
+fn read_fast_identifier(source: &mut ParserSource<'_>) -> Option<FastIdentifier> {
+    let d = *source.window().first_chunk::<4>()?;
+    let id = LexemeId::new(u16::from_le_bytes([d[0], d[1]]));
+    match class(id) {
+        Class::Token => {
+            source.advance(2);
+            Some(FastIdentifier::Token(id.0))
+        }
+        Class::Lookup2 => {
+            source.advance(4);
+            Some(FastIdentifier::Lookup(u32::from(u16::from_le_bytes([
+                d[2], d[3],
+            ]))))
+        }
+        Class::Lookup1 => {
+            source.advance(3);
+            Some(FastIdentifier::Lookup(u32::from(d[2])))
+        }
+        _ => None,
+    }
+}
+
+impl<RES> Eu5BinaryFormat<'_, RES>
+where
+    RES: TokenResolver,
+{
+    /// Decode the value that `id` names, reading its payload from the source.
+    ///
+    /// `COLOR` asks for the SAV03 color: the lookup string `rgb` followed by
+    /// a block of channels. Only an untyped value can be one, so the key and
+    /// the string paths use `false` and pay nothing for it.
+    #[inline]
+    fn dispatch<'de, V, const COLOR: bool>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        id: LexemeId,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let class = class(id);
+        match class {
+            Class::Lookup1 | Class::Lookup2 | Class::Lookup3 | Class::Lookup4 => {
+                let (format, source) = cx.parts();
+                let index = read_lookup(source, class)?;
+                if COLOR
+                    && index == format.rgb_index
+                    && source.peek_lexeme_id()? == Some(LexemeId::OPEN)
+                {
+                    return visitor.visit_rgb(source.read_rgb()?);
+                }
+                format.resolve_lookup(index, visitor)
+            }
+            Class::Fixed5 => {
+                let (format, source) = cx.parts();
+                let data = read_fixed5(source, id)?;
+                visitor.visit_f64(format.flavor.visit_f64(data))
+            }
+            Class::U32 => visitor.visit_u32(u32::from_le_bytes(*cx.source().take::<4>()?)),
+            Class::I32 => visitor.visit_i32(i32::from_le_bytes(*cx.source().take::<4>()?)),
+            Class::Str => {
+                let (format, source) = cx.parts();
+                let data = source.read_bstr()?;
+                match format.flavor.decode(data) {
+                    Cow::Borrowed(x) => visitor.visit_str(x),
+                    Cow::Owned(x) => visitor.visit_string(x),
+                }
+            }
+            Class::EmptyStr => visitor.visit_borrowed_str(""),
+            Class::Bool => visitor.visit_bool(cx.source().take::<1>()?[0] != 0),
+            Class::U64 => visitor.visit_u64(u64::from_le_bytes(*cx.source().take::<8>()?)),
+            Class::I64 => visitor.visit_i64(i64::from_le_bytes(*cx.source().take::<8>()?)),
+            Class::F64 => {
+                let (format, source) = cx.parts();
+                let data = *source.take::<8>()?;
+                visitor.visit_f64(format.flavor.visit_f64(data))
+            }
+            Class::F32 => {
+                let (format, source) = cx.parts();
+                let data = *source.take::<4>()?;
+                visitor.visit_f32(format.flavor.visit_f32(data))
+            }
+            Class::Rgb => visitor.visit_rgb(cx.source().read_rgb()?),
+            Class::Open => cx.visit_open_seq(visitor),
+            Class::Close | Class::Equal => Err(unexpected_structural(cx.source())),
+            Class::Token => cx.format().resolve_token(id.0, visitor),
+        }
+    }
+}
+
+impl<RES> BinaryFormat for Eu5BinaryFormat<'_, RES>
+where
+    RES: TokenResolver,
+{
+    #[inline]
+    fn decode_scalar<'a>(&self, data: &'a [u8]) -> Cow<'a, str> {
+        self.flavor.decode(data)
+    }
+
+    fn skip_value(cx: &mut BinaryFormatContext<'_, '_, Self>) -> Result<(), Error> {
+        let rgb_index = cx.format().rgb_index;
+        skip(cx.source(), rgb_index)
+    }
+
+    #[inline]
+    fn deserialize_identifier<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let (format, source) = cx.parts();
+        match read_fast_identifier(source) {
+            Some(FastIdentifier::Lookup(index)) => return format.resolve_lookup(index, visitor),
+            Some(FastIdentifier::Token(token)) => return format.resolve_token(token, visitor),
+            None => {}
+        }
+
+        let id = cx.source().read_lexeme_id()?;
+        Self::dispatch::<V, false>(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_str<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let (format, source) = cx.parts();
+        let id = source.read_lexeme_id()?;
+        if is_str_id(id) {
+            let data = source.read_bstr()?;
+            return match format.flavor.decode(data) {
+                Cow::Borrowed(x) => visitor.visit_str(x),
+                Cow::Owned(x) => visitor.visit_string(x),
+            };
+        }
+
+        Self::dispatch::<V, false>(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_bytes<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let source = cx.source();
+        let id = source.read_lexeme_id()?;
+        if is_str_id(id) {
+            return visitor.visit_bytes(source.read_bstr()?);
+        }
+
+        Self::dispatch::<V, false>(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_f64<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        // A fixed point lexeme is the common number of an EU5 save: a 1.4
+        // gamestate holds 6.7 million of them against 16 doubles. An older
+        // save is the other way around, so both get a path out of the window.
+        let (format, source) = cx.parts();
+        if let Some(d) = source.window().first_chunk::<10>().copied() {
+            let id = LexemeId::new(u16::from_le_bytes([d[0], d[1]]));
+            let payload = [d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9]];
+            if id == LexemeId::F64 {
+                let value = format.flavor.visit_f64(payload);
+                source.advance(10);
+                return visitor.visit_f64(value);
+            }
+
+            if is_fixed5_id(id) {
+                let (width, negative) = fixed5(id);
+                let value = format
+                    .flavor
+                    .visit_f64(fixed5_value(payload, width, negative));
+                source.advance(2 + width);
+                return visitor.visit_f64(value);
+            }
+        }
+
+        let id = source.read_lexeme_id()?;
+        Self::dispatch::<V, false>(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_u32<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let source = cx.source();
+        if let Some(d) = source.window().first_chunk::<6>()
+            && LexemeId::new(u16::from_le_bytes([d[0], d[1]])) == LexemeId::U32
+        {
+            let value = u32::from_le_bytes([d[2], d[3], d[4], d[5]]);
+            source.advance(6);
+            return visitor.visit_u32(value);
+        }
+
+        let id = source.read_lexeme_id()?;
+        if is_lookup_id(id) {
+            return visitor.visit_u32(read_lookup(source, class(id))?);
+        }
+
+        Self::dispatch::<V, false>(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_i32<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let source = cx.source();
+        if let Some(d) = source.window().first_chunk::<6>()
+            && LexemeId::new(u16::from_le_bytes([d[0], d[1]])) == LexemeId::I32
+        {
+            let value = i32::from_le_bytes([d[2], d[3], d[4], d[5]]);
+            source.advance(6);
+            return visitor.visit_i32(value);
+        }
+
+        let id = source.read_lexeme_id()?;
+        Self::dispatch::<V, false>(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_u64<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let source = cx.source();
+        if let Some(d) = source.window().first_chunk::<10>()
+            && LexemeId::new(u16::from_le_bytes([d[0], d[1]])) == LexemeId::U64
+        {
+            let value = u64::from_le_bytes([d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9]]);
+            source.advance(10);
+            return visitor.visit_u64(value);
+        }
+
+        let id = source.read_lexeme_id()?;
+        Self::dispatch::<V, false>(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_i64<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let source = cx.source();
+        if let Some(d) = source.window().first_chunk::<10>()
+            && LexemeId::new(u16::from_le_bytes([d[0], d[1]])) == LexemeId::I64
+        {
+            let value = i64::from_le_bytes([d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9]]);
+            source.advance(10);
+            return visitor.visit_i64(value);
+        }
+
+        let id = source.read_lexeme_id()?;
+        Self::dispatch::<V, false>(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_bool<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let source = cx.source();
+        if let Some(d) = source.window().first_chunk::<3>()
+            && LexemeId::new(u16::from_le_bytes([d[0], d[1]])) == LexemeId::BOOL
+        {
+            let value = d[2] != 0;
+            source.advance(3);
+            return visitor.visit_bool(value);
+        }
+
+        let id = source.read_lexeme_id()?;
+        Self::dispatch::<V, false>(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_f32<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        let id = cx.source().read_lexeme_id()?;
+        Self::dispatch::<V, false>(cx, id, visitor)
+    }
+
+    #[inline]
+    fn deserialize_any<'de, V>(
+        cx: &mut BinaryFormatContext<'_, 'de, Self>,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: PdxVisitor<'de>,
+    {
+        // An untyped value is the only place a SAV03 color can arrive,
+        // because a color asks for a sequence and the deserializer sends a
+        // value that does not open a container here.
+        let id = cx.source().read_lexeme_id()?;
+        Self::dispatch::<V, true>(cx, id, visitor)
+    }
+}
+
+/// Skip the next value, container and all.
+///
+/// A save holds large subtrees that no model reads, so this is one of the
+/// hottest paths of a parse.
+fn skip(source: &mut ParserSource<'_>, rgb_index: u32) -> Result<(), Error> {
+    let id = source.read_lexeme_id()?;
+    if id == LexemeId::OPEN {
+        return skip_container(source);
+    }
+
+    // From SAV03 a color is the lookup string `rgb` followed by a separate
+    // block of channels. The string and the block are one value, so a
+    // skip that stops after the string leaves the block to be read as the next
+    // key.
+    if is_lookup_id(id) {
+        let index = read_lookup(source, class(id))?;
+        if index == rgb_index && source.peek_lexeme_id()? == Some(LexemeId::OPEN) {
+            source.take::<2>()?;
+            return skip_container(source);
+        }
+        return Ok(());
+    }
+
+    skip_payload(source, id)
+}
+
+/// Skip the rest of a container whose opening delimiter is already read.
+fn skip_container(source: &mut ParserSource<'_>) -> Result<(), Error> {
+    // The fast loop walks the current window with a local cursor, so that
+    // skipping a lexeme is register arithmetic. Sending the source pointer
+    // through memory for every lexeme dominated the instruction count of this
+    // loop.
+    let mut depth = 1u32;
+    loop {
+        // The borrow of the window ends with this statement, so the source can
+        // be advanced below. The source never changes while `base` is read, so
+        // the pointer stays valid.
+        let base = source.window().as_ptr();
+        let len = source.window_len();
+        let mut i = 0usize;
+
+        // A ten byte tail margin means a lexeme id and its largest fixed
+        // payload are always in bounds, so the loop needs no bounds check.
+        while i + 10 <= len {
+            // SAFETY: `i + 10 <= len` from the loop condition.
+            let id = LexemeId::new(u16::from_le_bytes(unsafe {
+                [*base.add(i), *base.add(i + 1)]
+            }));
+            match class(id) {
+                Class::Open => {
+                    i += 2;
+                    depth += 1;
+                }
+                Class::Close => {
+                    i += 2;
+                    depth -= 1;
+                    if depth == 0 {
+                        // SAFETY: `i <= len`.
+                        unsafe { source.advance_unchecked(i) };
+                        return Ok(());
+                    }
+                }
+                Class::Str => {
+                    // Layout: [id:2][len:2][bytes:len]. The length is in bounds
+                    // through the margin, the bytes may not be, and then the
+                    // careful path below takes over. Skipping a string here
+                    // rather than leaving the loop is what keeps a string heavy
+                    // subtree out of a refill for every string.
+                    // SAFETY: `i + 4 <= len` from the margin.
+                    let str_len =
+                        u16::from_le_bytes(unsafe { [*base.add(i + 2), *base.add(i + 3)] })
+                            as usize;
+                    let total = 4 + str_len;
+                    if i + total > len {
+                        break;
+                    }
+                    i += total;
+                }
+                // Rare and variable width. The careful path handles it.
+                Class::Rgb => break,
+                _ => i += 2 + payload_size(id),
+            }
+        }
+
+        // Commit what the fast loop consumed, then take one careful step over
+        // the window boundary.
+        // SAFETY: `i <= len`.
+        unsafe { source.advance_unchecked(i) };
+        source.refill()?;
+        skip_step(source, &mut depth)?;
+        if depth == 0 {
+            return Ok(());
+        }
+    }
+}
+
+#[cold]
+fn skip_step(source: &mut ParserSource<'_>, depth: &mut u32) -> Result<(), Error> {
+    let id = source.read_lexeme_id()?;
+    match id {
+        LexemeId::OPEN => {
+            *depth += 1;
+            Ok(())
+        }
+        LexemeId::CLOSE => {
+            *depth -= 1;
+            Ok(())
+        }
+        _ => skip_payload(source, id),
+    }
+}
+
+/// Skip the payload of one lexeme that does not open or close a container.
+fn skip_payload(source: &mut ParserSource<'_>, id: LexemeId) -> Result<(), Error> {
+    match id {
+        LexemeId::QUOTED | LexemeId::UNQUOTED | LexemeId::STR_SAV03 => {
+            source.read_bstr()?;
+            Ok(())
+        }
+        LexemeId::RGB => source.read_rgb().map(|_| ()),
+        // A const size take for each width keeps this off the variable length
+        // path, because a save skips millions of scalars.
+        _ => match payload_size(id) {
+            0 => Ok(()),
+            1 => source.take::<1>().map(|_| ()).map_err(Error::from),
+            2 => source.take::<2>().map(|_| ()).map_err(Error::from),
+            3 => source.take::<3>().map(|_| ()).map_err(Error::from),
+            4 => source.take::<4>().map(|_| ()).map_err(Error::from),
+            5 => source.take::<5>().map(|_| ()).map_err(Error::from),
+            6 => source.take::<6>().map(|_| ()).map_err(Error::from),
+            7 => source.take::<7>().map(|_| ()).map_err(Error::from),
+            _ => source.take::<8>().map(|_| ()).map_err(Error::from),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jomini::binary::{BinaryFormatDeserializer, Rgb};
+    use serde::Deserialize;
+
+    /// A resolver for the string table only, like the body of a SAV03 save,
+    /// where nearly every key and string value is a lookup.
+    struct LookupResolver(&'static [&'static str]);
+
+    impl TokenResolver for LookupResolver {
+        fn resolve(&self, _token: u16) -> Option<&str> {
+            None
+        }
+
+        fn lookup(&self, index: u32) -> Option<&str> {
+            self.0.get(index as usize).copied()
+        }
+    }
+
+    fn id(lexeme: LexemeId) -> [u8; 2] {
+        lexeme.0.to_le_bytes()
+    }
+
+    /// A 16 bit lookup, the form that holds most of a SAV03 save.
+    fn lookup16(index: u16) -> Vec<u8> {
+        let mut out = Vec::from(id(LexemeId::LOOKUP_U16_SAV03));
+        out.extend_from_slice(&index.to_le_bytes());
+        out
+    }
+
+    fn u32_value(value: u32) -> Vec<u8> {
+        let mut out = Vec::from(id(LexemeId::U32));
+        out.extend_from_slice(&value.to_le_bytes());
+        out
+    }
+
+    fn from_binary<'de, T: Deserialize<'de>>(
+        data: &'de [u8],
+        resolver: &'de LookupResolver,
+    ) -> Result<T, Error> {
+        BinaryFormatDeserializer::from_slice(data, Eu5BinaryFormat::new(resolver)).deserialize()
+    }
+
+    /// Every lexeme is either a class that EU5 writes or a game token, and the
+    /// payload table must agree with the class about which lexemes have a fixed
+    /// width payload.
+    #[test]
+    fn class_and_payload_agree() {
+        for raw in 0..=u16::MAX {
+            let lexeme = LexemeId::new(raw);
+            let size = payload_size(lexeme);
+            match class(lexeme) {
+                Class::Token | Class::Open | Class::Close | Class::Equal | Class::EmptyStr => {
+                    assert_eq!(size, 0, "0x{raw:04x} must have no payload")
+                }
+                // A string and a color carry a length that the id does not hold.
+                Class::Str | Class::Rgb => assert_eq!(size, 0, "0x{raw:04x} is variable width"),
+                Class::Lookup1 => assert_eq!(size, 1),
+                Class::Lookup2 => assert_eq!(size, 2),
+                Class::Lookup3 => assert_eq!(size, 3),
+                Class::Lookup4 => assert_eq!(size, 4),
+                Class::Bool => assert_eq!(size, 1),
+                Class::U32 | Class::I32 | Class::F32 => assert_eq!(size, 4),
+                Class::U64 | Class::I64 | Class::F64 => assert_eq!(size, 8),
+                Class::Fixed5 => {
+                    let (width, _) = fixed5(lexeme);
+                    assert_eq!(size, width, "0x{raw:04x} fixed point width");
+                    assert!(width <= 7);
+                }
+            }
+        }
+    }
+
+    /// The mask that the hot paths use must say the same as the class table.
+    #[test]
+    fn lookup_mask_matches_the_class_table() {
+        for raw in 0..=u16::MAX {
+            let lexeme = LexemeId::new(raw);
+            let by_class = matches!(
+                class(lexeme),
+                Class::Lookup1 | Class::Lookup2 | Class::Lookup3 | Class::Lookup4
+            );
+            assert_eq!(is_lookup_id(lexeme), by_class, "0x{raw:04x}");
+            assert_eq!(
+                is_str_id(lexeme),
+                class(lexeme) == Class::Str,
+                "0x{raw:04x}"
+            );
+            assert_eq!(
+                is_fixed5_id(lexeme),
+                class(lexeme) == Class::Fixed5,
+                "0x{raw:04x}"
+            );
+        }
+    }
+
+    /// The fixed point lexemes hold a value with five decimal places, and the
+    /// width and the sign come from the id.
+    #[test]
+    fn fixed_point_widths() {
+        assert_eq!(fixed5(LexemeId::FIXED5_ZERO), (0, false));
+        assert_eq!(fixed5(LexemeId::FIXED5_U8), (1, false));
+        assert_eq!(fixed5(LexemeId::FIXED5_U56), (7, false));
+        assert_eq!(fixed5(LexemeId::FIXED5_I8), (1, true));
+        assert_eq!(fixed5(LexemeId::FIXED5_I56), (7, true));
+    }
+
+    #[test]
+    fn deserialize_fixed_point() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Data {
+            zero: f64,
+            small: f64,
+            large: f64,
+            negative: f64,
+        }
+
+        let resolver = LookupResolver(&["zero", "small", "large", "negative"]);
+        let mut data = Vec::new();
+        data.extend_from_slice(&lookup16(0));
+        data.extend_from_slice(&id(LexemeId::EQUAL));
+        data.extend_from_slice(&id(LexemeId::FIXED5_ZERO));
+        data.extend_from_slice(&lookup16(1));
+        data.extend_from_slice(&id(LexemeId::EQUAL));
+        data.extend_from_slice(&id(LexemeId::FIXED5_U8));
+        data.push(100);
+        data.extend_from_slice(&lookup16(2));
+        data.extend_from_slice(&id(LexemeId::EQUAL));
+        data.extend_from_slice(&id(LexemeId::FIXED5_U24));
+        data.extend_from_slice(&[0x40, 0x42, 0x0f]);
+        data.extend_from_slice(&lookup16(3));
+        data.extend_from_slice(&id(LexemeId::EQUAL));
+        data.extend_from_slice(&id(LexemeId::FIXED5_I16));
+        data.extend_from_slice(&1000u16.to_le_bytes());
+
+        let actual: Data = from_binary(&data, &resolver).unwrap();
+        assert_eq!(
+            actual,
+            Data {
+                zero: 0.0,
+                small: 0.001,
+                large: 10.0,
+                negative: -0.01,
+            }
+        );
+    }
+
+    /// From SAV03 a color is the lookup string `rgb` and a block of channels,
+    /// where an older save writes the `RGB` lexeme.
+    #[test]
+    fn color_from_a_lookup_header() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Data {
+            color: (u32, u32, u32),
+        }
+
+        let resolver = LookupResolver(&["color", "rgb"]);
+        let mut data = Vec::new();
+        data.extend_from_slice(&lookup16(0));
+        data.extend_from_slice(&id(LexemeId::EQUAL));
+        data.extend_from_slice(&lookup16(1));
+        data.extend_from_slice(&id(LexemeId::OPEN));
+        data.extend_from_slice(&u32_value(187));
+        data.extend_from_slice(&u32_value(180));
+        data.extend_from_slice(&u32_value(0));
+        data.extend_from_slice(&id(LexemeId::CLOSE));
+
+        let actual: Data = from_binary(&data, &resolver).unwrap();
+        assert_eq!(
+            actual,
+            Data {
+                color: (187, 180, 0)
+            }
+        );
+    }
+
+    /// A color block belongs to the value that the `rgb` string starts, so a
+    /// skip over an unread color must take the block with it. Without this the
+    /// block becomes the next key.
+    #[test]
+    fn skip_over_a_color_header() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Data {
+            after: u32,
+        }
+
+        let resolver = LookupResolver(&["color2", "rgb", "after"]);
+        let mut data = Vec::new();
+        data.extend_from_slice(&lookup16(0));
+        data.extend_from_slice(&id(LexemeId::EQUAL));
+        data.extend_from_slice(&lookup16(1));
+        data.extend_from_slice(&id(LexemeId::OPEN));
+        data.extend_from_slice(&u32_value(234));
+        data.extend_from_slice(&u32_value(234));
+        data.extend_from_slice(&u32_value(234));
+        data.extend_from_slice(&id(LexemeId::CLOSE));
+        data.extend_from_slice(&lookup16(2));
+        data.extend_from_slice(&id(LexemeId::EQUAL));
+        data.extend_from_slice(&u32_value(7));
+
+        let actual: Data = from_binary(&data, &resolver).unwrap();
+        assert_eq!(actual, Data { after: 7 });
+    }
+
+    /// The string `rgb` on its own is still a string. Only a block after it
+    /// makes it a color.
+    #[test]
+    fn a_plain_rgb_string_is_not_a_color() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Data {
+            name: String,
+        }
+
+        let resolver = LookupResolver(&["name", "rgb"]);
+        let mut data = Vec::new();
+        data.extend_from_slice(&lookup16(0));
+        data.extend_from_slice(&id(LexemeId::EQUAL));
+        data.extend_from_slice(&lookup16(1));
+
+        let actual: Data = from_binary(&data, &resolver).unwrap();
+        assert_eq!(
+            actual,
+            Data {
+                name: String::from("rgb")
+            }
+        );
+    }
+
+    /// An older save writes a color as the `RGB` lexeme, and the format must
+    /// still read it.
+    #[test]
+    fn color_from_the_rgb_lexeme() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Data {
+            color: (u32, u32, u32),
+        }
+
+        let resolver = LookupResolver(&["color"]);
+        let mut data = Vec::new();
+        data.extend_from_slice(&lookup16(0));
+        data.extend_from_slice(&id(LexemeId::EQUAL));
+        data.extend_from_slice(&id(LexemeId::RGB));
+        data.extend_from_slice(&id(LexemeId::OPEN));
+        data.extend_from_slice(&u32_value(1));
+        data.extend_from_slice(&u32_value(2));
+        data.extend_from_slice(&u32_value(3));
+        data.extend_from_slice(&id(LexemeId::CLOSE));
+
+        let actual: Data = from_binary(&data, &resolver).unwrap();
+        assert_eq!(actual, Data { color: (1, 2, 3) });
+    }
+
+    /// A save with no `rgb` entry must not take any index for a color.
+    #[test]
+    fn a_save_without_a_color_header() {
+        let resolver = LookupResolver(&["alpha", "beta"]);
+        assert_eq!(find_rgb(&resolver), NO_RGB);
+
+        let resolver = LookupResolver(&["alpha", "rgb", "beta"]);
+        assert_eq!(find_rgb(&resolver), 1);
+    }
+
+    /// A skip must step over every lexeme that EU5 writes, whatever its width.
+    #[test]
+    fn skip_every_width() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Data {
+            after: u32,
+        }
+
+        let resolver = LookupResolver(&["ignored", "after", "text"]);
+        let widths: Vec<Vec<u8>> = vec![
+            {
+                let mut x = Vec::from(id(LexemeId::BOOL));
+                x.push(1);
+                x
+            },
+            u32_value(5),
+            {
+                let mut x = Vec::from(id(LexemeId::I64));
+                x.extend_from_slice(&(-5i64).to_le_bytes());
+                x
+            },
+            {
+                let mut x = Vec::from(id(LexemeId::QUOTED));
+                x.extend_from_slice(&4u16.to_le_bytes());
+                x.extend_from_slice(b"text");
+                x
+            },
+            {
+                let mut x = Vec::from(id(LexemeId::FIXED5_U40));
+                x.extend_from_slice(&[1, 2, 3, 4, 5]);
+                x
+            },
+            {
+                let mut x = Vec::from(id(LexemeId::RGB));
+                x.extend_from_slice(&id(LexemeId::OPEN));
+                x.extend_from_slice(&u32_value(1));
+                x.extend_from_slice(&u32_value(2));
+                x.extend_from_slice(&u32_value(3));
+                x.extend_from_slice(&id(LexemeId::CLOSE));
+                x
+            },
+            lookup16(2),
+        ];
+
+        for width in widths {
+            let mut data = Vec::new();
+            data.extend_from_slice(&lookup16(0));
+            data.extend_from_slice(&id(LexemeId::EQUAL));
+            data.extend_from_slice(&width);
+            data.extend_from_slice(&lookup16(1));
+            data.extend_from_slice(&id(LexemeId::EQUAL));
+            data.extend_from_slice(&u32_value(9));
+
+            let actual: Data = from_binary(&data, &resolver).unwrap();
+            assert_eq!(actual, Data { after: 9 }, "skipping {width:02x?}");
+        }
+    }
+
+    /// A skip must also step over a whole subtree.
+    #[test]
+    fn skip_a_container() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Data {
+            after: u32,
+        }
+
+        let resolver = LookupResolver(&["ignored", "after", "inner"]);
+        let mut data = Vec::new();
+        data.extend_from_slice(&lookup16(0));
+        data.extend_from_slice(&id(LexemeId::EQUAL));
+        data.extend_from_slice(&id(LexemeId::OPEN));
+        data.extend_from_slice(&lookup16(2));
+        data.extend_from_slice(&id(LexemeId::EQUAL));
+        data.extend_from_slice(&id(LexemeId::OPEN));
+        data.extend_from_slice(&u32_value(1));
+        data.extend_from_slice(&id(LexemeId::CLOSE));
+        data.extend_from_slice(&id(LexemeId::CLOSE));
+        data.extend_from_slice(&lookup16(1));
+        data.extend_from_slice(&id(LexemeId::EQUAL));
+        data.extend_from_slice(&u32_value(3));
+
+        let actual: Data = from_binary(&data, &resolver).unwrap();
+        assert_eq!(actual, Data { after: 3 });
+    }
+
+    /// An unresolved lookup must be an error when the caller asks for one.
+    #[test]
+    fn unresolved_lookup() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Data {
+            name: String,
+        }
+
+        let resolver = LookupResolver(&["name"]);
+        let mut data = Vec::new();
+        data.extend_from_slice(&lookup16(0));
+        data.extend_from_slice(&id(LexemeId::EQUAL));
+        data.extend_from_slice(&lookup16(9));
+
+        let format = Eu5BinaryFormat::with_failed_resolve(&resolver, FailedResolveStrategy::Error);
+        let result: Result<Data, Error> =
+            BinaryFormatDeserializer::from_slice(&data, format).deserialize();
+        result.unwrap_err();
+
+        let format =
+            Eu5BinaryFormat::with_failed_resolve(&resolver, FailedResolveStrategy::Stringify);
+        let actual: Data = BinaryFormatDeserializer::from_slice(&data, format)
+            .deserialize()
+            .unwrap();
+        assert_eq!(
+            actual,
+            Data {
+                name: String::from("0x9")
+            }
+        );
+    }
+
+    /// The fixed point reader and the window fast path must agree.
+    #[test]
+    fn fixed_point_value_matches_the_slow_path() {
+        for raw in LexemeId::FIXED5_ZERO.0..=LexemeId::FIXED5_I56.0 {
+            let lexeme = LexemeId::new(raw);
+            let (width, negative) = fixed5(lexeme);
+            let payload = [1u8, 2, 3, 4, 5, 6, 7, 8];
+            let fast = fixed5_value(payload, width, negative);
+
+            let mut stream = Vec::from(id(lexeme));
+            stream.extend_from_slice(&payload[..width]);
+            let mut source = ParserSource::from_slice(&stream);
+            let read = source.read_lexeme_id().unwrap();
+            let slow = read_fixed5(&mut source, read).unwrap();
+            assert_eq!(fast, slow, "0x{raw:04x}");
+        }
+    }
+
+    /// A color block can carry a fourth alpha channel, as `color3` and
+    /// `unit_color2` do.
+    #[test]
+    fn rgb_with_an_alpha_channel() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&lookup16(0));
+        data.extend_from_slice(&id(LexemeId::OPEN));
+        data.extend_from_slice(&u32_value(1));
+        data.extend_from_slice(&u32_value(2));
+        data.extend_from_slice(&u32_value(3));
+        data.extend_from_slice(&u32_value(4));
+        data.extend_from_slice(&id(LexemeId::CLOSE));
+
+        let mut source = ParserSource::from_slice(&data[4..]);
+        assert_eq!(
+            source.read_rgb().unwrap(),
+            Rgb {
+                r: 1,
+                g: 2,
+                b: 3,
+                a: Some(4)
+            }
+        );
+    }
+}

--- a/crates/eu5save/src/date.rs
+++ b/crates/eu5save/src/date.rs
@@ -1,0 +1,277 @@
+use arena_serde::ArenaDeserialize;
+use jomini::common::{DateError, DateFormat, PdsDate, PdsDateFormatter, RawDate};
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{self, Visitor},
+};
+use std::fmt::{self, Debug};
+
+/// A date in EU5 format
+///
+/// All years are common years (i.e. no leap years).
+///
+/// In-game hours are between 08:00 and 19:00, inclusive. Hours are serialized
+/// in save files with the hour divided by 2 and added to 8. This means only
+/// even hour components (0, 2, 4, 6, ..., 22) are valid in the game format.
+///
+/// Some examples of how in-game hours are serialized in the game format.
+///
+/// - 08:00 → no hour component
+/// - 09:00 → hour component 2  
+/// - 10:00 → hour component 4
+/// - 11:00 → hour component 6
+/// - 19:00 → hour component 22
+///
+/// ```
+/// # use eu5save::Eu5Date;
+/// # use jomini::common::PdsDate;
+///
+/// let test_cases = [
+///     ("1444.11.11", "1444-11-11T08"),      // 08:00 in-game
+///     ("1444.11.11.2", "1444-11-11T09"),    // 09:00 in-game  
+///     ("1444.11.11.4", "1444-11-11T10"),    // 10:00 in-game
+///     ("1444.11.11.22", "1444-11-11T19"),   // 19:00 in-game
+/// ];
+///
+/// for (input, expected_iso) in test_cases {
+///     let date = Eu5Date::parse(input).unwrap();
+///     assert_eq!(date.iso_8601().to_string(), expected_iso);
+/// }
+/// ```
+///
+/// The game format is for roundtrip compatibility with the game.
+///
+/// ```
+/// # use eu5save::Eu5Date;
+/// # use jomini::common::PdsDate;
+///
+/// let test_cases = [
+///     ("1444.11.11", 8),       // 08:00 in-game
+///     ("1444.11.11.2", 9),     // 09:00 in-game
+///     ("1444.11.11.4", 10),    // 10:00 in-game
+///     ("1444.11.11.22", 19),   // 19:00 in-game
+/// ];
+///
+/// for (input, expected_hour) in test_cases {
+///     let date = Eu5Date::parse(input).unwrap();
+///     assert_eq!(date.hour(), expected_hour);
+///     // Game format preserves original input
+///     assert_eq!(date.game_fmt().to_string(), input);
+///     // Roundtrip equivalence
+///     let roundtrip = Eu5Date::parse(date.game_fmt().to_string()).unwrap();
+///     assert_eq!(date, roundtrip);
+/// }
+/// ```
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Eu5Date {
+    raw: RawDate,
+}
+
+impl Debug for Eu5Date {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Eu5Date({})", self.game_fmt())
+    }
+}
+
+impl Eu5Date {
+    fn from_raw(raw: RawDate) -> Option<Self> {
+        const DAYS_PER_MONTH: [u8; 13] = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+        let days = DAYS_PER_MONTH[usize::from(raw.month())];
+        if raw.day() > days {
+            return None;
+        }
+
+        if raw.hour() > 22 {
+            return None;
+        }
+
+        Some(Self { raw })
+    }
+
+    #[inline]
+    pub fn parse<T: AsRef<[u8]>>(s: T) -> Result<Self, DateError> {
+        let date = RawDate::parse(s)?;
+        Self::from_raw(date).ok_or(DateError)
+    }
+
+    #[inline]
+    pub fn from_binary(s: i32) -> Option<Self> {
+        RawDate::from_binary(s).and_then(Self::from_raw)
+    }
+
+    #[inline]
+    pub fn from_binary_heuristic(s: i32) -> Option<Self> {
+        let date = RawDate::from_binary(s)?;
+        if date.hour() % 2 == 1 {
+            return None;
+        }
+
+        if date.year() <= -100 {
+            return None;
+        }
+
+        Self::from_raw(date)
+    }
+
+    #[inline]
+    pub fn hour(&self) -> u8 {
+        // Convert game format hour component to in-game hour
+        // Game format: 0 = 08:00, 2 = 09:00, 4 = 10:00, ..., 22 = 19:00
+        self.raw.hour() / 2 + 8
+    }
+
+    /// Format only the date components (year, month, day) without hour
+    pub fn date_fmt(&self) -> PdsDateFormatter {
+        let date_only_raw =
+            RawDate::from_ymdh(self.raw.year(), self.raw.month(), self.raw.day(), 0);
+        PdsDateFormatter::new(date_only_raw, DateFormat::Iso8601)
+    }
+}
+
+impl PdsDate for Eu5Date {
+    #[inline]
+    fn year(&self) -> i16 {
+        self.raw.year()
+    }
+
+    #[inline]
+    fn month(&self) -> u8 {
+        self.raw.month()
+    }
+
+    #[inline]
+    fn day(&self) -> u8 {
+        self.raw.day()
+    }
+
+    fn iso_8601(&self) -> PdsDateFormatter {
+        // Use the same conversion as the hour() method, but add 1 for ISO formatter
+        // (ISO formatter shows hour-1, so we need hour+1 to get the right output)
+        let in_game_hour = self.hour() + 1;
+        let iso_raw = RawDate::from_ymdh(
+            self.raw.year(),
+            self.raw.month(),
+            self.raw.day(),
+            in_game_hour,
+        );
+
+        PdsDateFormatter::new(iso_raw, DateFormat::Iso8601)
+    }
+
+    fn game_fmt(&self) -> PdsDateFormatter {
+        // We store the game format internally, so just use it directly
+        PdsDateFormatter::new(self.raw, DateFormat::DotShort)
+    }
+}
+
+impl Serialize for Eu5Date {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.iso_8601().to_string().as_str())
+    }
+}
+
+struct DateVisitor;
+
+impl Visitor<'_> for DateVisitor {
+    type Value = Eu5Date;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a date")
+    }
+
+    fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Eu5Date::from_binary(v)
+            .ok_or_else(|| de::Error::custom(format!("invalid binary date: {v}")))
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Eu5Date::parse(v.as_bytes()).map_err(|_| de::Error::custom(format!("invalid date: {v}")))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.visit_str(v.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Eu5Date {
+    fn deserialize<D>(deserializer: D) -> Result<Eu5Date, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(DateVisitor)
+    }
+}
+
+impl<'bump> ArenaDeserialize<'bump> for Eu5Date {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump arena_serde::Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Eu5Date doesn't need arena allocation, so we can just use the standard deserializer
+        Self::deserialize(deserializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_date_fmt() {
+        let test_cases = [
+            ("1444.11.11", "1444-11-11"),    // No hour component
+            ("1444.11.11.2", "1444-11-11"),  // 09:00 in-game -> date only
+            ("1444.11.11.4", "1444-11-11"),  // 10:00 in-game -> date only
+            ("1444.11.11.22", "1444-11-11"), // 19:00 in-game -> date only
+            ("1500.1.1", "1500-01-01"),      // Single digit month/day
+            ("1500.12.31", "1500-12-31"),    // End of year
+        ];
+
+        for (input, expected_date_fmt) in test_cases {
+            let date = Eu5Date::parse(input).unwrap();
+            assert_eq!(
+                date.date_fmt().to_string(),
+                expected_date_fmt,
+                "date_fmt() for input '{}' should return '{}'",
+                input,
+                expected_date_fmt
+            );
+        }
+    }
+
+    #[test]
+    fn test_date_fmt_vs_game_fmt() {
+        let test_cases = [
+            ("1444.11.11", "1444.11.11"),
+            ("1444.11.11.2", "1444.11.11.2"),
+            ("1444.11.11.4", "1444.11.11.4"),
+            ("1444.11.11.22", "1444.11.11.22"),
+        ];
+
+        for (input, expected_game_fmt) in test_cases {
+            let date = Eu5Date::parse(input).unwrap();
+            let date_only = date.date_fmt().to_string();
+            let game_full = date.game_fmt().to_string();
+
+            // date_fmt should always strip hour component
+            assert_eq!(date_only, "1444-11-11");
+            // game_fmt should preserve original format
+            assert_eq!(game_full, expected_game_fmt);
+        }
+    }
+}

--- a/crates/eu5save/src/errors.rs
+++ b/crates/eu5save/src/errors.rs
@@ -1,0 +1,65 @@
+use std::io;
+
+#[derive(thiserror::Error, Debug)]
+#[error(transparent)]
+pub struct Eu5Error(#[from] Box<Eu5ErrorKind>);
+
+impl Eu5Error {
+    pub(crate) fn new(kind: Eu5ErrorKind) -> Eu5Error {
+        Eu5Error(Box::new(kind))
+    }
+
+    /// Return the specific type of error
+    pub fn kind(&self) -> &Eu5ErrorKind {
+        &self.0
+    }
+}
+
+impl From<io::Error> for Eu5Error {
+    fn from(value: io::Error) -> Self {
+        Eu5Error::from(Eu5ErrorKind::from(value))
+    }
+}
+
+impl From<jomini::Error> for Eu5Error {
+    fn from(value: jomini::Error) -> Self {
+        Eu5Error::from(Eu5ErrorKind::from(value))
+    }
+}
+
+impl From<jomini::binary::ReaderError> for Eu5Error {
+    fn from(value: jomini::binary::ReaderError) -> Self {
+        Eu5Error::from(Eu5ErrorKind::from(value))
+    }
+}
+
+/// Specific type of error
+#[derive(thiserror::Error, Debug)]
+pub enum Eu5ErrorKind {
+    #[error("invalid header")]
+    InvalidHeader,
+
+    #[error("parser error: {0}")]
+    Jomini(#[from] jomini::Error),
+
+    #[error("file envelope error: {0}")]
+    Envelope(#[from] jomini::envelope::EnvelopeError),
+
+    #[error("binary reader error: {0}")]
+    BinaryReader(#[from] jomini::binary::ReaderError),
+
+    #[error("io error: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("unknown token: 0x{token_id:x}")]
+    UnknownToken { token_id: u16 },
+
+    #[error("unknown lookup: 0x{lookup_id:x}")]
+    UnknownLookup { lookup_id: u32 },
+}
+
+impl From<Eu5ErrorKind> for Eu5Error {
+    fn from(err: Eu5ErrorKind) -> Self {
+        Eu5Error::new(err)
+    }
+}

--- a/crates/eu5save/src/file.rs
+++ b/crates/eu5save/src/file.rs
@@ -1,0 +1,342 @@
+use crate::{Eu5BinaryFormat, Eu5Error, Eu5ErrorKind, MeltOptions, melt};
+use jomini::{
+    Encoding, Utf8Encoding,
+    binary::{BinaryFlavor, BinaryFormatDeserializer, TokenResolver},
+    text::de::TextReaderDeserializer,
+};
+use serde::de::DeserializeOwned;
+use std::io::{Read, Write};
+
+pub use jomini::envelope::JominiFile as Eu5File;
+pub use jomini::envelope::*;
+
+/// Type alias for Eu5 text deserializer
+///
+/// A lazy way to avoid the need to reimplement deserializer
+pub type Eu5TextDeserializer<'r> = TextReaderDeserializer<'r, Utf8Encoding>;
+pub type Eu5BinaryDeserializer<'r, 'res, RES> =
+    BinaryFormatDeserializer<'r, Eu5BinaryFormat<'res, RES>>;
+
+pub trait Eu5BinaryDeserialization {
+    fn deserializer<'res, RES: TokenResolver>(
+        &mut self,
+        resolver: &'res RES,
+    ) -> Eu5BinaryDeserializer<'_, 'res, RES>;
+}
+
+impl<R: ReaderAt> Eu5BinaryDeserialization for &'_ SaveData<BinaryEncoding, R> {
+    fn deserializer<'res, RES: TokenResolver>(
+        &mut self,
+        resolver: &'res RES,
+    ) -> Eu5BinaryDeserializer<'_, 'res, RES> {
+        BinaryFormatDeserializer::from_reader(self.body().cursor(), Eu5BinaryFormat::new(resolver))
+    }
+}
+
+impl<R: Read> Eu5BinaryDeserialization for SaveContent<BinaryEncoding, R> {
+    fn deserializer<'res, RES: TokenResolver>(
+        &mut self,
+        resolver: &'res RES,
+    ) -> Eu5BinaryDeserializer<'_, 'res, RES> {
+        BinaryFormatDeserializer::from_reader(self, Eu5BinaryFormat::new(resolver))
+    }
+}
+
+impl<R: Read> Eu5BinaryDeserialization for SaveMetadata<BinaryEncoding, R> {
+    fn deserializer<'res, RES: TokenResolver>(
+        &mut self,
+        resolver: &'res RES,
+    ) -> Eu5BinaryDeserializer<'_, 'res, RES> {
+        BinaryFormatDeserializer::from_reader(self, Eu5BinaryFormat::new(resolver))
+    }
+}
+
+pub trait Eu5Melt {
+    fn melt<Resolver, Writer>(
+        &mut self,
+        options: MeltOptions,
+        resolver: Resolver,
+        output: Writer,
+    ) -> Result<melt::MeltedDocument, Eu5Error>
+    where
+        Resolver: TokenResolver,
+        Writer: Write;
+}
+
+pub trait Eu5TextMelt {
+    fn melt<Writer>(&mut self, output: Writer) -> Result<melt::MeltedDocument, Eu5Error>
+    where
+        Writer: Write;
+}
+
+impl<R: ReaderAt> Eu5Melt for &'_ Eu5File<R> {
+    fn melt<Resolver, Writer>(
+        &mut self,
+        options: MeltOptions,
+        resolver: Resolver,
+        mut output: Writer,
+    ) -> Result<melt::MeltedDocument, Eu5Error>
+    where
+        Resolver: TokenResolver,
+        Writer: Write,
+    {
+        match self.kind() {
+            JominiFileKind::Uncompressed(SaveDataKind::Text(x)) => (&mut (&*x)).melt(output),
+            JominiFileKind::Uncompressed(SaveDataKind::Binary(x)) => melt::melt(
+                &mut x.body().cursor(),
+                &mut output,
+                resolver,
+                options,
+                self.header().clone(),
+            ),
+            JominiFileKind::Zip(x) => Eu5Melt::melt(&mut (&*x), options, resolver, output),
+        }
+    }
+}
+
+/// Save resolver that takes the save specific string lookup table and layers it
+/// over the EU5 game tokens.
+#[derive(Debug)]
+pub struct SaveResolver<R> {
+    inner: R,
+    string_lookup: Vec<&'static str>,
+    #[expect(dead_code)]
+    lookup_data: Vec<u8>,
+}
+
+impl<R> SaveResolver<R> {
+    pub fn from_file(file: &Eu5File<impl ReaderAt>, inner: R) -> Result<Self, Eu5Error> {
+        match file.kind() {
+            JominiFileKind::Zip(x) => SaveResolver::create(x, inner),
+            _ => Ok(Self {
+                inner,
+                string_lookup: Vec::new(),
+                lookup_data: Vec::new(),
+            }),
+        }
+    }
+
+    pub fn create(file: &JominiZip<impl ReaderAt>, inner: R) -> Result<Self, Eu5Error> {
+        let mut lookup_data = Vec::new();
+        let string_lookup = if file.header().version() >= 2 {
+            file.read_entry("string_lookup")
+                .map_err(Eu5ErrorKind::from)?
+                .read_to_end(&mut lookup_data)?;
+
+            // extend lifetime on lookup data
+            let data = lookup_data.as_slice();
+            let lookup_data: &'static [u8] = unsafe { std::mem::transmute(data) };
+            string_lookup_parse(lookup_data)
+        } else {
+            Vec::new()
+        };
+
+        Ok(Self {
+            inner,
+            string_lookup,
+            lookup_data,
+        })
+    }
+}
+
+impl<R: TokenResolver> TokenResolver for SaveResolver<R> {
+    fn resolve(&self, token: u16) -> Option<&str> {
+        self.inner.resolve(token)
+    }
+
+    fn lookup(&self, index: u32) -> Option<&str> {
+        self.string_lookup.get(index as usize).copied()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+}
+
+impl<R: ReaderAt> Eu5Melt for &'_ JominiZip<R> {
+    fn melt<Resolver, Writer>(
+        &mut self,
+        options: MeltOptions,
+        resolver: Resolver,
+        mut output: Writer,
+    ) -> Result<melt::MeltedDocument, Eu5Error>
+    where
+        Resolver: TokenResolver,
+        Writer: Write,
+    {
+        let resolver = SaveResolver::create(self, resolver)?;
+        match self.gamestate().map_err(Eu5ErrorKind::from)? {
+            SaveContentKind::Text(mut save_body) => {
+                let mut new_header = self.header().clone();
+                new_header.set_kind(SaveHeaderKind::Text);
+                new_header.write(&mut output)?;
+                std::io::copy(&mut save_body, &mut output)?;
+                Ok(melt::MeltedDocument::new())
+            }
+            SaveContentKind::Binary(mut save_body) => melt::melt(
+                &mut save_body,
+                &mut output,
+                resolver,
+                options,
+                self.header().clone(),
+            ),
+        }
+    }
+}
+
+impl<R: Read> Eu5Melt for SaveMetadataKind<R> {
+    fn melt<Resolver, Writer>(
+        &mut self,
+        options: MeltOptions,
+        resolver: Resolver,
+        output: Writer,
+    ) -> Result<melt::MeltedDocument, Eu5Error>
+    where
+        Resolver: TokenResolver,
+        Writer: Write,
+    {
+        match self {
+            SaveMetadataKind::Text(x) => x.melt(output),
+            SaveMetadataKind::Binary(x) => x.melt(options, resolver, output),
+        }
+    }
+}
+
+impl<R: ReaderAt> Eu5TextMelt for &'_ SaveData<TextEncoding, R> {
+    fn melt<Writer>(&mut self, mut output: Writer) -> Result<melt::MeltedDocument, Eu5Error>
+    where
+        Writer: Write,
+    {
+        let mut new_header = self.header().clone();
+        new_header.set_kind(SaveHeaderKind::Text);
+        new_header.write(&mut output)?;
+        std::io::copy(&mut self.body().cursor(), &mut output)?;
+        Ok(melt::MeltedDocument::new())
+    }
+}
+
+impl<R: Read> Eu5TextMelt for SaveMetadata<TextEncoding, R> {
+    fn melt<Writer>(&mut self, mut output: Writer) -> Result<melt::MeltedDocument, Eu5Error>
+    where
+        Writer: Write,
+    {
+        let mut new_header = self.header().clone();
+        new_header.set_kind(SaveHeaderKind::Text);
+        new_header.write(&mut output)?;
+        std::io::copy(self, &mut output)?;
+        Ok(melt::MeltedDocument::new())
+    }
+}
+
+impl<R: Read> Eu5Melt for SaveMetadata<BinaryEncoding, R> {
+    fn melt<Resolver, Writer>(
+        &mut self,
+        options: MeltOptions,
+        resolver: Resolver,
+        output: Writer,
+    ) -> Result<melt::MeltedDocument, Eu5Error>
+    where
+        Resolver: TokenResolver,
+        Writer: Write,
+    {
+        let header = self.header().clone();
+        melt::melt(self, output, resolver, options, header)
+    }
+}
+
+pub trait DeserializeEu5 {
+    fn deserialize<T>(&mut self, resolver: impl TokenResolver) -> Result<T, Eu5Error>
+    where
+        T: DeserializeOwned;
+}
+
+impl<R: ReaderAt> DeserializeEu5 for &'_ Eu5File<R> {
+    fn deserialize<T>(&mut self, resolver: impl TokenResolver) -> Result<T, Eu5Error>
+    where
+        T: DeserializeOwned,
+    {
+        match self.kind() {
+            JominiFileKind::Uncompressed(SaveDataKind::Text(x)) => {
+                Ok(x.deserializer().deserialize()?)
+            }
+            JominiFileKind::Uncompressed(SaveDataKind::Binary(x)) => {
+                Ok((&*x).deserializer(&resolver).deserialize()?)
+            }
+            JominiFileKind::Zip(x) => Ok(match x.gamestate().map_err(Eu5ErrorKind::Envelope)? {
+                SaveContentKind::Text(mut x) => x.deserializer().deserialize()?,
+                SaveContentKind::Binary(mut x) => x.deserializer(&resolver).deserialize()?,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Eu5Flavor(Utf8Encoding);
+impl Eu5Flavor {
+    pub fn new() -> Self {
+        Eu5Flavor(Utf8Encoding::new())
+    }
+}
+
+impl Default for Eu5Flavor {
+    fn default() -> Self {
+        Eu5Flavor::new()
+    }
+}
+
+impl BinaryFlavor for Eu5Flavor {
+    fn visit_f32(&self, data: [u8; 4]) -> f32 {
+        debug_assert!(false, "first save with f32 data");
+        f32::from_bits(u32::from_le_bytes(data))
+    }
+
+    fn visit_f64(&self, data: [u8; 8]) -> f64 {
+        let x = i64::from_le_bytes(data) as f64;
+        let eps = f64::from(f32::EPSILON);
+        (x + (eps * x.signum())).trunc() / 100_000.0
+    }
+}
+
+impl Encoding for Eu5Flavor {
+    fn decode<'a>(&self, data: &'a [u8]) -> std::borrow::Cow<'a, str> {
+        self.0.decode(data)
+    }
+}
+
+fn string_lookup_parse(mut data: &[u8]) -> Vec<&'_ str> {
+    let mut result = Vec::new();
+    data = data.get(5..).unwrap_or_default();
+
+    while !data.is_empty() {
+        let Some((len, rest)) = data.split_first_chunk::<2>() else {
+            break;
+        };
+        let len = u16::from_le_bytes(*len) as usize;
+        let Some((chunk, rest)) = rest.split_at_checked(len) else {
+            break;
+        };
+
+        result.push(std::str::from_utf8(chunk).unwrap_or_default());
+        data = rest;
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case([3, 176, 63, 231, 0, 0, 0, 0], 38797.10723)]
+    #[case([254, 3, 0, 0, 0, 0, 0, 0], 0.01022)]
+    #[case([85, 98, 0, 0, 0, 0, 0, 0], 0.25173)]
+    #[case([65, 0, 0, 0, 0, 0, 0, 0], 0.00065)]
+    #[case([4, 0, 0, 0, 0, 0, 0, 0], 0.00004)]
+    fn test_flavor_f64(#[case] input: [u8; 8], #[case] expected: f64) {
+        let flavor = Eu5Flavor::new();
+        let result = flavor.visit_f64(input);
+        assert_eq!(expected, result);
+    }
+}

--- a/crates/eu5save/src/hash.rs
+++ b/crates/eu5save/src/hash.rs
@@ -1,0 +1,86 @@
+use std::hash::{BuildHasherDefault, Hasher};
+
+#[derive(Debug)]
+pub struct FnvHasher(u64);
+
+impl Default for FnvHasher {
+    #[inline]
+    fn default() -> FnvHasher {
+        FnvHasher(0xcbf29ce484222325)
+    }
+}
+
+impl Hasher for FnvHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let FnvHasher(mut hash) = *self;
+
+        for byte in bytes.iter() {
+            hash ^= *byte as u64;
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+
+        *self = FnvHasher(hash);
+    }
+}
+
+/// A builder for default FNV hashers.
+pub type FnvBuildHasher = BuildHasherDefault<FnvHasher>;
+
+#[derive(Debug)]
+pub struct FxHasher {
+    hash: u64,
+}
+
+impl Default for FxHasher {
+    #[inline]
+    fn default() -> FxHasher {
+        FxHasher { hash: 0 }
+    }
+}
+
+impl Hasher for FxHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let mut remaining = bytes;
+
+        // Process 8 bytes at once
+        while remaining.len() >= 8 {
+            let chunk = u64::from_ne_bytes([
+                remaining[0],
+                remaining[1],
+                remaining[2],
+                remaining[3],
+                remaining[4],
+                remaining[5],
+                remaining[6],
+                remaining[7],
+            ]);
+            self.hash = self.hash.rotate_left(5) ^ chunk;
+            remaining = &remaining[8..];
+        }
+
+        // Process remaining bytes one by one
+        for byte in remaining {
+            self.hash = self.hash.rotate_left(5) ^ (*byte as u64);
+        }
+    }
+}
+
+/// A builder for default FxHash hashers.
+pub type FxBuildHasher = BuildHasherDefault<FxHasher>;
+pub type FxHashMap<K, V> = std::collections::HashMap<K, V, FxBuildHasher>;
+pub type FxHashSet<K> = std::collections::HashSet<K, FxBuildHasher>;
+
+pub type FnvHashMap<K, V> = std::collections::HashMap<K, V, FnvBuildHasher>;
+pub type FnvHashSet<K> = std::collections::HashSet<K, FnvBuildHasher>;

--- a/crates/eu5save/src/lib.rs
+++ b/crates/eu5save/src/lib.rs
@@ -1,0 +1,14 @@
+mod binary;
+mod date;
+mod errors;
+mod file;
+pub mod hash;
+mod melt;
+pub mod models;
+
+pub use binary::*;
+pub use date::*;
+pub use errors::*;
+pub use file::*;
+pub use jomini::binary::{BasicTokenResolver, FailedResolveStrategy};
+pub use melt::*;

--- a/crates/eu5save/src/melt.rs
+++ b/crates/eu5save/src/melt.rs
@@ -1,0 +1,464 @@
+use crate::{Eu5Date, Eu5Error, Eu5ErrorKind, Eu5Flavor};
+use jomini::{
+    TextWriterBuilder,
+    binary::{self, BinaryFlavor, FailedResolveStrategy, Token, TokenReader, TokenResolver},
+    common::PdsDate,
+    envelope::{SaveHeader, SaveHeaderKind},
+};
+use std::{
+    collections::HashSet,
+    io::{Cursor, Read, Write},
+};
+
+/// Output from melting a binary save to plaintext
+#[derive(Debug, Default)]
+pub struct MeltedDocument {
+    unknown_tokens: HashSet<u16>,
+    unknown_lookups: HashSet<u32>,
+}
+
+impl MeltedDocument {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The list of unknown tokens that the provided resolver accumulated
+    pub fn unknown_tokens(&self) -> &HashSet<u16> {
+        &self.unknown_tokens
+    }
+
+    /// The list of unknown lookups that the provided resolver accumulated
+    pub fn unknown_lookups(&self) -> &HashSet<u32> {
+        &self.unknown_lookups
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MeltOptions {
+    verbatim: bool,
+    on_failed_resolve: FailedResolveStrategy,
+}
+
+impl Default for MeltOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MeltOptions {
+    pub fn new() -> Self {
+        Self {
+            verbatim: false,
+            on_failed_resolve: FailedResolveStrategy::Ignore,
+        }
+    }
+
+    pub fn verbatim(self, verbatim: bool) -> Self {
+        MeltOptions { verbatim, ..self }
+    }
+
+    pub fn on_failed_resolve(self, on_failed_resolve: FailedResolveStrategy) -> Self {
+        MeltOptions {
+            on_failed_resolve,
+            ..self
+        }
+    }
+}
+
+pub(crate) fn melt<Reader, Writer, Resolver>(
+    input: Reader,
+    mut output: Writer,
+    resolver: Resolver,
+    options: MeltOptions,
+    mut header: SaveHeader,
+) -> Result<MeltedDocument, Eu5Error>
+where
+    Reader: Read,
+    Writer: Write,
+    Resolver: TokenResolver,
+{
+    let mut reader = TokenReader::new(input);
+
+    let header_sink = Vec::new();
+    let mut wtr = TextWriterBuilder::new()
+        .indent_char(b'\t')
+        .indent_factor(1)
+        .from_writer(Cursor::new(header_sink));
+
+    let mut doc = MeltedDocument::new();
+
+    inner_melt(&mut reader, &mut wtr, &resolver, options, &mut doc, true)?;
+
+    let mut data = wtr.into_inner().into_inner();
+    data.push(b'\n');
+    header.set_kind(SaveHeaderKind::Text);
+    header.set_metadata_len(data.len() as u64);
+
+    header.write(&mut output)?;
+    output.write_all(&data)?;
+
+    let mut wtr = TextWriterBuilder::new()
+        .indent_char(b'\t')
+        .indent_factor(1)
+        .from_writer(output);
+
+    inner_melt(&mut reader, &mut wtr, &resolver, options, &mut doc, false)?;
+
+    Ok(doc)
+}
+
+/// How to write the value that comes after a given key.
+///
+/// The binary format does not say if a value is a date, an integer, or a
+/// quoted string, so the key gives the hint.
+#[derive(Debug, Default, Clone, Copy)]
+struct KeyHints {
+    date: bool,
+    number: bool,
+    int: bool,
+    quote: bool,
+    unquote: bool,
+}
+
+impl KeyHints {
+    fn for_key(key: &str) -> Self {
+        Self {
+            date: matches!(
+                key,
+                "creation_date" | "date" | "leader_date" | "end_date" | "death_date"
+            ),
+            number: matches!(key, "seed" | "random_count" | "random" | "name_index"),
+            int: matches!(key, "resistance" | "percent" | "utility"),
+            unquote: matches!(key, "locations"),
+            quote: matches!(
+                key,
+                "Adjective"
+                    | "adjective"
+                    | "base"
+                    | "bookmark_key"
+                    | "coa"
+                    | "country_name"
+                    | "custom_name"
+                    | "dna"
+                    | "female_names"
+                    | "first_name"
+                    | "flags"
+                    | "historical"
+                    | "icon"
+                    | "key"
+                    | "last_name"
+                    | "male_names"
+                    | "name_key"
+                    | "name"
+                    | "nickname"
+                    | "original_tag"
+                    | "override_adj"
+                    | "override_name"
+                    | "province_definition"
+                    | "regnal_name"
+                    | "script"
+                    | "tag"
+                    | "title"
+                    | "value"
+            ),
+        }
+    }
+}
+
+fn inner_melt<Writer, Resolver>(
+    reader: &mut TokenReader<'_>,
+    wtr: &mut jomini::TextWriter<Writer>,
+    resolver: Resolver,
+    options: MeltOptions,
+    doc: &mut MeltedDocument,
+    header: bool,
+) -> Result<(), Eu5Error>
+where
+    Writer: Write,
+    Resolver: TokenResolver,
+{
+    let flavor = Eu5Flavor::new();
+    let mut known_quote = false;
+    let mut known_number = false;
+    let mut known_unquote = false;
+    let mut known_date = false;
+    let mut known_int = false;
+
+    // At the start of a container the writer cannot tell an object from an
+    // array, so a string there can be a key or the first array value. Hold it
+    // until the next token says which one it is.
+    let mut pending_lookup: Option<&str> = None;
+
+    let mut has_read = false;
+    while let Some(token) = reader.next()? {
+        has_read = true;
+        if let Some(pending) = pending_lookup.take() {
+            if matches!(token, Token::Equal) {
+                let hints = KeyHints::for_key(pending);
+                known_date = hints.date;
+                known_number = hints.number;
+                known_int = hints.int;
+                known_unquote = hints.unquote;
+                known_quote = hints.quote;
+                wtr.write_unquoted(pending.as_bytes())?;
+            } else if known_quote {
+                wtr.write_quoted(pending.as_bytes())?;
+            } else {
+                wtr.write_unquoted(pending.as_bytes())?;
+            }
+        }
+
+        match token {
+            Token::Id(x) => match resolver.resolve(x) {
+                Some(id) => {
+                    // Skip ironman flag so the game doesn't re-enable it when
+                    // loading the melted save
+                    if id == "ironman" && !options.verbatim {
+                        let mut next = reader.read()?;
+                        if matches!(next, binary::Token::Equal) {
+                            next = reader.read()?;
+                        }
+
+                        if matches!(next, binary::Token::Open) {
+                            reader.skip_container()?;
+                        }
+                        continue;
+                    }
+
+                    let hints = KeyHints::for_key(id);
+                    known_date = hints.date;
+                    known_number = hints.number;
+                    known_int = hints.int;
+                    known_unquote = hints.unquote;
+                    known_quote = hints.quote;
+                    wtr.write_unquoted(id.as_bytes())?;
+                }
+                None => {
+                    known_date = false;
+                    known_number = false;
+                    known_int = false;
+                    known_quote = false;
+                    known_unquote = false;
+                    match options.on_failed_resolve {
+                        FailedResolveStrategy::Error => {
+                            return Err(Eu5ErrorKind::UnknownToken { token_id: x }.into());
+                        }
+                        FailedResolveStrategy::Ignore if wtr.expecting_key() => {
+                            let mut next = reader.read()?;
+                            if matches!(next, Token::Equal) {
+                                next = reader.read()?;
+                            }
+
+                            if matches!(next, Token::Open) {
+                                reader.skip_container()?;
+                            }
+                        }
+                        _ => {
+                            doc.unknown_tokens.insert(x);
+                            let replacement = format!("__unknown_0x{x:x}");
+                            wtr.write_unquoted(replacement.as_bytes())?;
+                        }
+                    }
+                }
+            },
+            Token::Open => wtr.write_start()?,
+            Token::Close => {
+                known_date = false;
+                known_number = false;
+                known_int = false;
+                known_quote = false;
+                known_unquote = false;
+
+                wtr.write_end()?;
+                if header && wtr.depth() == 0 {
+                    wtr.inner().write_all(b"\n")?;
+                    return Ok(());
+                }
+            }
+            Token::Equal => wtr.write_operator(jomini::text::Operator::Equal)?,
+            Token::U32(value) => wtr.write_u32(value)?,
+            Token::U64(value) => wtr.write_u64(value)?,
+            Token::I32(value) => {
+                if known_number {
+                    known_number = false;
+                    wtr.write_i32(value)?;
+                } else if known_date {
+                    known_date = false;
+                    if let Some(date) = Eu5Date::from_binary(value) {
+                        wtr.write_date(date.game_fmt())?;
+                    } else {
+                        wtr.write_i32(value)?;
+                    }
+                } else if let Some(date) = Eu5Date::from_binary_heuristic(value) {
+                    wtr.write_date(date.game_fmt())?;
+                } else {
+                    wtr.write_i32(value)?;
+                }
+            }
+            Token::Bool(value) => wtr.write_bool(value)?,
+            Token::Quoted(scalar) => {
+                if wtr.expecting_key() || known_unquote {
+                    wtr.write_unquoted(scalar.as_bytes())?;
+                } else {
+                    wtr.write_quoted(scalar.as_bytes())?;
+                }
+            }
+            Token::Unquoted(scalar) => wtr.write_unquoted(scalar.as_bytes())?,
+            Token::F32(value) => {
+                let converted = flavor.visit_f32(value);
+                wtr.write_f32(converted)?;
+            }
+            Token::F64(value) => {
+                let mut converted = flavor.visit_f64(value);
+                if known_int {
+                    converted = (converted * 100_000.0).round();
+                    wtr.write_i64(converted as i64)?;
+                } else {
+                    wtr.write_f64(converted)?;
+                }
+            }
+            Token::Rgb(rgb) => wtr.write_rgb(&rgb)?,
+            Token::I64(value) => wtr.write_i64(value)?,
+            Token::Lookup(x) => match resolver.lookup(x) {
+                Some(s) => {
+                    // Most keys in the body of a save come from the string
+                    // lookup table and not from the token table, so a lookup in
+                    // key position must set the same hints as a resolved token.
+                    if wtr.at_unknown_start() {
+                        pending_lookup = Some(s);
+                    } else if wtr.expecting_key() {
+                        let hints = KeyHints::for_key(s);
+                        known_date = hints.date;
+                        known_number = hints.number;
+                        known_int = hints.int;
+                        known_unquote = hints.unquote;
+                        known_quote = hints.quote;
+                        wtr.write_unquoted(s.as_bytes())?
+                    } else if known_quote {
+                        wtr.write_quoted(s.as_bytes())?
+                    } else {
+                        wtr.write_unquoted(s.as_bytes())?
+                    }
+                }
+                None => match options.on_failed_resolve {
+                    FailedResolveStrategy::Error => {
+                        return Err(Eu5ErrorKind::UnknownLookup { lookup_id: x }.into());
+                    }
+                    _ => {
+                        doc.unknown_lookups.insert(x);
+                        let replacement = format!("__id_0x{x:x}");
+                        wtr.write_unquoted(replacement.as_bytes())?;
+                    }
+                },
+            },
+        }
+    }
+
+    if has_read {
+        wtr.inner().write_all(b"\n")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jomini::binary::LexemeId;
+
+    /// A resolver for the string lookup table only, like the body of a SAV03
+    /// save, where nearly every key and string value is a lookup.
+    struct LookupResolver(&'static [&'static str]);
+
+    impl TokenResolver for LookupResolver {
+        fn resolve(&self, _token: u16) -> Option<&str> {
+            None
+        }
+
+        fn lookup(&self, index: u32) -> Option<&str> {
+            self.0.get(index as usize).copied()
+        }
+    }
+
+    fn lookup(index: u16) -> [u8; 4] {
+        let id = LexemeId::LOOKUP_U16_SAV03.0.to_le_bytes();
+        let index = index.to_le_bytes();
+        [id[0], id[1], index[0], index[1]]
+    }
+
+    fn melt_body(data: &[u8], resolver: &LookupResolver) -> String {
+        let mut reader = TokenReader::new(data);
+        let mut wtr = TextWriterBuilder::new()
+            .indent_char(b'\t')
+            .indent_factor(1)
+            .from_writer(Vec::new());
+        let mut doc = MeltedDocument::new();
+        inner_melt(
+            &mut reader,
+            &mut wtr,
+            resolver,
+            MeltOptions::new(),
+            &mut doc,
+            false,
+        )
+        .unwrap();
+        String::from_utf8(wtr.into_inner()).unwrap()
+    }
+
+    /// A key at the start of a container is ambiguous, because an array value
+    /// can be there too. The melter must still apply the hints of the key.
+    #[test]
+    fn test_lookup_key_hints_at_container_start() {
+        let resolver = LookupResolver(&["timeline_notes", "key", "black_death", "location"]);
+        let mut data = Vec::new();
+        data.extend_from_slice(&lookup(0));
+        data.extend_from_slice(&LexemeId::EQUAL.0.to_le_bytes());
+        data.extend_from_slice(&LexemeId::OPEN.0.to_le_bytes());
+        data.extend_from_slice(&lookup(1));
+        data.extend_from_slice(&LexemeId::EQUAL.0.to_le_bytes());
+        data.extend_from_slice(&lookup(2));
+        data.extend_from_slice(&lookup(3));
+        data.extend_from_slice(&LexemeId::EQUAL.0.to_le_bytes());
+        data.extend_from_slice(&LexemeId::U32.0.to_le_bytes());
+        data.extend_from_slice(&4731u32.to_le_bytes());
+        data.extend_from_slice(&LexemeId::CLOSE.0.to_le_bytes());
+
+        let out = melt_body(&data, &resolver);
+        assert_eq!(
+            out,
+            "timeline_notes={\n\tkey=\"black_death\"\n\tlocation=4731\n}\n"
+        );
+    }
+
+    /// An array of strings must keep the hint of the key that opened it, and
+    /// the first value must not become a key.
+    #[test]
+    fn test_lookup_array_values() {
+        let resolver = LookupResolver(&["female_names", "anna", "berta"]);
+        let mut data = Vec::new();
+        data.extend_from_slice(&lookup(0));
+        data.extend_from_slice(&LexemeId::EQUAL.0.to_le_bytes());
+        data.extend_from_slice(&LexemeId::OPEN.0.to_le_bytes());
+        data.extend_from_slice(&lookup(1));
+        data.extend_from_slice(&lookup(2));
+        data.extend_from_slice(&LexemeId::CLOSE.0.to_le_bytes());
+
+        let out = melt_body(&data, &resolver);
+        assert_eq!(out, "female_names={\n\t\"anna\" \"berta\"\n}\n");
+    }
+
+    #[test]
+    fn test_lookup_key_hints() {
+        let resolver = LookupResolver(&["tag", "SWE", "last_stat_year"]);
+        let mut data = Vec::new();
+        data.extend_from_slice(&lookup(0));
+        data.extend_from_slice(&LexemeId::EQUAL.0.to_le_bytes());
+        data.extend_from_slice(&lookup(1));
+        data.extend_from_slice(&lookup(2));
+        data.extend_from_slice(&LexemeId::EQUAL.0.to_le_bytes());
+        data.extend_from_slice(&LexemeId::I32.0.to_le_bytes());
+        data.extend_from_slice(&1341i32.to_le_bytes());
+
+        let out = melt_body(&data, &resolver);
+        assert_eq!(out, "tag=\"SWE\"\nlast_stat_year=1341\n");
+    }
+}

--- a/crates/eu5save/src/models.rs
+++ b/crates/eu5save/src/models.rs
@@ -1,0 +1,298 @@
+mod bstr;
+mod building_manager;
+mod character_db;
+mod color;
+mod countries;
+mod culture_manager;
+mod de;
+mod diplomacy_manager;
+mod loan_manager;
+mod locations;
+mod market_manager;
+mod population;
+mod religion_manager;
+mod subunit_manager;
+mod timeline_manager;
+mod trade_manager;
+mod unit_manager;
+mod version;
+mod war_manager;
+
+pub use bstr::BStr;
+pub use building_manager::*;
+pub use character_db::*;
+pub use color::Color;
+pub use countries::*;
+pub use culture_manager::*;
+pub use diplomacy_manager::*;
+pub use loan_manager::*;
+pub use locations::*;
+pub use market_manager::*;
+pub use population::*;
+pub use religion_manager::*;
+pub use subunit_manager::*;
+pub use timeline_manager::*;
+pub use trade_manager::*;
+pub use unit_manager::*;
+pub use version::GameVersion;
+pub use war_manager::*;
+
+use crate::Eu5Date;
+use arena_serde::ArenaDeserialize;
+use de::*;
+
+#[derive(Debug, ArenaDeserialize)]
+pub struct ZipPrelude<'bump> {
+    pub metadata: Metadata<'bump>,
+}
+
+#[derive(Debug, ArenaDeserialize)]
+pub struct Metadata<'bump> {
+    pub compatibility: Compatibility<'bump>,
+    pub date: Eu5Date,
+    pub playthrough_id: BStr<'bump>,
+    pub playthrough_name: BStr<'bump>,
+    pub version: GameVersion,
+}
+
+#[derive(Debug, ArenaDeserialize)]
+pub struct Compatibility<'bump> {
+    pub locations: &'bump [BStr<'bump>],
+}
+
+impl<'bump> Compatibility<'bump> {
+    pub fn locations_iter(&self) -> impl ExactSizeIterator<Item = (LocationId, &str)> + '_ {
+        self.locations
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (LocationId::new((i + 1) as u32), s.to_str()))
+    }
+}
+
+#[derive(Debug, ArenaDeserialize)]
+pub struct Gamestate<'bump> {
+    pub metadata: Metadata<'bump>,
+    pub provinces: Eu5Database<'bump, Province<'bump>>,
+    pub population: population::PopulationDirectory<'bump>,
+    pub countries: countries::Countries<'bump>,
+    pub locations: Locations<'bump>,
+    #[arena(duplicated, alias = "played_country")]
+    pub played_countries: &'bump [PlayedCountry<'bump>],
+    pub diplomacy_manager: DiplomacyManager<'bump>,
+    pub market_manager: MarketManager<'bump>,
+    pub building_manager: BuildingManager<'bump>,
+    pub character_db: CharacterDb<'bump>,
+    pub war_manager: WarManager<'bump>,
+    pub unit_manager: UnitManager<'bump>,
+    pub subunit_manager: SubUnitManager<'bump>,
+    pub loan_manager: LoanManager<'bump>,
+    pub trade_manager: TradeManager<'bump>,
+    pub religion_manager: ReligionManager<'bump>,
+    pub culture_manager: CultureManager<'bump>,
+    #[arena(default)]
+    pub timeline_manager: TimelineManager<'bump>,
+}
+
+#[derive(Debug, ArenaDeserialize)]
+pub struct Province<'bump> {
+    pub owner: countries::CountryId,
+    pub province_definition: BStr<'bump>,
+}
+
+#[derive(Debug, ArenaDeserialize, PartialEq)]
+pub struct PlayedCountry<'bump> {
+    pub name: BStr<'bump>,
+    pub country: countries::CountryId,
+}
+
+#[derive(Debug)]
+pub struct Eu5Database<'bump, Of: ArenaDeserialize<'bump>> {
+    pub database: &'bump [(u32, Option<Of>)],
+}
+
+impl<'bump, Of: ArenaDeserialize<'bump> + 'bump> ArenaDeserialize<'bump>
+    for Eu5Database<'bump, Of>
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump arena_serde::Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de;
+        use std::fmt;
+
+        #[derive(serde::Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            Database,
+        }
+
+        struct Eu5DatabaseVisitor<'a, T> {
+            allocator: &'a arena_serde::Arena,
+            marker: std::marker::PhantomData<T>,
+        }
+
+        impl<'de, 'a, T: ArenaDeserialize<'a> + 'a> de::Visitor<'de> for Eu5DatabaseVisitor<'a, T> {
+            type Value = Eu5Database<'a, T>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct Eu5Database")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Eu5Database<'a, T>, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let mut database = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Database => {
+                            if database.is_some() {
+                                return Err(de::Error::duplicate_field("database"));
+                            }
+
+                            struct DatabaseSeed<'b, U> {
+                                allocator: &'b arena_serde::Arena,
+                                marker: std::marker::PhantomData<U>,
+                            }
+
+                            impl<'de, 'b, U: ArenaDeserialize<'b> + 'b> de::DeserializeSeed<'de> for DatabaseSeed<'b, U> {
+                                type Value = bumpalo::collections::Vec<'b, (u32, Option<U>)>;
+
+                                fn deserialize<D>(
+                                    self,
+                                    deserializer: D,
+                                ) -> Result<Self::Value, D::Error>
+                                where
+                                    D: serde::Deserializer<'de>,
+                                {
+                                    deserialize_vec_pair_arena(deserializer, self.allocator)
+                                }
+                            }
+
+                            database = Some(map.next_value_seed(DatabaseSeed {
+                                allocator: self.allocator,
+                                marker: std::marker::PhantomData,
+                            })?);
+                        }
+                    }
+                }
+                let database = database.ok_or_else(|| de::Error::missing_field("database"))?;
+                Ok(Eu5Database {
+                    database: database.into_bump_slice(),
+                })
+            }
+        }
+
+        const FIELDS: &[&str] = &["database"];
+        deserializer.deserialize_struct(
+            "Eu5Database",
+            FIELDS,
+            Eu5DatabaseVisitor {
+                allocator,
+                marker: std::marker::PhantomData,
+            },
+        )
+    }
+}
+
+impl<'bump> Gamestate<'bump> {
+    /// Finds the maximum population across all locations in the gamestate.
+    pub fn location_max_population(&self) -> (f64, LocationId) {
+        self.locations
+            .iter()
+            .map(|x| (self.location_population(x.location()), x.id()))
+            .max_by(|(a, _), (b, _)| a.total_cmp(b))
+            .unwrap_or((0.0, LocationId::new(0)))
+    }
+
+    /// Calculates the total population for a specific location by summing up all pops.
+    /// Population is calculated as floor(size * 1000) for each pop.
+    pub fn location_population(&self, location: &Location) -> f64 {
+        location
+            .population
+            .pops
+            .iter()
+            .filter_map(|pop_id| {
+                self.population
+                    .database
+                    .lookup(*pop_id)
+                    .map(|pop| (pop.size * 1000.0).floor())
+            })
+            .sum()
+    }
+
+    pub fn location_max_development(&self) -> (f64, LocationId) {
+        self.locations
+            .iter()
+            .map(|x| (x.location().development, x.id()))
+            .max_by(|(a, _), (b, _)| a.total_cmp(b))
+            .unwrap_or((0.0, LocationId::new(0)))
+    }
+
+    pub fn location_max_rgo_level(&self) -> (f64, LocationId) {
+        self.locations
+            .iter()
+            .map(|x| (x.location().rgo_level, x.id()))
+            .max_by(|(a, _), (b, _)| a.total_cmp(b))
+            .unwrap_or((0.0, LocationId::new(0)))
+    }
+
+    pub fn location_max_wealth(&self) -> (f64, LocationId) {
+        self.locations
+            .iter()
+            .map(|x| (x.location().possible_tax, x.id()))
+            .max_by(|(a, _), (b, _)| a.total_cmp(b))
+            .unwrap_or((0.0, LocationId::new(0)))
+    }
+
+    /// Finds the maximum building levels sum across all locations.
+    /// Only counts buildings where the building owner matches the location owner.
+    pub fn location_max_building_levels(&self) -> (f64, LocationId) {
+        self.locations
+            .iter()
+            .map(|entry| {
+                let sum = self.location_building_levels_sum(entry.id(), entry.location());
+                (sum, entry.id())
+            })
+            .max_by(|(a, _), (b, _)| a.total_cmp(b))
+            .unwrap_or((0.0, LocationId::new(0)))
+    }
+
+    /// Calculates the sum of building levels for a specific location.
+    /// Only counts buildings where the building owner matches the location owner.
+    pub fn location_building_levels_sum(
+        &self,
+        location_id: LocationId,
+        location: &Location,
+    ) -> f64 {
+        self.building_manager
+            .database
+            .iter()
+            .filter(|building| building.location == location_id && building.owner == location.owner)
+            .map(|building| building.level)
+            .sum()
+    }
+
+    /// Provides access to metadata with arena-allocated strings
+    pub fn metadata(&self) -> &Metadata<'bump> {
+        &self.metadata
+    }
+
+    // pub fn provinces(&self) -> &Eu5Database<'bump, Province<'bump>> {
+    //     &self.provinces
+    // }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gamestate_is_send_sync() {
+        fn assert_send<T: Send + Sync>() {}
+        assert_send::<Gamestate>();
+    }
+}

--- a/crates/eu5save/src/models/bstr.rs
+++ b/crates/eu5save/src/models/bstr.rs
@@ -1,0 +1,110 @@
+use arena_serde::ArenaDeserialize;
+use serde::de;
+
+/// A conventionally UTF-8 string that is not required to be UTF-8.
+///
+/// A `BStr` allows us to quickly deserialize more data than what we need
+/// without paying the cost of UTF-8 parsing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct BStr<'bump>(&'bump [u8]);
+
+impl<'bump> BStr<'bump> {
+    pub fn new(bytes: &'bump [u8]) -> Self {
+        Self(bytes)
+    }
+
+    /// Return a string slice that encompasses the valid UTF-8 subset of the
+    /// `BStr`
+    pub fn to_str(&self) -> &'bump str {
+        match std::str::from_utf8(self.0) {
+            Ok(s) => s,
+            Err(e) => {
+                let valid_up_to = e.valid_up_to();
+                unsafe { std::str::from_utf8_unchecked(&self.0[..valid_up_to]) }
+            }
+        }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0
+    }
+}
+
+impl std::fmt::Display for BStr<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_str())
+    }
+}
+
+impl<'bump> ArenaDeserialize<'bump> for BStr<'bump> {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump arena_serde::Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct BStrVisitor<'bump>(&'bump arena_serde::Arena);
+
+        impl<'de, 'bump> de::Visitor<'de> for BStrVisitor<'bump> {
+            type Value = BStr<'bump>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a byte string")
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let bytes = self.0.alloc_slice_copy(v);
+                Ok(BStr::new(bytes))
+            }
+
+            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let bytes = self.0.alloc_slice_copy(v);
+                Ok(BStr::new(bytes))
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let bytes = self.0.alloc_slice_copy(v.as_bytes());
+                Ok(BStr::new(bytes))
+            }
+        }
+
+        deserializer.deserialize_bytes(BStrVisitor(allocator))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(b"Hello, World!", "Hello, World!")]
+    #[case(b"", "")]
+    #[case("Möng Köng".as_bytes(), "Möng Köng")]
+    #[case(b"up to\xD6 not-this", "up to")]
+    fn test_bstr_to_str(#[case] input: &[u8], #[case] expected: &str) {
+        let bstr = BStr::new(input);
+        let result = bstr.to_str();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_bstr_to_str_preserves_lifetime() {
+        let bytes = b"test";
+        let actual = {
+            let bstr = BStr::new(bytes);
+            bstr.to_str()
+        };
+        assert_eq!(actual, "test");
+    }
+}

--- a/crates/eu5save/src/models/building_manager.rs
+++ b/crates/eu5save/src/models/building_manager.rs
@@ -1,0 +1,98 @@
+use std::fmt;
+
+use crate::models::{CountryId, LocationId, bstr::BStr, de::Maybe};
+use arena_serde::{ArenaDeserialize, ArenaSeed};
+use serde::{Deserialize, de};
+
+#[derive(Debug, PartialEq, ArenaDeserialize)]
+pub struct BuildingManager<'bump> {
+    #[arena(deserialize_with = "deserialize_buildings")]
+    pub database: BuildingDatabase<'bump>,
+}
+
+impl<'bump> BuildingManager<'bump> {}
+
+#[derive(Debug, PartialEq)]
+pub struct BuildingDatabase<'bump> {
+    ids: &'bump [BuildingId],
+    values: &'bump [Option<Building<'bump>>],
+}
+
+impl<'bump> BuildingDatabase<'bump> {
+    /// Returns an iterator over all buildings in the database
+    pub fn iter(&self) -> impl Iterator<Item = &Building<'bump>> {
+        self.values.iter().filter_map(|x| x.as_ref())
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Default, ArenaDeserialize,
+)]
+#[serde(transparent)]
+pub struct BuildingId(u32);
+
+impl BuildingId {
+    #[inline]
+    pub fn new(id: u32) -> Self {
+        BuildingId(id)
+    }
+
+    #[inline]
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, ArenaDeserialize, PartialEq)]
+pub struct Building<'bump> {
+    #[arena(alias = "type")]
+    pub kind: BStr<'bump>,
+    #[arena(default)]
+    pub level: f64,
+    pub location: LocationId,
+    #[arena(default)]
+    pub owner: CountryId,
+    #[arena(default)]
+    pub employed: f64, // 0.08 => 80 employed
+}
+
+#[inline]
+fn deserialize_buildings<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<BuildingDatabase<'bump>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct MarketsVisitor<'bump>(&'bump arena_serde::Arena);
+
+    impl<'de, 'bump> de::Visitor<'de> for MarketsVisitor<'bump> {
+        type Value = BuildingDatabase<'bump>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map containing building entries")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut building_ids = bumpalo::collections::Vec::with_capacity_in(65536, self.0);
+            let mut building_values = bumpalo::collections::Vec::with_capacity_in(65536, self.0);
+            while let Some((key, value)) = map.next_entry_seed(
+                ArenaSeed::new(self.0),
+                ArenaSeed::<Maybe<Building<'bump>>>::new(self.0),
+            )? {
+                building_ids.push(key);
+                building_values.push(value.into_value());
+            }
+
+            let ids = building_ids.into_bump_slice();
+            let values = building_values.into_bump_slice();
+
+            Ok(BuildingDatabase { ids, values })
+        }
+    }
+
+    deserializer.deserialize_map(MarketsVisitor(allocator))
+}

--- a/crates/eu5save/src/models/character_db.rs
+++ b/crates/eu5save/src/models/character_db.rs
@@ -1,0 +1,237 @@
+use crate::{
+    Eu5Date,
+    models::{CountryId, LocationId, bstr::BStr, de::Maybe},
+};
+use arena_serde::{ArenaDeserialize, ArenaSeed};
+use serde::de::value::MapAccessDeserializer;
+use serde::{Deserialize, Deserializer, de};
+use std::fmt;
+
+#[derive(Debug, PartialEq, ArenaDeserialize)]
+pub struct CharacterDb<'bump> {
+    #[arena(deserialize_with = "deserialize_characters")]
+    pub database: CharacterDatabase<'bump>,
+}
+
+impl<'bump> CharacterDb<'bump> {}
+
+#[derive(Debug, PartialEq)]
+pub struct CharacterDatabase<'bump> {
+    ids: &'bump [CharacterId],
+    values: &'bump [Option<Character<'bump>>],
+}
+
+impl<'bump> CharacterDatabase<'bump> {
+    /// Returns an iterator over all characters in the database
+    pub fn iter(&self) -> impl Iterator<Item = &Character<'bump>> {
+        self.values.iter().filter_map(|x| x.as_ref())
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Default, ArenaDeserialize,
+)]
+#[serde(transparent)]
+pub struct CharacterId(u32);
+
+impl CharacterId {
+    #[inline]
+    pub fn new(id: u32) -> Self {
+        CharacterId(id)
+    }
+
+    #[inline]
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, ArenaDeserialize, PartialEq)]
+pub struct Character<'bump> {
+    #[arena(default)]
+    pub country: CountryId,
+    #[arena(deserialize_with = "deserialize_first_name")]
+    pub first_name: BStr<'bump>,
+    #[arena(default)]
+    pub adm: f64,
+    #[arena(default)]
+    pub dip: f64,
+    #[arena(default)]
+    pub mil: f64,
+    pub birth: Option<LocationId>,
+    pub birth_date: Eu5Date,
+    pub father: Option<CharacterId>,
+    pub mother: Option<CharacterId>,
+}
+
+#[inline]
+fn deserialize_first_name<'de, 'bump, D>(
+    deserializer: D,
+    alloc: &'bump arena_serde::Arena,
+) -> Result<BStr<'bump>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct FirstNameVisitor<'bump>(&'bump arena_serde::Arena);
+
+    #[derive(Debug, ArenaDeserialize)]
+    struct FirstNameKey<'bump> {
+        #[arena(alias = "Custom_Name")]
+        custom_name: BStr<'bump>,
+    }
+
+    #[derive(Debug, ArenaDeserialize)]
+    struct FirstNameObject<'bump> {
+        name: BStr<'bump>,
+        #[arena(default)]
+        custom_name: Option<BStr<'bump>>,
+        #[arena(default)]
+        key: Option<FirstNameKey<'bump>>,
+    }
+
+    impl<'de, 'bump> de::Visitor<'de> for FirstNameVisitor<'bump> {
+        type Value = BStr<'bump>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a first name")
+        }
+
+        fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            self.visit_bytes(v.as_bytes())
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            self.visit_bytes(v.as_bytes())
+        }
+
+        fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            self.visit_str(&v)
+        }
+
+        fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(BStr::new(self.0.alloc_slice_copy(v)))
+        }
+
+        fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let deser = MapAccessDeserializer::new(map);
+            let first_name = FirstNameObject::deserialize_in_arena(deser, self.0)?;
+            if let Some(custom_name) = first_name.custom_name {
+                Ok(custom_name)
+            } else if let Some(key) = first_name.key {
+                Ok(key.custom_name)
+            } else {
+                Ok(first_name.name)
+            }
+        }
+    }
+
+    deserializer.deserialize_map(FirstNameVisitor(alloc))
+}
+
+#[inline]
+fn deserialize_characters<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<CharacterDatabase<'bump>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct CharacterVisitor<'bump>(&'bump arena_serde::Arena);
+
+    impl<'de, 'bump> de::Visitor<'de> for CharacterVisitor<'bump> {
+        type Value = CharacterDatabase<'bump>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map containing character entries")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut character_ids = bumpalo::collections::Vec::with_capacity_in(65536, self.0);
+            let mut character_values = bumpalo::collections::Vec::with_capacity_in(65536, self.0);
+            while let Some((key, value)) = map.next_entry_seed(
+                ArenaSeed::new(self.0),
+                ArenaSeed::<Maybe<Character<'bump>>>::new(self.0),
+            )? {
+                character_ids.push(key);
+                character_values.push(value.into_value());
+            }
+
+            let ids = character_ids.into_bump_slice();
+            let values = character_values.into_bump_slice();
+            Ok(CharacterDatabase { ids, values })
+        }
+    }
+
+    deserializer.deserialize_map(CharacterVisitor(allocator))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jomini::TextDeserializer;
+
+    #[test]
+    fn test_first_name_simple_string() {
+        let data = r#"first_name="Margret Thatcher"
+birth_date=1925.1.1"#;
+        let allocator = arena_serde::Arena::new();
+        let d = TextDeserializer::from_utf8_slice(data.as_bytes())
+            .expect("Failed to create deserializer");
+        let character: Character = Character::deserialize_in_arena(&d, &allocator)
+            .expect("Failed to deserialize character with simple first_name");
+
+        assert_eq!(character.first_name.to_str(), "Margret Thatcher");
+    }
+
+    #[test]
+    fn test_first_name_object_with_custom_name() {
+        let data = r#"first_name={
+name="name_william"
+custom_name="Margret Thatcher"
+}
+birth_date=1925.1.1"#;
+        let allocator = arena_serde::Arena::new();
+        let d = TextDeserializer::from_utf8_slice(data.as_bytes())
+            .expect("Failed to create deserializer");
+        let character: Character = Character::deserialize_in_arena(&d, &allocator)
+            .expect("Failed to deserialize character with object first_name with custom_name");
+
+        assert_eq!(character.first_name.to_str(), "Margret Thatcher");
+    }
+
+    #[test]
+    fn test_first_name_object_with_key_custom_name() {
+        // https://discord.com/channels/712465396590182461/712632868274438195/1477326537811296428
+        let data = r#"first_name={
+name="name_bohuslav"
+key={
+Custom_Name="Ronny"
+}
+}
+birth_date=1925.1.1"#;
+        let allocator = arena_serde::Arena::new();
+        let d = TextDeserializer::from_utf8_slice(data.as_bytes())
+            .expect("Failed to create deserializer");
+        let character: Character = Character::deserialize_in_arena(&d, &allocator)
+            .expect("Failed to deserialize character with key-based custom name");
+        assert_eq!(character.first_name.to_str(), "Ronny");
+    }
+}

--- a/crates/eu5save/src/models/color.rs
+++ b/crates/eu5save/src/models/color.rs
@@ -1,0 +1,63 @@
+use arena_serde::ArenaDeserialize;
+use serde::de::{self, Deserialize, value::SeqAccessDeserializer};
+use std::fmt;
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct Color(pub [u8; 3]);
+
+impl Default for Color {
+    fn default() -> Self {
+        // Default to the "unowned" color so that an unowned location will use
+        // country id 0's color (gray)
+        Color([128, 128, 128])
+    }
+}
+
+struct ColorVisitor;
+
+impl<'de> de::Visitor<'de> for ColorVisitor {
+    type Value = Color;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a color array of 3 integers")
+    }
+
+    fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        // A binary color arrives with its channel count known. Some fields,
+        // such as `color3`, hold a fourth alpha channel that the map ignores.
+        if matches!(seq.size_hint(), Some(3) | Some(4)) {
+            let arr = <[u8; 3]>::deserialize(SeqAccessDeserializer::new(seq))?;
+            Ok(Color(arr))
+        } else {
+            // Otherwise it will be a two element tuple of color=rgb { 100 200, 50 }
+            let (_ignored, arr) =
+                <(de::IgnoredAny, [u8; 3])>::deserialize(SeqAccessDeserializer::new(seq))?;
+            Ok(Color(arr))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Color {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(ColorVisitor)
+    }
+}
+
+impl<'bump> ArenaDeserialize<'bump> for Color {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump arena_serde::Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Color has no arena data. Forward to the custom visitor above.
+        Self::deserialize(deserializer)
+    }
+}

--- a/crates/eu5save/src/models/countries.rs
+++ b/crates/eu5save/src/models/countries.rs
@@ -1,0 +1,1247 @@
+use crate::models::ReligionId;
+use crate::models::bstr::BStr;
+use crate::models::{Color, LocationId, de::Maybe};
+use arena_serde::{ArenaDeserialize, ArenaSeed};
+use serde::{
+    Deserialize, Deserializer,
+    de::{self, DeserializeSeed, IgnoredAny, value::MapAccessDeserializer},
+};
+use std::ops::IndexMut;
+use std::{collections::HashMap, fmt, num::NonZeroU32, ops::Index};
+
+/// A country ID as stored in the save file; may be [CountryId::DUMMY]
+///
+/// Consider [CountryId::real_id]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, ArenaDeserialize, Deserialize,
+)]
+pub struct CountryId(u32);
+
+impl CountryId {
+    const DUMMY: CountryId = CountryId(0);
+
+    #[inline]
+    pub fn new(id: u32) -> Self {
+        CountryId(id)
+    }
+
+    #[inline]
+    pub fn value(self) -> u32 {
+        self.0
+    }
+
+    #[inline]
+    pub fn is_dummy(&self) -> bool {
+        *self == CountryId::DUMMY
+    }
+
+    #[inline]
+    pub fn real_id(&self) -> Option<RealCountryId> {
+        NonZeroU32::new(self.0).map(RealCountryId)
+    }
+}
+
+impl Default for CountryId {
+    fn default() -> Self {
+        CountryId::DUMMY
+    }
+}
+
+/// A country ID that is not [CountryId::DUMMY]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RealCountryId(NonZeroU32);
+
+impl RealCountryId {
+    #[inline]
+    pub fn country_id(self) -> CountryId {
+        CountryId(self.0.get())
+    }
+}
+
+impl From<RealCountryId> for CountryId {
+    #[inline]
+    fn from(real: RealCountryId) -> Self {
+        real.country_id()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct CountryIdx(NonZeroU32);
+
+impl CountryIdx {
+    #[inline]
+    fn index(self) -> usize {
+        self.0.get() as usize - 1
+    }
+
+    #[inline]
+    fn from_index(index: usize) -> Self {
+        CountryIdx(NonZeroU32::new(index as u32 + 1).unwrap())
+    }
+
+    #[inline]
+    pub fn value(self) -> u32 {
+        self.0.get()
+    }
+
+    #[inline]
+    pub fn from_value(v: u32) -> Option<Self> {
+        NonZeroU32::new(v).map(CountryIdx)
+    }
+}
+
+/// The tag of a country.
+///
+/// A tag is not limited to the classic three uppercase letters. The game makes
+/// new tags at runtime with a five character `AAA00` sequence, and script can
+/// give a country a longer tag (for example the `SAR_piedmont` formable), so
+/// the tag keeps the bytes of the save instead of a fixed size buffer.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, ArenaDeserialize)]
+pub struct CountryTag<'bump>(BStr<'bump>);
+
+impl<'bump> CountryTag<'bump> {
+    #[inline]
+    pub fn new(bstr: BStr<'bump>) -> Self {
+        Self(bstr)
+    }
+
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+
+    #[inline]
+    pub fn as_str(&self) -> &'bump str {
+        self.0.to_str()
+    }
+
+    #[inline]
+    pub fn to_str(&self) -> &'bump str {
+        self.as_str()
+    }
+}
+
+impl fmt::Debug for CountryTag<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl fmt::Display for CountryTag<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug)]
+pub struct Countries<'bump> {
+    ids: CountryIndexedVec<'bump, CountryId>,
+    tags: CountryIndexedVec<'bump, CountryTag<'bump>>,
+    database: CountryIndexedVec<'bump, Option<Country<'bump>>>,
+    historical_world_population: &'bump [f64],
+}
+
+impl<'bump> Countries<'bump> {
+    pub fn get(&self, id: impl Into<CountryId>) -> Option<CountryIdx> {
+        self.get_idx(id.into())
+    }
+
+    fn get_idx(&self, id: CountryId) -> Option<CountryIdx> {
+        // Fast path: check if the country is at the same index as its tag
+        let index = id.value() as usize;
+        if self.ids.data.get(index).is_some_and(|cid| *cid == id) {
+            return Some(CountryIdx::from_index(index));
+        }
+
+        // Otherwise it is probably one of the more dynamic IDs at the end of
+        // the list and we may have to search a few dozen for it.
+        let index = self.ids.iter().rposition(|cid| *cid == id)?;
+        Some(CountryIdx::from_index(index))
+    }
+
+    pub fn get_entry(&self, id: CountryId) -> Option<CountryEntry<'_>> {
+        Some(self.index(self.get(id)?))
+    }
+
+    pub fn index(&self, idx: CountryIdx) -> CountryEntry<'_> {
+        CountryEntry {
+            idx,
+            countries: self,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.ids.data.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ids.data.is_empty()
+    }
+
+    pub fn iter(&self) -> CountriesIter<'_> {
+        CountriesIter::new(self)
+    }
+
+    pub fn create_index<T: Clone>(&self, initial: T) -> CountryIndexedVecOwned<T> {
+        CountryIndexedVecOwned {
+            data: vec![initial; self.len()].into_boxed_slice(),
+        }
+    }
+
+    /// The population of the whole world, one annual sample per year of the
+    /// campaign. Empty in a save that does not have the series.
+    pub fn historical_world_population(&self) -> &'bump [f64] {
+        self.historical_world_population
+    }
+}
+
+#[derive(Debug, Clone, ArenaDeserialize)]
+pub struct CountryEconomy<'bump> {
+    #[arena(default)]
+    pub income: f64,
+    #[arena(default)]
+    pub expense: f64,
+    #[arena(default)]
+    pub monthly_gold: &'bump [f64],
+    #[arena(default)]
+    pub recent_balance: &'bump [f64],
+}
+
+impl<'bump> Default for CountryEconomy<'bump> {
+    fn default() -> Self {
+        CountryEconomy {
+            income: 0.0,
+            expense: 0.0,
+            monthly_gold: &[],
+            recent_balance: &[],
+        }
+    }
+}
+
+#[derive(Debug, Clone, ArenaDeserialize)]
+pub struct Country<'bump> {
+    pub country_name: CountryName<'bump>,
+    #[arena(default)]
+    pub color: Color,
+    /// The coat of arms key this country flies (e.g. `flag=MER`). Used to look
+    /// up the pre-rendered flag in the web UI.
+    #[arena(default)]
+    pub flag: Option<BStr<'bump>>,
+    pub capital: Option<LocationId>,
+    #[arena(default)]
+    pub historical_population: &'bump [f64],
+    #[arena(default)]
+    pub historical_tax_base: &'bump [f64],
+    #[arena(default)]
+    pub historical_economical_base: &'bump [f64],
+    /// The year of the last sample in the historical arrays.
+    pub last_stat_year: Option<i16>,
+    #[arena(default)]
+    pub previous_tags: &'bump [CountryTag<'bump>],
+    #[arena(default)]
+    pub economy: CountryEconomy<'bump>,
+    #[arena(default)]
+    pub great_power_rank: i32,
+    #[arena(default)]
+    pub artists: i32,
+    #[arena(default)]
+    pub estimated_monthly_income_trade_and_tax: f64,
+    #[arena(default)]
+    pub estimated_monthly_income: f64,
+    #[arena(default)]
+    pub monthly_trade_balance: f64,
+    #[arena(default)]
+    pub monthly_trade_value: f64,
+    #[arena(default)]
+    pub current_tax_base: f64,
+    #[arena(default)]
+    pub monthly_manpower: f64, // x1000
+    #[arena(default)]
+    pub monthly_sailors: f64, // x1000
+    #[arena(default)]
+    pub max_manpower: f64, // x1000
+    #[arena(default)]
+    pub max_sailors: f64, // x1000
+    #[arena(default)]
+    pub total_produced: f64,
+    pub score: CountryScore,
+    pub currency_data: CurrencyData,
+    pub primary_religion: Option<ReligionId>,
+}
+
+/// The year of each sample of a `historical_*` array.
+///
+/// The samples are annual and the last one is `last_stat_year`, so the first
+/// one is the start year of the campaign. The length is not the same for every
+/// country: a country that formed late has fewer samples.
+pub fn historical_sample_years(
+    last_stat_year: i16,
+    samples: usize,
+) -> impl ExactSizeIterator<Item = i16> {
+    let first = last_stat_year - (samples as i16) + 1;
+    (0..samples as i16).map(move |i| first + i)
+}
+
+impl Country<'_> {
+    /// The year of each sample of the historical arrays of this country. All
+    /// of the arrays have the same length.
+    ///
+    /// Empty if the country has no `last_stat_year`.
+    pub fn historical_years(&self) -> impl ExactSizeIterator<Item = i16> {
+        let Some(last_stat_year) = self.last_stat_year else {
+            return historical_sample_years(0, 0);
+        };
+
+        historical_sample_years(last_stat_year, self.historical_population.len())
+    }
+
+    /// The economic base is defined as the tax base of the country plus the
+    /// volume of all its trades
+    ///
+    /// TODO: factor in sound tolls
+    #[inline]
+    pub fn economic_base(&self) -> f64 {
+        self.current_tax_base + self.monthly_trade_value
+    }
+}
+
+/// A country name is deceptively complex:
+///
+/// ```ignore
+/// country_name="TEU"
+/// ```
+///
+/// ```ignore
+/// country_name={
+///    name="CIVILWAR_FACTION_nobles_estate_NAME"
+///    adjective="CIVILWAR_FACTION_nobles_estate_ADJECTIVE"
+///    base="DNS"
+/// }
+/// ```
+///
+/// ```ignore
+/// country_name={
+///    name="CIVILWAR_FACTION_nobles_estate_NAME"
+///    adjective="CIVILWAR_FACTION_nobles_estate_ADJECTIVE"
+///    base={
+///        name="UNN"
+///        override_name="oyama_dynasty"
+///        override_adj="oyama_dynasty"
+///    }
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub enum CountryName<'bump> {
+    Tag(BStr<'bump>),
+    Object(CountryNameObject<'bump>),
+}
+
+impl<'bump> CountryName<'bump> {
+    /// Returns the raw name key: the tag for `Tag` variants, or `obj.name` for objects.
+    /// For presentation code use a proper resolver; this is for debug/raw-key access only.
+    pub fn name(&self) -> BStr<'bump> {
+        match self {
+            CountryName::Tag(tag) => *tag,
+            CountryName::Object(obj) => obj.name.unwrap_or(BStr::new(&[])),
+        }
+    }
+}
+
+/// The `key` map inside a `country_name` object, e.g. `key={ "Adjective"="YMT_ADJ" }`.
+#[derive(Debug, Clone, Default, ArenaDeserialize)]
+pub struct CountryNameKeys<'bump> {
+    #[arena(default, alias = "Adjective")]
+    pub adjective: Option<BStr<'bump>>,
+    #[arena(default, alias = "Custom_Name")]
+    pub custom_name: Option<BStr<'bump>>,
+}
+
+impl<'bump> CountryNameKeys<'bump> {
+    pub fn adjective_key(&self) -> Option<BStr<'bump>> {
+        self.adjective
+    }
+}
+
+/// The `bases` map inside a `country_name` object, e.g. `bases={ Base=JAL }`.
+///
+/// `Base` can also be a full country-name object (e.g. `Base={ name="ASK" override_name=... }`);
+/// in that case the inner `name` field is extracted as the base tag.
+#[derive(Debug, Clone, Default, ArenaDeserialize)]
+pub struct CountryNameBases<'bump> {
+    #[arena(default, alias = "Base", deserialize_with = "deserialize_base")]
+    pub base: Option<BStr<'bump>>,
+}
+
+/// Accepts a bare tag string or a `{ name=... }` country-name object as a base tag.
+/// Returns the name field of the object, or the string itself.
+/// Sequences (binary-encoding of objects) are drained and return `None`.
+fn deserialize_base<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<Option<BStr<'bump>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Visitor<'bump>(&'bump arena_serde::Arena);
+    impl<'de, 'bump> de::Visitor<'de> for Visitor<'bump> {
+        type Value = Option<BStr<'bump>>;
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("base tag string or object")
+        }
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            Ok(Some(BStr::new(self.0.alloc_slice_copy(v.as_bytes()))))
+        }
+        fn visit_borrowed_str<E: de::Error>(self, v: &'de str) -> Result<Self::Value, E> {
+            Ok(Some(BStr::new(self.0.alloc_slice_copy(v.as_bytes()))))
+        }
+        fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+            Ok(Some(BStr::new(self.0.alloc_slice_copy(v))))
+        }
+        fn visit_map<A: de::MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
+            let obj =
+                CountryNameObject::deserialize_in_arena(MapAccessDeserializer::new(map), self.0)?;
+            Ok(obj.name)
+        }
+        fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            while seq.next_element::<IgnoredAny>()?.is_some() {}
+            Ok(None)
+        }
+    }
+    deserializer.deserialize_any(Visitor(allocator))
+}
+
+#[derive(Debug, Clone, ArenaDeserialize)]
+pub struct CountryNameObject<'bump> {
+    /// Absent for placeholder countries (e.g. "Paradox Country" which only has a `key`).
+    #[arena(default)]
+    pub name: Option<BStr<'bump>>,
+    /// Localization key (and any template variables) for the display name.
+    #[arena(default, deserialize_with = "deserialize_override")]
+    pub override_name: Option<CountryNameOverride<'bump>>,
+    /// Localization key (and any template variables) for the adjective form.
+    #[arena(default, deserialize_with = "deserialize_override")]
+    pub override_adj: Option<CountryNameOverride<'bump>>,
+    /// String-keyed localization entries such as `"Adjective"="YMT_ADJ"`.
+    #[arena(default)]
+    pub key: CountryNameKeys<'bump>,
+    /// Base tag substitutions such as `Base=JAL` used by `$ADJ$` templates.
+    #[arena(default)]
+    pub bases: CountryNameBases<'bump>,
+}
+
+/// Loc key plus optional `$VAR$` substitutions for the resolved template.
+#[derive(Debug, Clone, ArenaDeserialize)]
+pub struct CountryNameOverride<'bump> {
+    pub key: BStr<'bump>,
+    #[arena(default)]
+    pub variables: &'bump [CountryNameVariable<'bump>],
+}
+
+#[derive(Debug, Clone, ArenaDeserialize)]
+pub struct CountryNameVariable<'bump> {
+    pub key: BStr<'bump>,
+    pub value: BStr<'bump>,
+}
+
+/// Accepts a bare string, a `{ key=... variables={...} }` object, or a seq
+/// (binary-encoding variant, which yields `None`).
+fn deserialize_override<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<Option<CountryNameOverride<'bump>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Visitor<'bump>(&'bump arena_serde::Arena);
+    impl<'de, 'bump> de::Visitor<'de> for Visitor<'bump> {
+        type Value = Option<CountryNameOverride<'bump>>;
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("string, object with key field, or sequence")
+        }
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            self.visit_bytes(v.as_bytes())
+        }
+        fn visit_borrowed_str<E: de::Error>(self, v: &'de str) -> Result<Self::Value, E> {
+            self.visit_bytes(v.as_bytes())
+        }
+        fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+            Ok(Some(CountryNameOverride {
+                key: BStr::new(self.0.alloc_slice_copy(v)),
+                variables: &[],
+            }))
+        }
+        fn visit_map<A: de::MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
+            let obj =
+                CountryNameOverride::deserialize_in_arena(MapAccessDeserializer::new(map), self.0)?;
+            Ok(Some(obj))
+        }
+        fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            while seq.next_element::<IgnoredAny>()?.is_some() {}
+            Ok(None)
+        }
+    }
+    deserializer.deserialize_any(Visitor(allocator))
+}
+
+#[derive(Debug, Clone, ArenaDeserialize)]
+pub struct CountryScore {
+    pub score_place: Option<i32>,
+    #[arena(default)]
+    pub score_rating: CountryScoreRating,
+    #[arena(default)]
+    pub score_rank: CountryScoreRank,
+}
+
+#[derive(Debug, Clone, Default, ArenaDeserialize)]
+pub struct CountryScoreRating {
+    #[arena(default, alias = "ADM")]
+    pub adm: f64,
+    #[arena(default, alias = "DIP")]
+    pub dip: f64,
+    #[arena(default, alias = "MIL")]
+    pub mil: f64,
+}
+
+#[derive(Debug, Clone, Default, ArenaDeserialize)]
+pub struct CountryScoreRank {
+    #[arena(alias = "ADM")]
+    pub adm: f64,
+    #[arena(alias = "DIP")]
+    pub dip: f64,
+    #[arena(alias = "MIL")]
+    pub mil: f64,
+}
+
+#[derive(Debug, Clone, Default, ArenaDeserialize)]
+pub struct CurrencyData {
+    #[arena(default)]
+    pub manpower: f64,
+    #[arena(default)]
+    pub gold: f64,
+    #[arena(default)]
+    pub stability: f64,
+    #[arena(default)]
+    pub prestige: f64,
+    #[arena(default)]
+    pub army_tradition: f64,
+    #[arena(default)]
+    pub navy_tradition: f64,
+    #[arena(default)]
+    pub government_power: f64,
+}
+
+struct CountryDatabaseSeed<'bump> {
+    country_ids: &'bump [CountryId],
+    allocator: &'bump arena_serde::Arena,
+}
+
+impl<'bump> CountryDatabaseSeed<'bump> {
+    fn new(country_ids: &'bump [CountryId], allocator: &'bump arena_serde::Arena) -> Self {
+        Self {
+            country_ids,
+            allocator,
+        }
+    }
+}
+
+impl<'bump, 'de> DeserializeSeed<'de> for CountryDatabaseSeed<'bump> {
+    type Value = &'bump [Option<Country<'bump>>];
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct CountryDatabaseVisitor<'bump> {
+            country_ids: &'bump [CountryId],
+            allocator: &'bump arena_serde::Arena,
+        }
+
+        impl<'bump, 'de> serde::de::Visitor<'de> for CountryDatabaseVisitor<'bump> {
+            type Value = &'bump [Option<Country<'bump>>];
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a map of country database entries")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                // Unfortunately, the tag list and the country database are
+                // often not in the same order. We have to match them up by ID.
+                let id_idxs = self
+                    .country_ids
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, cid)| (cid, idx))
+                    .collect::<HashMap<_, _>>();
+
+                let mut database = bumpalo::collections::Vec::with_capacity_in(
+                    self.country_ids.len(),
+                    self.allocator,
+                );
+                database.resize(self.country_ids.len(), None);
+                let mut expected_index = 0;
+
+                while let Some((country_id, country)) = map.next_entry_seed(
+                    ArenaSeed::<CountryId>::new(self.allocator),
+                    ArenaSeed::<Maybe<Country<'bump>>>::new(self.allocator),
+                )? {
+                    let country = country.into_value();
+
+                    // There will be entries in the countries database like
+                    // "33556688=none" that don't show up in the tags list. We
+                    // skip over these entries.
+                    if country.is_none() && !id_idxs.contains_key(&country_id) {
+                        continue;
+                    }
+
+                    if expected_index >= self.country_ids.len() {
+                        return Err(serde::de::Error::custom(format!(
+                            "unexpected country ID {}: more entries than expected",
+                            country_id.value()
+                        )));
+                    }
+
+                    let expected_id = self.country_ids[expected_index];
+                    let index = if country_id == expected_id {
+                        expected_index
+                    } else if let Some(&idx) = id_idxs.get(&country_id) {
+                        idx
+                    } else {
+                        return Err(serde::de::Error::custom(format!(
+                            "unexpected country ID {}: not in expected list",
+                            country_id.value()
+                        )));
+                    };
+
+                    database[index] = country;
+                    expected_index += 1;
+                }
+
+                if expected_index != self.country_ids.len() {
+                    return Err(serde::de::Error::custom(format!(
+                        "incomplete country data: expected {} entries, found {}",
+                        self.country_ids.len(),
+                        expected_index
+                    )));
+                }
+
+                Ok(database.into_bump_slice())
+            }
+        }
+
+        deserializer.deserialize_map(CountryDatabaseVisitor {
+            country_ids: self.country_ids,
+            allocator: self.allocator,
+        })
+    }
+}
+
+struct CountriesVisitor<'bump>(&'bump arena_serde::Arena);
+impl<'de, 'bump> serde::de::Visitor<'de> for CountriesVisitor<'bump> {
+    type Value = Countries<'bump>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a map of country data")
+    }
+
+    fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+    where
+        V: serde::de::MapAccess<'de>,
+    {
+        let Some(key) = map.next_key::<CountryField>()? else {
+            return Err(serde::de::Error::custom("expected countries data"));
+        };
+
+        if !matches!(key, CountryField::Tags) {
+            return Err(serde::de::Error::custom("expected 'tags' field first"));
+        }
+
+        struct TagDataSeed<'bump>(&'bump arena_serde::Arena);
+
+        impl<'bump, 'de> DeserializeSeed<'de> for TagDataSeed<'bump> {
+            type Value = (&'bump [CountryId], &'bump [CountryTag<'bump>]);
+
+            fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct TagDataVisitor<'bump>(&'bump arena_serde::Arena);
+
+                impl<'bump, 'de> serde::de::Visitor<'de> for TagDataVisitor<'bump> {
+                    type Value = (&'bump [CountryId], &'bump [CountryTag<'bump>]);
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        formatter.write_str("a map with country IDs and tags")
+                    }
+
+                    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+                    where
+                        A: serde::de::MapAccess<'de>,
+                    {
+                        let mut ids = bumpalo::collections::Vec::new_in(self.0);
+                        let mut tags = bumpalo::collections::Vec::new_in(self.0);
+
+                        while let Some(key) = map.next_key::<CountryId>()? {
+                            let tag =
+                                map.next_value_seed(
+                                    arena_serde::ArenaSeed::<CountryTag<'bump>>::new(self.0),
+                                )?;
+                            ids.push(key);
+                            tags.push(tag);
+                        }
+
+                        Ok((ids.into_bump_slice(), tags.into_bump_slice()))
+                    }
+                }
+
+                deserializer.deserialize_map(TagDataVisitor(self.0))
+            }
+        }
+
+        let tag_data = map.next_value_seed(TagDataSeed(self.0))?;
+
+        let mut world_population: &[f64] = &[];
+        loop {
+            let Some(key) = map.next_key::<CountryField>()? else {
+                return Err(serde::de::Error::custom("expected countries data"));
+            };
+
+            match key {
+                CountryField::Database => break,
+                CountryField::HistoricalWorldPopulation => {
+                    world_population =
+                        map.next_value_seed(arena_serde::ArenaSeed::<&[f64]>::new(self.0))?;
+                }
+                _ => {
+                    map.next_value::<serde::de::IgnoredAny>()?;
+                }
+            }
+        }
+
+        let database_seed = CountryDatabaseSeed::new(tag_data.0, self.0);
+        let database = map.next_value_seed(database_seed)?;
+
+        while map
+            .next_entry::<CountryField, serde::de::IgnoredAny>()?
+            .is_some()
+        {
+            // Ignore any other fields
+        }
+
+        Ok(Countries {
+            ids: CountryIndexedVec { data: tag_data.0 },
+            tags: CountryIndexedVec { data: tag_data.1 },
+            database: CountryIndexedVec { data: database },
+            historical_world_population: world_population,
+        })
+    }
+}
+
+impl<'bump> ArenaDeserialize<'bump> for Countries<'bump> {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump arena_serde::Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(CountriesVisitor(allocator))
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+enum CountryField {
+    #[serde(alias = "tags")]
+    Tags,
+    #[serde(alias = "database")]
+    Database,
+    #[serde(alias = "historical_world_population")]
+    HistoricalWorldPopulation,
+    #[serde(other)]
+    Other,
+}
+
+impl<'bump> ArenaDeserialize<'bump> for CountryName<'bump> {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump arena_serde::Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct CountryNameVisitor<'bump>(&'bump arena_serde::Arena);
+        impl<'de, 'bump> serde::de::Visitor<'de> for CountryNameVisitor<'bump> {
+            type Value = CountryName<'bump>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a country name")
+            }
+
+            fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_bytes(v.as_bytes())
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_bytes(v.as_bytes())
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_str(&v)
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(CountryName::Tag(BStr::new(self.0.alloc_slice_copy(v))))
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let deser = MapAccessDeserializer::new(map);
+                let country = CountryNameObject::deserialize_in_arena(deser, self.0)?;
+                Ok(CountryName::Object(country))
+            }
+        }
+
+        deserializer.deserialize_map(CountryNameVisitor(allocator))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arena_serde::ArenaDeserialize;
+    use jomini::TextDeserializer;
+
+    #[derive(ArenaDeserialize)]
+    struct Wrapper<'bump> {
+        country_name: CountryName<'bump>,
+    }
+
+    fn deserialize_country_name<'bump>(
+        data: &str,
+        allocator: &'bump arena_serde::Arena,
+    ) -> CountryName<'bump> {
+        let deserializer =
+            TextDeserializer::from_utf8_slice(data.as_bytes()).expect("valid text data");
+        Wrapper::deserialize_in_arena(&deserializer, allocator)
+            .expect("country name deserializes")
+            .country_name
+    }
+
+    fn deserialize_countries<'bump>(
+        data: &str,
+        allocator: &'bump arena_serde::Arena,
+    ) -> Countries<'bump> {
+        #[derive(ArenaDeserialize)]
+        struct Wrapper<'bump> {
+            countries: Countries<'bump>,
+        }
+
+        // `Countries` reads its keys as an enum, which only the reader based
+        // deserializer supports. This is the same path the save file takes.
+        let mut deserializer =
+            TextDeserializer::from_utf8_reader(jomini::text::TokenReader::new(data.as_bytes()));
+        Wrapper::deserialize_in_arena(&mut deserializer, allocator)
+            .expect("countries deserialize")
+            .countries
+    }
+
+    /// Newer saves put `historical_world_population` between `tags` and
+    /// `database`, so the visitor must not demand a fixed field order.
+    #[test]
+    fn countries_with_world_population_between_tags_and_database() {
+        let allocator = arena_serde::Arena::new();
+        let countries = deserialize_countries(
+            r#"countries={
+                tags={
+                    0=DUMMY
+                    3=SWE
+                }
+                historical_world_population={ 370505.00095 369278.91483 }
+                database={
+                    0=none
+                    3={
+                        country_name="SWE"
+                        historical_population={ 624.72491 630.38638 }
+                        historical_tax_base={ 43.94665 50.88643 }
+                        historical_economical_base={ 58.24301 86.7986 }
+                        last_stat_year=1346
+                        score={ }
+                        currency_data={ }
+                    }
+                }
+            }"#,
+            &allocator,
+        );
+
+        assert_eq!(
+            countries.historical_world_population(),
+            &[370505.00095, 369278.91483]
+        );
+
+        let swe = countries.get_entry(CountryId::new(3)).expect("SWE present");
+        let swe = swe.data().expect("SWE has data");
+        assert_eq!(swe.historical_economical_base, &[58.24301, 86.7986]);
+        assert_eq!(swe.last_stat_year, Some(1346));
+        assert_eq!(swe.historical_years().collect::<Vec<_>>(), vec![1345, 1346]);
+    }
+
+    /// An older save has no statistic year, so it has no sample years either.
+    #[test]
+    fn historical_years_without_last_stat_year() {
+        let allocator = arena_serde::Arena::new();
+        let countries = deserialize_countries(
+            r#"countries={
+                tags={ 3=SWE }
+                database={ 3={
+                    country_name="SWE"
+                    historical_population={ 1.0 2.0 }
+                    score={ }
+                    currency_data={ }
+                } }
+            }"#,
+            &allocator,
+        );
+
+        let swe = countries.get_entry(CountryId::new(3)).expect("SWE present");
+        let swe = swe.data().expect("SWE has data");
+        assert!(countries.historical_world_population().is_empty());
+        assert_eq!(swe.historical_years().count(), 0);
+    }
+
+    #[test]
+    fn historical_sample_years_are_annual() {
+        assert_eq!(
+            historical_sample_years(1346, 3).collect::<Vec<_>>(),
+            vec![1344, 1345, 1346]
+        );
+        assert_eq!(
+            historical_sample_years(1346, 1).collect::<Vec<_>>(),
+            vec![1346]
+        );
+        assert_eq!(historical_sample_years(1346, 0).count(), 0);
+    }
+
+    #[test]
+    fn country_name_tag_string() {
+        let allocator = arena_serde::Arena::new();
+        let name = deserialize_country_name(r#"country_name="GBR""#, &allocator);
+        assert_eq!(name.name().to_str(), "GBR");
+    }
+
+    #[test]
+    fn country_name_object_with_name_and_adjective_key() {
+        // e.g. name="INC" key={ "Adjective"="INC_ADJ" }
+        let allocator = arena_serde::Arena::new();
+        let name = deserialize_country_name(
+            r#"country_name={ name="INC" key={ "Adjective"="INC_ADJ" } }"#,
+            &allocator,
+        );
+        let CountryName::Object(obj) = name else {
+            panic!("expected Object")
+        };
+        assert_eq!(obj.name.unwrap().to_str(), "INC");
+        assert_eq!(obj.key.adjective_key().unwrap().to_str(), "INC_ADJ");
+        assert!(obj.override_name.is_none());
+        assert!(obj.bases.base.is_none());
+        assert!(obj.override_adj.is_none());
+    }
+
+    #[test]
+    fn country_name_object_without_name_is_empty() {
+        // "Paradox Country" placeholder: only has a key, no name field
+        let allocator = arena_serde::Arena::new();
+        let name = deserialize_country_name(
+            r#"country_name={ key={ "Custom_Name"="Paradox Country" } }"#,
+            &allocator,
+        );
+        let CountryName::Object(obj) = name else {
+            panic!("expected Object")
+        };
+        assert!(obj.name.is_none());
+        assert_eq!(obj.key.custom_name.unwrap().to_str(), "Paradox Country");
+    }
+
+    #[test]
+    fn country_name_object_with_plain_override() {
+        // e.g. name="KOU" override_name="saitama" override_adj="saitama"
+        let allocator = arena_serde::Arena::new();
+        let name = deserialize_country_name(
+            r#"country_name={ name="KOU" override_name="saitama" override_adj="saitama" }"#,
+            &allocator,
+        );
+        let CountryName::Object(obj) = name else {
+            panic!("expected Object")
+        };
+        let on = obj.override_name.unwrap();
+        let oa = obj.override_adj.unwrap();
+        assert_eq!(on.key.to_str(), "saitama");
+        assert!(on.variables.is_empty());
+        assert_eq!(oa.key.to_str(), "saitama");
+        assert!(oa.variables.is_empty());
+    }
+
+    #[test]
+    fn country_name_object_with_override_and_adjective_key() {
+        // e.g. name="YMT" override_name="kyoto" override_adj="kyoto" key={ "Adjective"="YMT_ADJ" }
+        let allocator = arena_serde::Arena::new();
+        let name = deserialize_country_name(
+            r#"country_name={ name="YMT" override_name="kyoto" override_adj="kyoto" key={ "Adjective"="YMT_ADJ" } }"#,
+            &allocator,
+        );
+        let CountryName::Object(obj) = name else {
+            panic!("expected Object")
+        };
+        assert_eq!(obj.name.unwrap().to_str(), "YMT");
+        assert_eq!(obj.override_name.unwrap().key.to_str(), "kyoto");
+        assert_eq!(obj.override_adj.unwrap().key.to_str(), "kyoto");
+        assert_eq!(obj.key.adjective_key().unwrap().to_str(), "YMT_ADJ");
+    }
+
+    #[test]
+    fn country_name_object_with_bases() {
+        // e.g. name="CIVILWAR_FACTION_nobles_estate_NAME" key={ "Adjective"="..." } bases={ Base=HKK }
+        let allocator = arena_serde::Arena::new();
+        let name = deserialize_country_name(
+            r#"country_name={ name="CIVILWAR_FACTION_nobles_estate_NAME" key={ "Adjective"="CIVILWAR_FACTION_nobles_estate_ADJECTIVE" } bases={ Base=HKK } }"#,
+            &allocator,
+        );
+        let CountryName::Object(obj) = name else {
+            panic!("expected Object")
+        };
+        assert_eq!(
+            obj.name.unwrap().to_str(),
+            "CIVILWAR_FACTION_nobles_estate_NAME"
+        );
+        assert_eq!(
+            obj.key.adjective_key().unwrap().to_str(),
+            "CIVILWAR_FACTION_nobles_estate_ADJECTIVE"
+        );
+        assert_eq!(obj.bases.base.unwrap().to_str(), "HKK");
+    }
+
+    #[test]
+    fn country_name_horde_pretender_full_shape() {
+        // Verbatim shape from the EU5 save horde civil war pretender entry.
+        let allocator = arena_serde::Arena::new();
+        let name = deserialize_country_name(
+            r#"country_name={
+                name="horde_civil_war_pretender_country"
+                key={
+                    "Adjective"="horde_civil_war_pretender_country_adjective"
+                }
+                bases={
+                    Base=TIM
+                }
+            }"#,
+            &allocator,
+        );
+        let CountryName::Object(obj) = name else {
+            panic!("expected Object")
+        };
+        assert_eq!(
+            obj.name.unwrap().to_str(),
+            "horde_civil_war_pretender_country"
+        );
+        assert_eq!(
+            obj.key.adjective_key().unwrap().to_str(),
+            "horde_civil_war_pretender_country_adjective"
+        );
+        assert_eq!(obj.bases.base.unwrap().to_str(), "TIM");
+    }
+
+    #[test]
+    fn country_name_object_with_structured_override_extracts_key() {
+        // e.g. override_name={ key="game_dynasty_name_struct_notooltip" variables={...} }
+        let allocator = arena_serde::Arena::new();
+        let name = deserialize_country_name(
+            r#"country_name={ name="CLR" override_name={ key="game_dynasty_name_struct_notooltip" variables={ { key="PREFIX" value="x" } } } }"#,
+            &allocator,
+        );
+        let CountryName::Object(obj) = name else {
+            panic!("expected Object")
+        };
+        let on = obj.override_name.unwrap();
+        assert_eq!(on.key.to_str(), "game_dynasty_name_struct_notooltip");
+        assert_eq!(on.variables.len(), 1);
+        assert_eq!(on.variables[0].key.to_str(), "PREFIX");
+        assert_eq!(on.variables[0].value.to_str(), "x");
+    }
+
+    #[test]
+    fn country_name_object_with_structured_override_multiple_variables() {
+        let allocator = arena_serde::Arena::new();
+        let name = deserialize_country_name(
+            r#"country_name={ name="CLR" override_name={ key="game_dynasty_name_struct_notooltip" variables={ { key="PREFIX" value="a" } { key="SUFFIX" value="b" } } } }"#,
+            &allocator,
+        );
+        let CountryName::Object(obj) = name else {
+            panic!("expected Object")
+        };
+        let on = obj.override_name.unwrap();
+        assert_eq!(on.variables.len(), 2);
+        assert_eq!(on.variables[1].key.to_str(), "SUFFIX");
+        assert_eq!(on.variables[1].value.to_str(), "b");
+    }
+
+    #[test]
+    fn country_name_object_with_base_object() {
+        // bases.Base can be a nested CountryNameObject rather than a simple tag string,
+        // as seen in civil war faction countries in EU5 saves.
+        let allocator = arena_serde::Arena::new();
+        let name = deserialize_country_name(
+            r#"country_name={
+                name="CIVILWAR_FACTION_clergy_estate_NAME"
+                key={
+                    "Adjective"="CIVILWAR_FACTION_clergy_estate_ADJECTIVE"
+                }
+                bases={
+                    Base={
+                        name="ASK"
+                        override_name="toshima_kanto"
+                        override_adj="toshima_kanto"
+                        key={
+                            "Adjective"="ASK_ADJ"
+                        }
+                    }
+                }
+            }"#,
+            &allocator,
+        );
+        let CountryName::Object(obj) = name else {
+            panic!("expected Object")
+        };
+        assert_eq!(
+            obj.name.unwrap().to_str(),
+            "CIVILWAR_FACTION_clergy_estate_NAME"
+        );
+        assert_eq!(obj.bases.base.unwrap().to_str(), "ASK");
+    }
+}
+
+#[derive(Debug)]
+pub struct CountriesIter<'a> {
+    index: usize,
+    countries: &'a Countries<'a>,
+}
+
+impl<'a> CountriesIter<'a> {
+    pub fn new(countries: &'a Countries<'a>) -> Self {
+        CountriesIter {
+            index: 0,
+            countries,
+        }
+    }
+}
+
+impl<'a> Iterator for CountriesIter<'a> {
+    type Item = CountryEntry<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.countries.ids.data.len() {
+            let result = CountryEntry {
+                idx: CountryIdx::from_index(self.index),
+                countries: self.countries,
+            };
+            self.index += 1;
+            Some(result)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.countries.ids.data.len() - self.index;
+        (len, Some(len))
+    }
+}
+
+#[derive(Debug)]
+pub struct CountryEntry<'a> {
+    idx: CountryIdx,
+    countries: &'a Countries<'a>,
+}
+
+impl<'a> CountryEntry<'a> {
+    #[inline]
+    pub fn idx(&self) -> CountryIdx {
+        self.idx
+    }
+
+    #[inline]
+    pub fn id(&self) -> CountryId {
+        self.countries.ids[self.idx]
+    }
+
+    #[inline]
+    pub fn tag(&self) -> CountryTag<'a> {
+        self.countries.tags[self.idx]
+    }
+
+    #[inline]
+    pub fn data(&self) -> Option<&'a Country<'a>> {
+        self.countries.database[self.idx].as_ref()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct CountryIndexedVec<'bump, T> {
+    data: &'bump [T],
+}
+
+impl<'bump, T> CountryIndexedVec<'bump, T> {
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.data.iter()
+    }
+}
+
+impl<'bump, T> Index<CountryIdx> for CountryIndexedVec<'bump, T> {
+    type Output = T;
+
+    #[inline]
+    fn index(&self, index: CountryIdx) -> &Self::Output {
+        &self.data[index.index()]
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct CountryIndexedVecOwned<T> {
+    data: Box<[T]>,
+}
+
+impl<T> CountryIndexedVecOwned<T> {
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.data.iter()
+    }
+}
+
+impl<T> Index<CountryIdx> for CountryIndexedVecOwned<T> {
+    type Output = T;
+
+    #[inline]
+    fn index(&self, index: CountryIdx) -> &Self::Output {
+        &self.data[index.index()]
+    }
+}
+
+impl<T> IndexMut<CountryIdx> for CountryIndexedVecOwned<T> {
+    #[inline]
+    fn index_mut(&mut self, index: CountryIdx) -> &mut Self::Output {
+        &mut self.data[index.index()]
+    }
+}

--- a/crates/eu5save/src/models/culture_manager.rs
+++ b/crates/eu5save/src/models/culture_manager.rs
@@ -1,0 +1,320 @@
+use crate::models::Color;
+use crate::models::bstr::BStr;
+use arena_serde::{ArenaDeserialize, ArenaSeed};
+use serde::de::value::MapAccessDeserializer;
+use serde::{Deserialize, de};
+use std::fmt;
+
+#[derive(Debug, Default, ArenaDeserialize)]
+pub struct CultureManager<'bump> {
+    #[arena(deserialize_with = "deserialize_cultures")]
+    pub database: CultureDatabase<'bump>,
+}
+
+impl<'bump> CultureManager<'bump> {
+    pub fn lookup(&self, id: CultureId) -> Option<&Culture<'bump>> {
+        if let Some(x) = self.database.ids.get(id.value() as usize)
+            && *x == id
+        {
+            return Some(&self.database.values[id.value() as usize]);
+        }
+
+        self.database
+            .ids
+            .iter()
+            .position(|&x| x == id)
+            .map(|idx| &self.database.values[idx])
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct CultureDatabase<'bump> {
+    ids: &'bump [CultureId],
+    values: &'bump [Culture<'bump>],
+}
+
+impl<'bump> CultureDatabase<'bump> {
+    pub fn iter(&self) -> impl Iterator<Item = &Culture<'bump>> {
+        self.values.iter()
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Default, ArenaDeserialize,
+)]
+#[serde(transparent)]
+pub struct CultureId(u32);
+
+impl CultureId {
+    #[inline]
+    pub fn new(id: u32) -> Self {
+        CultureId(id)
+    }
+
+    #[inline]
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, ArenaDeserialize)]
+pub struct Culture<'bump> {
+    pub name: CultureName<'bump>,
+    #[arena(default)]
+    pub key: Option<BStr<'bump>>,
+    #[arena(default)]
+    pub size: f64,
+    #[arena(default)]
+    pub cultural_influence: f64,
+    #[arena(default)]
+    pub color: Color,
+}
+
+/// Culture name, either a plain string identifier or a localization object with
+/// a key and interpolation variables.
+///
+/// Plain string:
+/// ```text
+/// name="dakelh_culture"
+/// ```
+///
+/// Object:
+/// ```text
+/// name={
+///     key="NEW_CULTURE_NAME_ADJ_OLD_CULTURE"
+///     variables={ { key="OLD_CULTURE_NAME" value="irish" } }
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub enum CultureName<'bump> {
+    Tag(BStr<'bump>),
+    Object(CultureNameObject<'bump>),
+}
+
+impl<'bump> CultureName<'bump> {
+    pub fn key(&self) -> BStr<'bump> {
+        match self {
+            CultureName::Tag(tag) => *tag,
+            CultureName::Object(obj) => obj.key,
+        }
+    }
+}
+
+#[derive(Debug, Clone, ArenaDeserialize)]
+pub struct CultureNameObject<'bump> {
+    pub key: BStr<'bump>,
+    #[arena(default)]
+    pub variables: &'bump [CultureNameVariable<'bump>],
+}
+
+#[derive(Debug, Clone, ArenaDeserialize)]
+pub struct CultureNameVariable<'bump> {
+    pub key: BStr<'bump>,
+    pub value: BStr<'bump>,
+}
+
+impl<'bump> ArenaDeserialize<'bump> for CultureName<'bump> {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump arena_serde::Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct CultureNameVisitor<'bump>(&'bump arena_serde::Arena);
+
+        impl<'de, 'bump> de::Visitor<'de> for CultureNameVisitor<'bump> {
+            type Value = CultureName<'bump>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a culture name string or object")
+            }
+
+            fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                self.visit_bytes(v.as_bytes())
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                self.visit_bytes(v.as_bytes())
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                self.visit_str(&v)
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(CultureName::Tag(BStr::new(self.0.alloc_slice_copy(v))))
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::MapAccess<'de>,
+            {
+                let deser = MapAccessDeserializer::new(map);
+                let obj = CultureNameObject::deserialize_in_arena(deser, self.0)?;
+                Ok(CultureName::Object(obj))
+            }
+        }
+
+        deserializer.deserialize_map(CultureNameVisitor(allocator))
+    }
+}
+
+#[inline]
+fn deserialize_cultures<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<CultureDatabase<'bump>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct CultureVisitor<'bump>(&'bump arena_serde::Arena);
+
+    impl<'de, 'bump> de::Visitor<'de> for CultureVisitor<'bump> {
+        type Value = CultureDatabase<'bump>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map containing culture entries")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut culture_ids = bumpalo::collections::Vec::with_capacity_in(1024, self.0);
+            let mut culture_values = bumpalo::collections::Vec::with_capacity_in(1024, self.0);
+            while let Some((key, value)) =
+                map.next_entry_seed(ArenaSeed::new(self.0), ArenaSeed::<Culture>::new(self.0))?
+            {
+                culture_ids.push(key);
+                culture_values.push(value);
+            }
+
+            let ids = culture_ids.into_bump_slice();
+            let values = culture_values.into_bump_slice();
+            Ok(CultureDatabase { ids, values })
+        }
+    }
+
+    deserializer.deserialize_map(CultureVisitor(allocator))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jomini::TextDeserializer;
+
+    #[test]
+    fn parses_culture_with_name_tag() {
+        let data = r#"database={
+    0={
+        name="dakelh_culture"
+        size=3.392
+        culture_definition=dakelh_culture
+        color=rgb {
+            68 252 27
+        }
+        language=nadene_language
+    }
+    1={
+        name="wetsuweten_culture"
+        size=1.431
+        culture_definition=wetsuweten_culture
+        color=rgb {
+            105 220 125
+        }
+        language=nadene_language
+    }
+}"#;
+
+        let allocator = arena_serde::Arena::new();
+        let deserializer =
+            TextDeserializer::from_utf8_slice(data.as_bytes()).expect("valid text data");
+        let manager = CultureManager::deserialize_in_arena(&deserializer, &allocator)
+            .expect("culture manager deserializes");
+
+        let cultures: Vec<_> = manager.database.iter().collect();
+        assert_eq!(cultures.len(), 2);
+
+        let dakelh = manager
+            .lookup(CultureId::new(0))
+            .expect("culture id 0 exists");
+        assert_eq!(dakelh.name.key().to_str(), "dakelh_culture");
+        assert_eq!(dakelh.size, 3.392);
+        assert_eq!(dakelh.color.0, [68, 252, 27]);
+
+        let wetsuweten = manager
+            .lookup(CultureId::new(1))
+            .expect("culture id 1 exists");
+        assert_eq!(wetsuweten.name.key().to_str(), "wetsuweten_culture");
+        assert_eq!(wetsuweten.size, 1.431);
+        assert_eq!(wetsuweten.color.0, [105, 220, 125]);
+    }
+
+    #[test]
+    fn parses_culture_with_name_object() {
+        let data = r#"database={
+    2085={
+        name={
+            key="NEW_CULTURE_NAME_ADJ_OLD_CULTURE"
+            variables={
+                {
+                    key="COUNTRY_NAME"
+                    value="nova_scotia_scripted_country_name"
+                }
+                {
+                    key="COUNTRY_ADJ"
+                    value="nova_scotia_scripted_country_name"
+                }
+                {
+                    key="OLD_CULTURE_NAME"
+                    value="irish"
+                }
+            }
+        }
+        key="irish_aba45"
+        size=2252.95637
+        cultural_influence=1074.29957
+    }
+}"#;
+
+        let allocator = arena_serde::Arena::new();
+        let deserializer =
+            TextDeserializer::from_utf8_slice(data.as_bytes()).expect("valid text data");
+        let manager = CultureManager::deserialize_in_arena(&deserializer, &allocator)
+            .expect("culture manager deserializes");
+
+        let culture = manager
+            .lookup(CultureId::new(2085))
+            .expect("culture id 2085 exists");
+
+        let CultureName::Object(ref name_obj) = culture.name else {
+            panic!("expected CultureName::Object");
+        };
+        assert_eq!(name_obj.key.to_str(), "NEW_CULTURE_NAME_ADJ_OLD_CULTURE");
+        assert_eq!(name_obj.variables.len(), 3);
+        assert_eq!(name_obj.variables[0].key.to_str(), "COUNTRY_NAME");
+        assert_eq!(
+            name_obj.variables[0].value.to_str(),
+            "nova_scotia_scripted_country_name"
+        );
+        assert_eq!(name_obj.variables[2].key.to_str(), "OLD_CULTURE_NAME");
+        assert_eq!(name_obj.variables[2].value.to_str(), "irish");
+
+        assert_eq!(culture.key.map(|x| x.to_str()), Some("irish_aba45"));
+        assert_eq!(culture.size, 2252.95637);
+        assert_eq!(culture.cultural_influence, 1074.29957);
+    }
+}

--- a/crates/eu5save/src/models/de.rs
+++ b/crates/eu5save/src/models/de.rs
@@ -1,0 +1,7 @@
+mod maybe;
+mod vec_capacity;
+mod vec_pair;
+
+pub use maybe::*;
+pub use vec_capacity::*;
+pub use vec_pair::*;

--- a/crates/eu5save/src/models/de/maybe.rs
+++ b/crates/eu5save/src/models/de/maybe.rs
@@ -1,0 +1,394 @@
+use serde::{
+    Deserialize, Deserializer, Serialize,
+    de::{
+        self,
+        value::{BorrowedStrDeserializer, StrDeserializer, StringDeserializer},
+    },
+};
+use std::marker::PhantomData;
+
+/// Helper trait for implementing special value deserializers
+pub(crate) trait SpecialValueDeserializer<T> {
+    /// Check if a string represents the special value
+    fn is_special(value: &str) -> bool;
+
+    /// Create the special variant
+    fn create_special() -> Self;
+
+    /// Create the visible variant
+    fn create_visible(value: T) -> Self;
+}
+
+/// Value that could be "none"
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct Maybe<T>(Option<T>);
+
+impl<T> Maybe<T> {
+    pub fn into_value(self) -> Option<T> {
+        self.0
+    }
+}
+
+impl<T> SpecialValueDeserializer<T> for Maybe<T> {
+    fn is_special(value: &str) -> bool {
+        value == "none"
+    }
+
+    fn create_special() -> Self {
+        Maybe(None)
+    }
+
+    fn create_visible(value: T) -> Self {
+        Maybe(Some(value))
+    }
+}
+
+impl<T> Serialize for Maybe<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0 {
+            None => serializer.serialize_str("none"),
+            Some(ref value) => value.serialize(serializer),
+        }
+    }
+}
+
+pub(crate) fn deserialize_special_value<'de, D, T, S>(deserializer: D) -> Result<S, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+    S: SpecialValueDeserializer<T>,
+{
+    struct SpecialVisitor<T, S> {
+        marker: PhantomData<(T, S)>,
+    }
+
+    impl<'de, T, S> de::Visitor<'de> for SpecialVisitor<T, S>
+    where
+        T: Deserialize<'de>,
+        S: SpecialValueDeserializer<T>,
+    {
+        type Value = S;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a string or a value")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if S::is_special(v) {
+                Ok(S::create_special())
+            } else {
+                T::deserialize(StrDeserializer::new(v)).map(S::create_visible)
+            }
+        }
+
+        fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if S::is_special(&v) {
+                Ok(S::create_special())
+            } else {
+                T::deserialize(StringDeserializer::new(v)).map(S::create_visible)
+            }
+        }
+
+        fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if S::is_special(v) {
+                Ok(S::create_special())
+            } else {
+                T::deserialize(BorrowedStrDeserializer::new(v)).map(S::create_visible)
+            }
+        }
+
+        // For all non-string types, just deserialize directly to visible variant
+        fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(S::create_visible(T::deserialize(
+                serde::de::value::BoolDeserializer::new(v),
+            )?))
+        }
+
+        fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(S::create_visible(T::deserialize(
+                serde::de::value::I8Deserializer::new(v),
+            )?))
+        }
+
+        fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(S::create_visible(T::deserialize(
+                serde::de::value::I16Deserializer::new(v),
+            )?))
+        }
+
+        fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(S::create_visible(T::deserialize(
+                serde::de::value::I32Deserializer::new(v),
+            )?))
+        }
+
+        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(S::create_visible(T::deserialize(
+                serde::de::value::I64Deserializer::new(v),
+            )?))
+        }
+
+        fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(S::create_visible(T::deserialize(
+                serde::de::value::U8Deserializer::new(v),
+            )?))
+        }
+
+        fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(S::create_visible(T::deserialize(
+                serde::de::value::U16Deserializer::new(v),
+            )?))
+        }
+
+        fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(S::create_visible(T::deserialize(
+                serde::de::value::U32Deserializer::new(v),
+            )?))
+        }
+
+        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(S::create_visible(T::deserialize(
+                serde::de::value::U64Deserializer::new(v),
+            )?))
+        }
+
+        fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(S::create_visible(T::deserialize(
+                serde::de::value::F32Deserializer::new(v),
+            )?))
+        }
+
+        fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(S::create_visible(T::deserialize(
+                serde::de::value::F64Deserializer::new(v),
+            )?))
+        }
+
+        fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::SeqAccess<'de>,
+        {
+            Ok(S::create_visible(T::deserialize(
+                serde::de::value::SeqAccessDeserializer::new(seq),
+            )?))
+        }
+
+        fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            Ok(S::create_visible(T::deserialize(
+                serde::de::value::MapAccessDeserializer::new(map),
+            )?))
+        }
+    }
+
+    deserializer.deserialize_map(SpecialVisitor {
+        marker: PhantomData,
+    })
+}
+
+impl<'de, T> Deserialize<'de> for Maybe<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_special_value(deserializer)
+    }
+}
+
+// ArenaDeserialize implementation for Maybe
+impl<'bump, T> arena_serde::ArenaDeserialize<'bump> for Maybe<T>
+where
+    T: arena_serde::ArenaDeserialize<'bump>,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump arena_serde::Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        fn deserialize_special_value_arena<'de, 'bump, D, T, S>(
+            deserializer: D,
+            allocator: &'bump arena_serde::Arena,
+        ) -> Result<S, D::Error>
+        where
+            D: Deserializer<'de>,
+            T: arena_serde::ArenaDeserialize<'bump>,
+            S: SpecialValueDeserializer<T>,
+        {
+            struct SpecialArenaVisitor<'bump, T, S> {
+                allocator: &'bump arena_serde::Arena,
+                marker: PhantomData<(T, S)>,
+            }
+
+            impl<'de, 'bump, T, S> de::Visitor<'de> for SpecialArenaVisitor<'bump, T, S>
+            where
+                T: arena_serde::ArenaDeserialize<'bump>,
+                S: SpecialValueDeserializer<T>,
+            {
+                type Value = S;
+
+                fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    formatter.write_str("a string or a value")
+                }
+
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    if S::is_special(v) {
+                        Ok(S::create_special())
+                    } else {
+                        T::deserialize_in_arena(StrDeserializer::new(v), self.allocator)
+                            .map(S::create_visible)
+                    }
+                }
+
+                fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    if S::is_special(&v) {
+                        Ok(S::create_special())
+                    } else {
+                        T::deserialize_in_arena(StringDeserializer::new(v), self.allocator)
+                            .map(S::create_visible)
+                    }
+                }
+
+                fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    if S::is_special(v) {
+                        Ok(S::create_special())
+                    } else {
+                        T::deserialize_in_arena(BorrowedStrDeserializer::new(v), self.allocator)
+                            .map(S::create_visible)
+                    }
+                }
+
+                fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+                where
+                    A: de::MapAccess<'de>,
+                {
+                    Ok(S::create_visible(T::deserialize_in_arena(
+                        serde::de::value::MapAccessDeserializer::new(map),
+                        self.allocator,
+                    )?))
+                }
+
+                // For all other types, delegate to the ArenaDeserialize implementation
+                fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    Ok(S::create_visible(T::deserialize_in_arena(
+                        serde::de::value::BoolDeserializer::new(v),
+                        self.allocator,
+                    )?))
+                }
+
+                fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    Ok(S::create_visible(T::deserialize_in_arena(
+                        serde::de::value::I32Deserializer::new(v),
+                        self.allocator,
+                    )?))
+                }
+
+                fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    Ok(S::create_visible(T::deserialize_in_arena(
+                        serde::de::value::U32Deserializer::new(v),
+                        self.allocator,
+                    )?))
+                }
+
+                fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    Ok(S::create_visible(T::deserialize_in_arena(
+                        serde::de::value::F64Deserializer::new(v),
+                        self.allocator,
+                    )?))
+                }
+
+                fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+                where
+                    A: de::SeqAccess<'de>,
+                {
+                    Ok(S::create_visible(T::deserialize_in_arena(
+                        serde::de::value::SeqAccessDeserializer::new(seq),
+                        self.allocator,
+                    )?))
+                }
+            }
+
+            deserializer.deserialize_map(SpecialArenaVisitor {
+                allocator,
+                marker: PhantomData,
+            })
+        }
+
+        deserialize_special_value_arena(deserializer, allocator)
+    }
+}

--- a/crates/eu5save/src/models/de/vec_capacity.rs
+++ b/crates/eu5save/src/models/de/vec_capacity.rs
@@ -1,0 +1,47 @@
+use std::marker::PhantomData;
+
+use arena_serde::{ArenaDeserialize, ArenaSeed};
+
+pub fn deserialize_vec_capacity<'bump, 'de, D, T, const CAPACITY: usize>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<&'bump [T], D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: ArenaDeserialize<'bump> + 'bump,
+{
+    struct VecVisitor<'bump, T> {
+        allocator: &'bump arena_serde::Arena,
+        capacity: usize,
+        marker: PhantomData<T>,
+    }
+
+    impl<'bump, 'de, T1> serde::de::Visitor<'de> for VecVisitor<'bump, T1>
+    where
+        T1: ArenaDeserialize<'bump> + 'bump,
+    {
+        type Value = &'bump [T1];
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a capacity initial vec")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut vec =
+                bumpalo::collections::Vec::with_capacity_in(self.capacity, self.allocator);
+            while let Some(element) = seq.next_element_seed(ArenaSeed::new(self.allocator))? {
+                vec.push(element);
+            }
+            Ok(vec.into_bump_slice())
+        }
+    }
+
+    deserializer.deserialize_seq(VecVisitor {
+        allocator,
+        marker: PhantomData,
+        capacity: CAPACITY,
+    })
+}

--- a/crates/eu5save/src/models/de/vec_pair.rs
+++ b/crates/eu5save/src/models/de/vec_pair.rs
@@ -1,0 +1,98 @@
+use crate::models::de::Maybe;
+use arena_serde::{ArenaDeserialize, ArenaSeed};
+use serde::{Deserializer, de};
+use std::{fmt, marker::PhantomData};
+
+pub fn deserialize_vec_pair_arena<'bump, 'de, D, K, V>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<bumpalo::collections::Vec<'bump, (K, Option<V>)>, D::Error>
+where
+    D: Deserializer<'de>,
+    K: ArenaDeserialize<'bump> + std::fmt::Debug + 'bump,
+    V: ArenaDeserialize<'bump> + 'bump,
+{
+    struct VecPairArenaVisitor<'bump, K1, V1> {
+        allocator: &'bump arena_serde::Arena,
+        marker: PhantomData<(K1, V1)>,
+    }
+
+    impl<'bump, 'de, K1, V1> de::Visitor<'de> for VecPairArenaVisitor<'bump, K1, V1>
+    where
+        K1: ArenaDeserialize<'bump> + std::fmt::Debug + 'bump,
+        V1: ArenaDeserialize<'bump> + 'bump,
+    {
+        type Value = bumpalo::collections::Vec<'bump, (K1, Option<V1>)>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map containing key value tuples")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut values = bumpalo::collections::Vec::new_in(self.allocator);
+
+            while let Some(key) = map.next_key_seed(ArenaSeed::<K1>::new(self.allocator))? {
+                let maybe_value =
+                    map.next_value_seed(ArenaSeed::<Maybe<V1>>::new(self.allocator))?;
+                let value = maybe_value.into_value();
+                values.push((key, value));
+            }
+
+            Ok(values)
+        }
+    }
+
+    deserializer.deserialize_map(VecPairArenaVisitor {
+        allocator,
+        marker: PhantomData,
+    })
+}
+
+pub fn deserialize_vec_pair_arena_required<'bump, 'de, D, K, V>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<bumpalo::collections::Vec<'bump, (K, V)>, D::Error>
+where
+    D: Deserializer<'de>,
+    K: ArenaDeserialize<'bump> + std::fmt::Debug + 'bump,
+    V: ArenaDeserialize<'bump> + 'bump,
+{
+    struct VecPairArenaRequiredVisitor<'bump, K1, V1> {
+        allocator: &'bump arena_serde::Arena,
+        marker: PhantomData<(K1, V1)>,
+    }
+
+    impl<'bump, 'de, K1, V1> de::Visitor<'de> for VecPairArenaRequiredVisitor<'bump, K1, V1>
+    where
+        K1: ArenaDeserialize<'bump> + std::fmt::Debug + 'bump,
+        V1: ArenaDeserialize<'bump> + 'bump,
+    {
+        type Value = bumpalo::collections::Vec<'bump, (K1, V1)>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map containing key value tuples")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut values = bumpalo::collections::Vec::new_in(self.allocator);
+
+            while let Some(key) = map.next_key_seed(ArenaSeed::<K1>::new(self.allocator))? {
+                let value = map.next_value_seed(ArenaSeed::<V1>::new(self.allocator))?;
+                values.push((key, value));
+            }
+
+            Ok(values)
+        }
+    }
+
+    deserializer.deserialize_map(VecPairArenaRequiredVisitor {
+        allocator,
+        marker: PhantomData,
+    })
+}

--- a/crates/eu5save/src/models/diplomacy_manager.rs
+++ b/crates/eu5save/src/models/diplomacy_manager.rs
@@ -1,0 +1,473 @@
+use crate::Eu5Date;
+use crate::models::countries::CountryId;
+use serde::de;
+use serde::{Deserialize, Deserializer};
+use std::fmt;
+
+#[derive(Debug, PartialEq)]
+pub struct DiplomacyManager<'bump> {
+    dependencies: &'bump [DiplomacyDependency],
+    entries: &'bump [CountryDiplomacy],
+}
+
+impl<'bump> DiplomacyManager<'bump> {
+    pub fn dependencies(&self) -> impl ExactSizeIterator<Item = &DiplomacyDependency> + '_ {
+        self.dependencies.iter()
+    }
+
+    pub fn entries(&self) -> impl ExactSizeIterator<Item = &CountryDiplomacy> + '_ {
+        self.entries.iter()
+    }
+}
+
+fn deserialize_diplomacy_manager<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<DiplomacyManager<'bump>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Debug, PartialEq, Clone, Copy)]
+    enum DiplomacyManagerField {
+        Int(u32),
+        Dependency,
+        Other,
+    }
+
+    struct DiplomacyManagerFieldVisitor;
+
+    impl<'de> de::Visitor<'de> for DiplomacyManagerFieldVisitor {
+        type Value = DiplomacyManagerField;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("an integer or a dependency")
+        }
+
+        fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(DiplomacyManagerField::Int(v as u32))
+        }
+
+        fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(DiplomacyManagerField::Int(v))
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if v == "dependency" {
+                Ok(DiplomacyManagerField::Dependency)
+            } else if let Ok(v) = v.parse() {
+                Ok(DiplomacyManagerField::Int(v))
+            } else {
+                Ok(DiplomacyManagerField::Other)
+            }
+        }
+    }
+
+    impl<'de> Deserialize<'de> for DiplomacyManagerField {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(DiplomacyManagerFieldVisitor)
+        }
+    }
+
+    struct DiplomacyManagerVisitor<'a>(&'a arena_serde::Arena);
+
+    impl<'de, 'a> de::Visitor<'de> for DiplomacyManagerVisitor<'a> {
+        type Value = DiplomacyManager<'a>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a diplomacy manager with dependencies")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut dependencies = bumpalo::collections::Vec::new_in(self.0);
+            let mut country_diplomacy = bumpalo::collections::Vec::new_in(self.0);
+
+            while let Some(key) = map.next_key()? {
+                match key {
+                    DiplomacyManagerField::Int(country) => {
+                        let raw = map.next_value::<CountryDiplomacyRaw>()?;
+                        country_diplomacy.push(CountryDiplomacy {
+                            country: CountryId::new(country),
+                            liberty_desire: raw.liberty_desire,
+                        });
+                    }
+                    DiplomacyManagerField::Dependency => {
+                        let dependency =
+                            map.next_value_seed(
+                                arena_serde::ArenaSeed::<DiplomacyDependency>::new(self.0),
+                            )?;
+                        dependencies.push(dependency);
+                    }
+                    DiplomacyManagerField::Other => {
+                        map.next_value::<de::IgnoredAny>()?;
+                    }
+                }
+            }
+
+            Ok(DiplomacyManager {
+                dependencies: dependencies.into_bump_slice(),
+                entries: country_diplomacy.into_bump_slice(),
+            })
+        }
+    }
+
+    deserializer.deserialize_map(DiplomacyManagerVisitor(allocator))
+}
+
+impl<'bump> arena_serde::ArenaDeserialize<'bump> for DiplomacyManager<'bump> {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump arena_serde::Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserialize_diplomacy_manager(deserializer, allocator)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct CountryDiplomacy {
+    pub country: CountryId,
+    pub liberty_desire: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CountryDiplomacyRaw {
+    liberty_desire: Option<f64>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct DiplomacyDependency {
+    pub first: CountryId,
+    pub second: CountryId,
+    pub start_date: Option<Eu5Date>,
+    pub subject_type: DiplomacySubjectType,
+}
+
+impl<'bump> arena_serde::ArenaDeserialize<'bump> for DiplomacyDependency {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump arena_serde::Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = DiplomacyDependencyRaw::deserialize(deserializer)?;
+        Ok(Self::from_raw(raw))
+    }
+}
+
+impl<'de> Deserialize<'de> for DiplomacyDependency {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = DiplomacyDependencyRaw::deserialize(deserializer)?;
+        Ok(Self::from_raw(raw))
+    }
+}
+
+impl DiplomacyDependency {
+    fn from_raw(raw: DiplomacyDependencyRaw) -> Self {
+        DiplomacyDependency {
+            first: raw.first,
+            second: raw.second,
+            start_date: raw.start_date,
+            subject_type: raw
+                .subject_type
+                .or(raw.named_targets)
+                .unwrap_or(DiplomacySubjectType::Other),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct DiplomacyDependencyRaw {
+    #[serde(default)]
+    first: CountryId,
+    #[serde(default)]
+    second: CountryId,
+    start_date: Option<Eu5Date>,
+    subject_type: Option<DiplomacySubjectType>,
+    #[serde(default, deserialize_with = "deserialize_dependency_named_targets")]
+    named_targets: Option<DiplomacySubjectType>,
+}
+
+fn deserialize_dependency_named_targets<'de, D>(
+    deserializer: D,
+) -> Result<Option<DiplomacySubjectType>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct NamedTargetsVisitor;
+
+    impl<'de> de::Visitor<'de> for NamedTargetsVisitor {
+        type Value = Option<DiplomacySubjectType>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("dependency named targets")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::SeqAccess<'de>,
+        {
+            let mut subject_type = None;
+
+            while let Some(target) = seq.next_element::<DependencyNamedTarget>()? {
+                if subject_type.is_none()
+                    && target.flag == Some(DependencyNamedTargetFlag::SubjectType)
+                {
+                    subject_type = target.target.and_then(|target| target.object);
+                }
+            }
+
+            Ok(subject_type)
+        }
+    }
+
+    deserializer.deserialize_seq(NamedTargetsVisitor)
+}
+
+#[derive(Debug, Deserialize)]
+struct DependencyNamedTarget {
+    flag: Option<DependencyNamedTargetFlag>,
+    target: Option<DependencyNamedTargetValue>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+enum DependencyNamedTargetFlag {
+    SubjectType,
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+struct DependencyNamedTargetValue {
+    object: Option<DiplomacySubjectType>,
+}
+
+#[derive(Debug, PartialEq, Clone, Copy, Deserialize, arena_serde::ArenaDeserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiplomacySubjectType {
+    Dominion,
+    Fiefdom,
+    Vassal,
+    Tributary,
+    HanseaticMember,
+    Samanta,
+    Appanage,
+    Tusi,
+    March,
+    MahaSamanta,
+    ColonialNation,
+    Conquistador,
+    TradeCompany,
+    #[serde(other)]
+    Other,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arena_serde::ArenaDeserialize;
+    use jomini::TextDeserializer;
+
+    fn deserialize_manager<'bump>(
+        data: &str,
+        allocator: &'bump arena_serde::Arena,
+    ) -> DiplomacyManager<'bump> {
+        let deserializer =
+            TextDeserializer::from_utf8_slice(data.as_bytes()).expect("valid text data");
+
+        DiplomacyManager::deserialize_in_arena(&deserializer, allocator)
+            .expect("diplomacy manager deserializes")
+    }
+
+    fn assert_vassal_dependency(data: &str) {
+        let allocator = arena_serde::Arena::new();
+        let manager = deserialize_manager(data, &allocator);
+        let dependencies: Vec<_> = manager.dependencies().collect();
+
+        assert_eq!(dependencies.len(), 1);
+        assert_eq!(dependencies[0].first, CountryId::new(314));
+        assert_eq!(dependencies[0].second, CountryId::new(339));
+        assert_eq!(dependencies[0].subject_type, DiplomacySubjectType::Vassal);
+    }
+
+    #[test]
+    fn diplomacy_dependency_deserializes_direct_subject_type() {
+        assert_vassal_dependency(
+            r#"
+dependency={
+    first=314
+    second=339
+    subject_type=vassal
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn diplomacy_dependency_deserializes_named_target_subject_type() {
+        assert_vassal_dependency(
+            r#"
+dependency={
+    first=314
+    second=339
+    named_targets={ {
+            flag="subject_type"
+            target={
+                type=subject_type
+                object=vassal
+            }
+        } }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn diplomacy_dependency_unknown_subject_type_deserializes_to_other() {
+        let allocator = arena_serde::Arena::new();
+        let manager = deserialize_manager(
+            r#"
+dependency={
+    first=314
+    second=339
+    named_targets={ {
+            flag="subject_type"
+            target={
+                type=subject_type
+                object=unknown_future_type
+            }
+        } }
+}
+"#,
+            &allocator,
+        );
+        let dependencies: Vec<_> = manager.dependencies().collect();
+        assert_eq!(dependencies.len(), 1);
+        assert_eq!(dependencies[0].subject_type, DiplomacySubjectType::Other);
+    }
+
+    #[test]
+    fn diplomacy_dependency_deserializes_colonial_nation_subject_type() {
+        let allocator = arena_serde::Arena::new();
+        let manager = deserialize_manager(
+            r#"
+dependency={
+    first=283
+    second=83888446
+    named_targets={ {
+            flag="subject_type"
+            target={
+                type=subject_type
+                object=colonial_nation
+            }
+        } }
+    start_date=1445.1.1
+}
+"#,
+            &allocator,
+        );
+        let dependencies: Vec<_> = manager.dependencies().collect();
+        assert_eq!(dependencies.len(), 1);
+        assert_eq!(
+            dependencies[0].subject_type,
+            DiplomacySubjectType::ColonialNation
+        );
+    }
+
+    #[test]
+    fn diplomacy_dependency_with_null_identity_falls_back_to_other() {
+        // Some dependencies have identity=18446744073709551615 (null sentinel) instead of
+        // object=<type>, leaving subject_type unresolvable — should fall back to Other.
+        let allocator = arena_serde::Arena::new();
+        let manager = deserialize_manager(
+            r#"
+dependency={
+    first=283
+    second=1898
+    named_targets={ {
+            flag="subject_type"
+            target={
+                type=subject_type
+                identity=18446744073709551615
+            }
+        } }
+    start_date=1572.2.2
+}
+"#,
+            &allocator,
+        );
+        let dependencies: Vec<_> = manager.dependencies().collect();
+        assert_eq!(dependencies.len(), 1);
+        assert_eq!(dependencies[0].subject_type, DiplomacySubjectType::Other);
+    }
+
+    #[test]
+    fn diplomacy_manager_deserializes_country_liberty_desire() {
+        let allocator = arena_serde::Arena::new();
+        let manager = deserialize_manager(
+            r#"
+0={
+    diplomats=2.5
+}
+3={
+    diplomats=1.1
+    liberty_desire=17
+    rivals_2={
+        list={
+            {
+                country=1773
+                date=1337.4.2
+            }
+        }
+    }
+}
+4={
+    diplomats=0.7
+    liberty_desire=70.5
+}
+dependency={
+    first=314
+    second=339
+    subject_type=vassal
+}
+"#,
+            &allocator,
+        );
+
+        let country_diplomacy: Vec<_> = manager.entries().collect();
+        let dependencies: Vec<_> = manager.dependencies().collect();
+
+        assert_eq!(country_diplomacy.len(), 3);
+        assert_eq!(country_diplomacy[0].country, CountryId::new(0));
+        assert_eq!(country_diplomacy[0].liberty_desire, None);
+        assert_eq!(country_diplomacy[1].country, CountryId::new(3));
+        assert_eq!(country_diplomacy[1].liberty_desire, Some(17.0));
+        assert_eq!(country_diplomacy[2].country, CountryId::new(4));
+        assert_eq!(country_diplomacy[2].liberty_desire, Some(70.5));
+        assert_eq!(dependencies.len(), 1);
+        assert_eq!(dependencies[0].first, CountryId::new(314));
+        assert_eq!(dependencies[0].second, CountryId::new(339));
+        assert_eq!(dependencies[0].subject_type, DiplomacySubjectType::Vassal);
+    }
+}

--- a/crates/eu5save/src/models/loan_manager.rs
+++ b/crates/eu5save/src/models/loan_manager.rs
@@ -1,0 +1,96 @@
+use crate::models::CountryId;
+use crate::models::de::Maybe;
+use arena_serde::{ArenaDeserialize, ArenaSeed};
+use serde::{Deserialize, de};
+use std::fmt;
+
+#[derive(Debug, PartialEq, ArenaDeserialize)]
+pub struct LoanManager<'bump> {
+    #[arena(deserialize_with = "deserialize_units")]
+    pub database: LoanDatabase<'bump>,
+}
+
+impl<'bump> LoanManager<'bump> {}
+
+#[derive(Debug, PartialEq)]
+pub struct LoanDatabase<'bump> {
+    ids: &'bump [LoanId],
+    values: &'bump [Option<Loan>],
+}
+
+impl<'bump> LoanDatabase<'bump> {
+    /// Returns an iterator over all loans in the database
+    pub fn iter(&self) -> impl Iterator<Item = &Loan> {
+        self.values.iter().filter_map(|x| x.as_ref())
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Default, ArenaDeserialize,
+)]
+#[serde(transparent)]
+pub struct LoanId(u32);
+
+impl LoanId {
+    #[inline]
+    pub fn new(id: u32) -> Self {
+        LoanId(id)
+    }
+
+    #[inline]
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, ArenaDeserialize, PartialEq)]
+pub struct Loan {
+    pub amount: f64,
+    pub interest: f64,
+    #[arena(default)]
+    pub month: u32,
+    #[arena(default)]
+    pub borrower: CountryId,
+    #[arena(default)]
+    pub lender: CountryId,
+}
+
+#[inline]
+fn deserialize_units<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<LoanDatabase<'bump>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct LoanVisitor<'bump>(&'bump arena_serde::Arena);
+
+    impl<'de, 'bump> de::Visitor<'de> for LoanVisitor<'bump> {
+        type Value = LoanDatabase<'bump>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map containing sub-unit entries")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut loan_ids = bumpalo::collections::Vec::with_capacity_in(4096, self.0);
+            let mut loan_values = bumpalo::collections::Vec::with_capacity_in(4096, self.0);
+            while let Some((key, value)) = map.next_entry_seed(
+                ArenaSeed::new(self.0),
+                ArenaSeed::<Maybe<Loan>>::new(self.0),
+            )? {
+                loan_ids.push(key);
+                loan_values.push(value.into_value());
+            }
+
+            let ids = loan_ids.into_bump_slice();
+            let values = loan_values.into_bump_slice();
+            Ok(LoanDatabase { ids, values })
+        }
+    }
+
+    deserializer.deserialize_map(LoanVisitor(allocator))
+}

--- a/crates/eu5save/src/models/locations.rs
+++ b/crates/eu5save/src/models/locations.rs
@@ -1,0 +1,405 @@
+use crate::{
+    Eu5Date,
+    models::{self, MarketId, ReligionId, countries::CountryId, countries::CountryTag},
+};
+use arena_serde::{ArenaDeserialize, ArenaSeed};
+use serde::{Deserialize, de};
+use std::{
+    fmt,
+    ops::{Index, IndexMut},
+};
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Default, ArenaDeserialize,
+)]
+#[serde(transparent)]
+pub struct LocationId(u32);
+
+impl LocationId {
+    #[inline]
+    pub fn new(id: u32) -> Self {
+        LocationId(id)
+    }
+
+    #[inline]
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Default, ArenaDeserialize,
+)]
+#[serde(transparent)]
+pub struct LocationIdx(u32);
+
+impl LocationIdx {
+    #[inline]
+    pub fn new(idx: u32) -> Self {
+        LocationIdx(idx)
+    }
+
+    #[inline]
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, ArenaDeserialize)]
+pub struct Locations<'bump> {
+    #[arena(deserialize_with = "deserialize_locations_arena")]
+    pub locations: LocationsDataArena<'bump>,
+}
+
+#[derive(Debug)]
+pub struct LocationsDataArena<'bump> {
+    ids: &'bump [LocationId],
+    values: &'bump [Location<'bump>],
+}
+
+impl<'bump> Locations<'bump> {
+    pub fn iter(&self) -> LocationsIter<'bump> {
+        LocationsIter::new(self.locations.ids, self.locations.values)
+    }
+
+    pub fn get(&self, id: LocationId) -> Option<LocationIdx> {
+        // Fast path: check if the location is at the same index as its ID (1-based)
+        let index = (id.value().saturating_sub(1)) as usize;
+        if self.locations.ids.get(index).is_some_and(|loc| loc == &id) {
+            return Some(LocationIdx(index as u32));
+        }
+
+        self.locations
+            .ids
+            .iter()
+            .position(|location| location == &id)
+            .map(|idx| LocationIdx(idx as u32))
+    }
+
+    pub fn index(&self, idx: LocationIdx) -> LocationEntry<'bump> {
+        LocationEntry {
+            idx,
+            ids: self.locations.ids,
+            values: self.locations.values,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.locations.ids.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.locations.ids.is_empty()
+    }
+
+    pub fn create_index<T: Clone>(&self, initial: T) -> LocationIndexedVec<T> {
+        LocationIndexedVec {
+            data: vec![initial; self.len()],
+        }
+    }
+}
+
+#[derive(Debug, ArenaDeserialize)]
+pub struct Location<'bump> {
+    #[arena(default)]
+    pub owner: CountryId,
+    #[arena(default)]
+    pub controller: CountryId,
+    pub religion: Option<ReligionId>,
+    #[arena(default)]
+    pub control: f64, // 0.0 to 1.0
+    #[arena(default)]
+    pub development: f64, // 0.0 to 100.0...
+    #[arena(default)]
+    pub population: LocationPopulation<'bump>,
+    #[arena(default, alias = "max_raw_material_workers")]
+    pub rgo_level: f64,
+    pub market: Option<MarketId>,
+    #[arena(default)]
+    pub market_access: f64, // 0.0 to 1.0
+    #[arena(default)]
+    pub market_attraction: f64, // 0.0 to 1.0
+    #[arena(default)]
+    pub prosperity: f64, // 0.0 to 1.0
+    #[arena(default)]
+    pub proximity: f64, // 0.0 to 100.0
+    #[arena(default)]
+    pub local_proximity_propagation: f64,
+    #[arena(default)]
+    pub tax: f64,
+    #[arena(default)]
+    pub possible_tax: f64,
+    pub raw_material: Option<models::GoodName<'bump>>,
+    #[arena(default)]
+    pub rank: LocationRank,
+    /// Every owner the location has had, in date order. The `owner` field above
+    /// is the current owner, and this is the historical source for a map at a
+    /// past date.
+    #[arena(default)]
+    pub ownership_history: &'bump [LocationOwnership<'bump>],
+}
+
+/// One entry of a [`Location::ownership_history`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ArenaDeserialize)]
+pub struct LocationOwnership<'bump> {
+    /// The date the country took the location.
+    pub date: Eu5Date,
+    /// The country that took the location. An entry that makes the location
+    /// unowned has no owner in the save and gets the dummy country, in the
+    /// same way as [`Location::owner`]. Such an entry has the tag `---`.
+    #[arena(default)]
+    pub owner: CountryId,
+    /// The tag of the owner at that date. A country can change its tag later,
+    /// so this is not always the current tag of `owner`.
+    pub tag: CountryTag<'bump>,
+}
+
+#[derive(Debug, ArenaDeserialize, PartialEq, Eq, Default)]
+#[arena(rename_all = "snake_case")]
+pub enum LocationRank {
+    RuralSettlement,
+    Town,
+    City,
+    Megalopolis,
+    #[default]
+    #[arena(other)]
+    Other,
+}
+
+#[derive(Debug, Default, ArenaDeserialize)]
+pub struct LocationPopulation<'bump> {
+    #[arena(default)]
+    pub pops: &'bump [models::PopId],
+}
+
+#[inline]
+fn deserialize_locations_arena<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<LocationsDataArena<'bump>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct LocationsVisitor<'bump>(&'bump arena_serde::Arena);
+
+    impl<'de, 'bump> de::Visitor<'de> for LocationsVisitor<'bump> {
+        type Value = LocationsDataArena<'bump>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map containing location entries")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            // There's approximately 30,000 locations in game.
+            let mut location_ids = bumpalo::collections::Vec::with_capacity_in(30000, self.0);
+            let mut location_values = bumpalo::collections::Vec::with_capacity_in(30000, self.0);
+            while let Some((key, value)) =
+                map.next_entry_seed(ArenaSeed::new(self.0), ArenaSeed::new(self.0))?
+            {
+                location_ids.push(key);
+                location_values.push(value);
+            }
+
+            Ok(LocationsDataArena {
+                ids: location_ids.into_bump_slice(),
+                values: location_values.into_bump_slice(),
+            })
+        }
+    }
+
+    deserializer.deserialize_map(LocationsVisitor(allocator))
+}
+
+#[derive(Debug, Clone)]
+pub struct LocationsIter<'bump> {
+    index: LocationIdx,
+    ids: &'bump [LocationId],
+    values: &'bump [Location<'bump>],
+}
+
+impl<'bump> LocationsIter<'bump> {
+    pub fn new(ids: &'bump [LocationId], values: &'bump [Location<'bump>]) -> Self {
+        LocationsIter {
+            index: LocationIdx(0),
+            ids,
+            values,
+        }
+    }
+}
+
+impl<'bump> Iterator for LocationsIter<'bump> {
+    type Item = LocationEntry<'bump>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if (self.index.0 as usize) < self.ids.len() {
+            let result = LocationEntry {
+                idx: self.index,
+                ids: self.ids,
+                values: self.values,
+            };
+            self.index.0 += 1;
+            Some(result)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.ids.len() - (self.index.0 as usize);
+        (len, Some(len))
+    }
+}
+
+#[derive(Debug)]
+pub struct LocationEntry<'bump> {
+    idx: LocationIdx,
+    ids: &'bump [LocationId],
+    values: &'bump [Location<'bump>],
+}
+
+impl<'bump> LocationEntry<'bump> {
+    #[inline]
+    pub fn idx(&self) -> LocationIdx {
+        self.idx
+    }
+
+    #[inline]
+    pub fn id(&self) -> LocationId {
+        self.ids[self.idx.0 as usize]
+    }
+
+    #[inline]
+    pub fn location(&self) -> &'bump Location<'bump> {
+        &self.values[self.idx.0 as usize]
+    }
+}
+
+#[derive(Debug)]
+pub struct LocationIndexedVec<T> {
+    data: Vec<T>,
+}
+
+impl<T> LocationIndexedVec<T> {
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.data.iter()
+    }
+}
+
+impl<T> IndexMut<LocationIdx> for LocationIndexedVec<T> {
+    #[inline]
+    fn index_mut(&mut self, index: LocationIdx) -> &mut Self::Output {
+        &mut self.data[index.0 as usize]
+    }
+}
+
+impl<T> Index<LocationIdx> for LocationIndexedVec<T> {
+    type Output = T;
+
+    #[inline]
+    fn index(&self, index: LocationIdx) -> &Self::Output {
+        &self.data[index.0 as usize]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jomini::{TextDeserializer, common::PdsDate};
+
+    /// Location 134 in a 1346 save: Denmark held it from the start of the
+    /// campaign, and Skane took it on 1338.6.3.
+    #[test]
+    fn ownership_history() {
+        #[derive(ArenaDeserialize)]
+        struct Wrapper<'bump> {
+            location: Location<'bump>,
+        }
+
+        let data = r#"location={
+            owner=5
+            ownership_history={ {
+                    date=1337.4.1
+                    owner=4
+                    tag="DAN"
+                } {
+                    date=1338.6.3
+                    owner=5
+                    tag="SKE"
+                } }
+        }"#;
+
+        let allocator = arena_serde::Arena::new();
+        let deserializer =
+            TextDeserializer::from_utf8_slice(data.as_bytes()).expect("valid text data");
+        let location = Wrapper::deserialize_in_arena(&deserializer, &allocator)
+            .expect("location deserializes")
+            .location;
+
+        let [first, second] = location.ownership_history else {
+            panic!("expected two ownership entries")
+        };
+        assert_eq!(first.date.game_fmt().to_string(), "1337.4.1");
+        assert_eq!(first.owner, CountryId::new(4));
+        assert_eq!(first.tag.as_str(), "DAN");
+        assert_eq!(second.date.game_fmt().to_string(), "1338.6.3");
+        assert_eq!(second.owner, CountryId::new(5));
+        assert_eq!(second.tag.as_str(), "SKE");
+
+        // The last entry at or before the save date is the current owner.
+        assert_eq!(second.owner, location.owner);
+    }
+
+    /// A location that never changed hands has no history.
+    /// A location can become unowned. The entry then has the tag `---` and no
+    /// owner at all.
+    #[test]
+    fn ownership_history_without_an_owner() {
+        #[derive(ArenaDeserialize)]
+        struct Wrapper<'bump> {
+            location: Location<'bump>,
+        }
+
+        let data = r#"location={
+            ownership_history={ {
+                    date=1337.4.1
+                    owner=606
+                    tag="KOR"
+                } {
+                    date=1352.3.1
+                    tag="---"
+                } }
+        }"#;
+
+        let allocator = arena_serde::Arena::new();
+        let deserializer =
+            TextDeserializer::from_utf8_slice(data.as_bytes()).expect("valid text data");
+        let location = Wrapper::deserialize_in_arena(&deserializer, &allocator)
+            .expect("location to deserialize")
+            .location;
+
+        let history = location.ownership_history;
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].owner, CountryId::new(606));
+        assert!(history[1].owner.is_dummy());
+        assert_eq!(history[1].date.game_fmt().to_string(), "1352.3.1");
+    }
+
+    #[test]
+    fn ownership_history_is_optional() {
+        #[derive(ArenaDeserialize)]
+        struct Wrapper<'bump> {
+            location: Location<'bump>,
+        }
+
+        let allocator = arena_serde::Arena::new();
+        let deserializer =
+            TextDeserializer::from_utf8_slice(b"location={ owner=3 }").expect("valid text data");
+        let location = Wrapper::deserialize_in_arena(&deserializer, &allocator)
+            .expect("location deserializes")
+            .location;
+        assert!(location.ownership_history.is_empty());
+    }
+}

--- a/crates/eu5save/src/models/market_manager.rs
+++ b/crates/eu5save/src/models/market_manager.rs
@@ -1,0 +1,444 @@
+use crate::models::bstr::BStr;
+use crate::models::de::Maybe;
+use crate::models::{
+    Color, CountryId, LocationId, de::deserialize_vec_pair_arena_required, deserialize_vec_capacity,
+};
+use arena_serde::{ArenaDeserialize, ArenaSeed};
+use core::fmt;
+use serde::{Deserialize, Deserializer, de};
+
+#[derive(Debug, ArenaDeserialize)]
+pub struct MarketManager<'bump> {
+    #[arena(deserialize_with = "deserialize_produced_goods")]
+    pub produced_goods: &'bump [(GoodName<'bump>, f64)],
+
+    #[arena(deserialize_with = "deserialize_markets")]
+    pub database: MarketDatabase<'bump>,
+}
+
+impl<'bump> MarketManager<'bump> {
+    pub fn get(&self, id: MarketId) -> Option<&Market<'bump>> {
+        // Fast path: check if the id is the same as the index
+        if let Some(location) = self.database.ids.get(id.value() as usize)
+            && id == *location
+        {
+            return self.database.values[id.value() as usize].as_ref();
+        }
+
+        let pos = self
+            .database
+            .ids
+            .iter()
+            .position(|location| location == &id)?;
+        self.database.values[pos].as_ref()
+    }
+
+    pub fn len(&self) -> usize {
+        self.database.ids.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.database.ids.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, ArenaDeserialize, PartialEq, Copy, Eq, Hash, PartialOrd, Ord)]
+pub struct GoodName<'bump>(BStr<'bump>);
+
+impl<'bump> GoodName<'bump> {
+    pub fn new(bstr: BStr<'bump>) -> Self {
+        Self(bstr)
+    }
+
+    pub fn to_str(&self) -> &str {
+        self.0.to_str()
+    }
+}
+
+impl std::fmt::Display for GoodName<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_str())
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Default, ArenaDeserialize,
+)]
+#[serde(transparent)]
+pub struct MarketId(u32);
+
+impl MarketId {
+    #[inline]
+    pub fn new(id: u32) -> Self {
+        MarketId(id)
+    }
+
+    #[inline]
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct MarketDatabase<'bump> {
+    ids: &'bump [MarketId],
+    values: &'bump [Option<Market<'bump>>],
+}
+
+impl MarketDatabase<'_> {
+    pub fn iter(&self) -> impl Iterator<Item = &Market<'_>> {
+        self.values.iter().filter_map(|x| x.as_ref())
+    }
+
+    pub fn iter_with_id(&self) -> impl Iterator<Item = (MarketId, &Market<'_>)> {
+        self.ids
+            .iter()
+            .zip(self.values.iter())
+            .filter_map(|(&id, v)| v.as_ref().map(|m| (id, m)))
+    }
+}
+
+#[derive(Debug, ArenaDeserialize, PartialEq)]
+pub struct Merchant {
+    #[arena(default)]
+    pub country: CountryId,
+    #[arena(default)]
+    pub power: f64,
+    #[arena(default)]
+    pub capacity: f64,
+    #[arena(default)]
+    pub original_power: f64,
+    #[arena(default)]
+    pub original_capacity: f64,
+    #[arena(default)]
+    pub used: f64,
+}
+
+#[derive(Debug, ArenaDeserialize, PartialEq)]
+pub struct Market<'bump> {
+    pub center: LocationId,
+    #[arena(default)]
+    pub color: Color,
+    #[arena(default, deserialize_with = "deserialize_market_goods")]
+    pub goods: &'bump [MarketGood<'bump>],
+    #[arena(duplicated, alias = "merchant")]
+    pub merchants: &'bump [Merchant],
+}
+
+impl Market<'_> {
+    pub fn market_value(&self) -> f64 {
+        self.goods.iter().map(|g| g.price * g.total_taken).sum()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct MarketGood<'bump> {
+    pub good: GoodName<'bump>,
+    pub price: f64,
+    pub supplied: &'bump [(BStr<'bump>, f64)],
+    pub demanded: &'bump [(BStr<'bump>, f64)],
+    pub taken: &'bump [(BStr<'bump>, f64)],
+    pub impact: f64,
+    pub supply: f64,
+    pub demand: f64,
+    pub total_taken: f64,
+    pub surplus: f64,
+    pub possible: f64,
+    pub allowed_export_amount: f64,
+    pub stockpile: f64,
+    pub locations_with_this_as_raw_material: u32,
+    pub priority: f64,
+    pub history: &'bump [f64],
+}
+
+#[inline]
+fn deserialize_markets<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<MarketDatabase<'bump>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct MarketsVisitor<'bump>(&'bump arena_serde::Arena);
+
+    impl<'de, 'bump> de::Visitor<'de> for MarketsVisitor<'bump> {
+        type Value = MarketDatabase<'bump>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map containing market entries")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut market_ids = bumpalo::collections::Vec::with_capacity_in(128, self.0);
+            let mut market_values = bumpalo::collections::Vec::with_capacity_in(128, self.0);
+            while let Some((key, value)) = map.next_entry_seed(
+                ArenaSeed::new(self.0),
+                ArenaSeed::<Maybe<Market<'bump>>>::new(self.0),
+            )? {
+                market_ids.push(key);
+                market_values.push(value.into_value());
+            }
+
+            let ids = market_ids.into_bump_slice();
+            let values = market_values.into_bump_slice();
+
+            Ok(MarketDatabase { ids, values })
+        }
+    }
+
+    deserializer.deserialize_map(MarketsVisitor(allocator))
+}
+
+fn deserialize_produced_goods<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<&'bump [(GoodName<'bump>, f64)], D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct ProducedGoodsVisitor<'bump>(&'bump arena_serde::Arena);
+
+    impl<'de, 'bump> de::Visitor<'de> for ProducedGoodsVisitor<'bump> {
+        type Value = &'bump [(GoodName<'bump>, f64)];
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of produced goods")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut result = bumpalo::collections::Vec::new_in(self.0);
+
+            while let Some((key, value)) =
+                map.next_entry_seed(ArenaSeed::new(self.0), ArenaSeed::new(self.0))?
+            {
+                result.push((key, value));
+            }
+
+            Ok(result.into_bump_slice())
+        }
+    }
+
+    deserializer.deserialize_map(ProducedGoodsVisitor(allocator))
+}
+
+fn deserialize_market_goods<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<&'bump [MarketGood<'bump>], D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Debug, ArenaDeserialize)]
+    struct MarketGoodRaw<'bump> {
+        #[arena(default)]
+        price: f64,
+        #[arena(default, deserialize_with = "deserialize_market_good_breakdown")]
+        supplied: &'bump [(BStr<'bump>, f64)],
+        #[arena(default, deserialize_with = "deserialize_market_good_breakdown")]
+        demanded: &'bump [(BStr<'bump>, f64)],
+        #[arena(default, deserialize_with = "deserialize_market_good_breakdown")]
+        taken: &'bump [(BStr<'bump>, f64)],
+        #[arena(default)]
+        impact: f64,
+        #[arena(default)]
+        supply: f64,
+        #[arena(default)]
+        demand: f64,
+        #[arena(default)]
+        total_taken: f64,
+        #[arena(default)]
+        surplus: f64,
+        #[arena(default)]
+        possible: f64,
+        #[arena(default)]
+        allowed_export_amount: f64,
+        #[arena(default)]
+        stockpile: f64,
+        #[arena(default)]
+        locations_with_this_as_raw_material: u32,
+        #[arena(default)]
+        priority: f64,
+        #[arena(deserialize_with = "deserialize_vec_capacity::<_, _, 120>")]
+        history: &'bump [f64],
+    }
+
+    struct MarketGoodVisitor<'bump>(&'bump arena_serde::Arena);
+
+    impl<'de, 'bump> de::Visitor<'de> for MarketGoodVisitor<'bump> {
+        type Value = &'bump [MarketGood<'bump>];
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of produced goods")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut result = bumpalo::collections::Vec::with_capacity_in(128, self.0);
+            while let Some((key, value)) = map.next_entry_seed(
+                ArenaSeed::new(self.0),
+                ArenaSeed::<MarketGoodRaw<'bump>>::new(self.0),
+            )? {
+                let good = MarketGood {
+                    good: key,
+                    price: value.price,
+                    supplied: value.supplied,
+                    demanded: value.demanded,
+                    taken: value.taken,
+                    impact: value.impact,
+                    supply: value.supply,
+                    demand: value.demand,
+                    total_taken: value.total_taken,
+                    surplus: value.surplus,
+                    possible: value.possible,
+                    allowed_export_amount: value.allowed_export_amount,
+                    stockpile: value.stockpile,
+                    locations_with_this_as_raw_material: value.locations_with_this_as_raw_material,
+                    priority: value.priority,
+                    history: value.history,
+                };
+                result.push(good);
+            }
+
+            Ok(result.into_bump_slice())
+        }
+    }
+
+    deserializer.deserialize_map(MarketGoodVisitor(allocator))
+}
+
+fn deserialize_market_good_breakdown<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<&'bump [(BStr<'bump>, f64)], D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(
+        deserialize_vec_pair_arena_required::<_, BStr<'bump>, f64>(deserializer, allocator)?
+            .into_bump_slice(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jomini::TextDeserializer;
+
+    fn deserialize_manager<'bump>(
+        data: &str,
+        allocator: &'bump arena_serde::Arena,
+    ) -> MarketManager<'bump> {
+        let deserializer =
+            TextDeserializer::from_utf8_slice(data.as_bytes()).expect("valid text data");
+        MarketManager::deserialize_in_arena(&deserializer, allocator)
+            .expect("market manager deserializes")
+    }
+
+    #[test]
+    fn market_parses_repeated_merchant_blocks() {
+        let allocator = arena_serde::Arena::new();
+        let manager = deserialize_manager(
+            r#"
+produced_goods={}
+database={
+    100={
+        center=100
+        merchant={
+            country=1523
+            power=44.33076
+            original_power=44.33076
+            capacity=23.51775
+            original_capacity=23.51775
+            used=23.51775
+        }
+        merchant={
+            country=2147
+            power=5.11316
+            original_power=5.11316
+            capacity=4.935
+            original_capacity=4.935
+            used=4.662
+        }
+        merchant={
+            country=214
+            power=2.90275
+            original_power=2.90275
+        }
+    }
+}
+"#,
+            &allocator,
+        );
+
+        let market = manager.get(MarketId::new(100)).expect("market 100 exists");
+        assert_eq!(market.merchants.len(), 3);
+
+        let m0 = &market.merchants[0];
+        assert_eq!(m0.country, CountryId::new(1523));
+        assert!((m0.power - 44.33076).abs() < 1e-5);
+        assert!((m0.capacity - 23.51775).abs() < 1e-5);
+        assert!((m0.used - 23.51775).abs() < 1e-5);
+
+        let m2 = &market.merchants[2];
+        assert_eq!(m2.country, CountryId::new(214));
+        assert!((m2.power - 2.90275).abs() < 1e-5);
+        assert_eq!(m2.capacity, 0.0);
+        assert_eq!(m2.used, 0.0);
+    }
+
+    #[test]
+    fn merchant_absent_numeric_fields_default_to_zero() {
+        let allocator = arena_serde::Arena::new();
+        let manager = deserialize_manager(
+            r#"
+produced_goods={}
+database={
+    1={
+        center=1
+        merchant={
+            country=99
+        }
+    }
+}
+"#,
+            &allocator,
+        );
+
+        let market = manager.get(MarketId::new(1)).expect("market 1 exists");
+        assert_eq!(market.merchants.len(), 1);
+        let m = &market.merchants[0];
+        assert_eq!(m.country, CountryId::new(99));
+        assert_eq!(m.power, 0.0);
+        assert_eq!(m.capacity, 0.0);
+        assert_eq!(m.original_power, 0.0);
+        assert_eq!(m.original_capacity, 0.0);
+        assert_eq!(m.used, 0.0);
+    }
+
+    #[test]
+    fn market_with_no_merchants_has_empty_slice() {
+        let allocator = arena_serde::Arena::new();
+        let manager = deserialize_manager(
+            r#"
+produced_goods={}
+database={
+    5={
+        center=5
+    }
+}
+"#,
+            &allocator,
+        );
+
+        let market = manager.get(MarketId::new(5)).expect("market 5 exists");
+        assert!(market.merchants.is_empty());
+    }
+}

--- a/crates/eu5save/src/models/population.rs
+++ b/crates/eu5save/src/models/population.rs
@@ -1,0 +1,167 @@
+use crate::hash::FnvHashMap;
+use crate::models::de::Maybe;
+use crate::models::{CultureId, ReligionId};
+use arena_serde::ArenaDeserialize;
+use jomini::JominiDeserialize;
+use serde::Deserialize;
+use serde::de::MapAccess;
+use serde::de::Visitor;
+
+#[derive(Debug, ArenaDeserialize)]
+pub struct PopulationDirectory<'bump> {
+    pub database: PopDatabase<'bump>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PopulationType {
+    Burghers,
+    Clergy,
+    Laborers,
+    Nobles,
+    Peasants,
+    Slaves,
+    Soldiers,
+    Tribesmen,
+    #[serde(other)]
+    Other,
+}
+
+impl<'bump> ArenaDeserialize<'bump> for PopulationType {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump arena_serde::Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // PopulationType is also read through serde by `Population`, so
+        // serde owns the variant names and this impl forwards to it.
+        Self::deserialize(deserializer)
+    }
+}
+
+#[derive(Debug, JominiDeserialize)]
+pub struct Population {
+    #[jomini(alias = "type")]
+    pub kind: PopulationType,
+    #[jomini(default)]
+    pub size: f64,
+    #[jomini(default)]
+    pub satisfaction: f64,
+    #[jomini(default)]
+    pub literacy: f64,
+    #[jomini(default)]
+    pub price: f64,
+    #[jomini(default)]
+    pub religion: ReligionId,
+    #[jomini(default)]
+    pub culture: Option<CultureId>,
+}
+
+pub(crate) struct PopDatabaseVisitor<'bump>(&'bump arena_serde::Arena);
+
+impl<'de, 'bump> Visitor<'de> for PopDatabaseVisitor<'bump> {
+    type Value = PopDatabase<'bump>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a map of population data")
+    }
+
+    fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+    where
+        V: MapAccess<'de>,
+    {
+        let mut ids = bumpalo::collections::Vec::with_capacity_in(131072, self.0);
+        let mut values = bumpalo::collections::Vec::with_capacity_in(131072, self.0);
+        while let Some((key, value)) = map.next_entry::<u32, Maybe<Population>>()? {
+            let id = PopId::new(key);
+            ids.push(id);
+            values.push(value.into_value());
+        }
+
+        let ids = ids.into_bump_slice();
+        let values = values.into_bump_slice();
+        let lookup = ids
+            .iter()
+            .enumerate()
+            .map(|(idx, &id)| (id, idx))
+            .collect::<FnvHashMap<_, _>>();
+        let db = PopDatabase {
+            ids,
+            values,
+            lookup,
+        };
+        Ok(db)
+    }
+}
+
+impl<'bump> ArenaDeserialize<'bump> for PopDatabase<'bump> {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump arena_serde::Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(PopDatabaseVisitor(allocator))
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Default, ArenaDeserialize,
+)]
+#[serde(transparent)]
+pub struct PopId(u32);
+
+impl PopId {
+    #[inline]
+    pub fn new(id: u32) -> Self {
+        PopId(id)
+    }
+
+    #[inline]
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Default, ArenaDeserialize,
+)]
+#[serde(transparent)]
+pub struct PopIdx(u32);
+
+impl From<usize> for PopIdx {
+    fn from(value: usize) -> Self {
+        PopIdx(value as u32)
+    }
+}
+
+impl From<PopIdx> for usize {
+    fn from(value: PopIdx) -> Self {
+        value.0 as usize
+    }
+}
+
+#[derive(Debug)]
+pub struct PopDatabase<'bump> {
+    ids: &'bump [PopId],
+    values: &'bump [Option<Population>],
+    lookup: FnvHashMap<PopId, usize>,
+}
+
+impl<'bump> PopDatabase<'bump> {
+    pub fn len(&self) -> usize {
+        self.ids.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ids.is_empty()
+    }
+
+    pub fn lookup(&self, id: PopId) -> Option<&Population> {
+        let idx = self.lookup.get(&id)?;
+        self.values.get(*idx)?.as_ref()
+    }
+}

--- a/crates/eu5save/src/models/religion_manager.rs
+++ b/crates/eu5save/src/models/religion_manager.rs
@@ -1,0 +1,105 @@
+use crate::models::Color;
+use crate::models::bstr::BStr;
+use arena_serde::{ArenaDeserialize, ArenaSeed};
+use serde::{Deserialize, de};
+use std::fmt;
+
+#[derive(Debug, PartialEq, ArenaDeserialize)]
+pub struct ReligionManager<'bump> {
+    #[arena(deserialize_with = "deserialize_religions")]
+    pub database: ReligionDatabase<'bump>,
+}
+
+impl<'bump> ReligionManager<'bump> {
+    pub fn lookup(&self, id: ReligionId) -> Option<&Religion<'bump>> {
+        if let Some(x) = self.database.ids.get(id.value() as usize)
+            && *x == id
+        {
+            return Some(&self.database.values[id.value() as usize]);
+        }
+
+        self.database
+            .ids
+            .iter()
+            .position(|&x| x == id)
+            .map(|idx| &self.database.values[idx])
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ReligionDatabase<'bump> {
+    ids: &'bump [ReligionId],
+    values: &'bump [Religion<'bump>],
+}
+
+impl<'bump> ReligionDatabase<'bump> {
+    /// Returns an iterator over all religions in the database
+    pub fn iter(&self) -> impl Iterator<Item = &Religion<'bump>> {
+        self.values.iter()
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Default, ArenaDeserialize,
+)]
+#[serde(transparent)]
+pub struct ReligionId(u32);
+
+impl ReligionId {
+    #[inline]
+    pub fn new(id: u32) -> Self {
+        ReligionId(id)
+    }
+
+    #[inline]
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, ArenaDeserialize, PartialEq)]
+pub struct Religion<'bump> {
+    pub name: BStr<'bump>,
+    pub key: BStr<'bump>,
+    #[arena(default)]
+    pub color: Color,
+}
+
+#[inline]
+fn deserialize_religions<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<ReligionDatabase<'bump>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct ReligionVisitor<'bump>(&'bump arena_serde::Arena);
+
+    impl<'de, 'bump> de::Visitor<'de> for ReligionVisitor<'bump> {
+        type Value = ReligionDatabase<'bump>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map containing religion entries")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut religion_ids = bumpalo::collections::Vec::with_capacity_in(1024, self.0);
+            let mut religion_values = bumpalo::collections::Vec::with_capacity_in(1024, self.0);
+            while let Some((key, value)) =
+                map.next_entry_seed(ArenaSeed::new(self.0), ArenaSeed::<Religion>::new(self.0))?
+            {
+                religion_ids.push(key);
+                religion_values.push(value);
+            }
+
+            let ids = religion_ids.into_bump_slice();
+            let values = religion_values.into_bump_slice();
+            Ok(ReligionDatabase { ids, values })
+        }
+    }
+
+    deserializer.deserialize_map(ReligionVisitor(allocator))
+}

--- a/crates/eu5save/src/models/subunit_manager.rs
+++ b/crates/eu5save/src/models/subunit_manager.rs
@@ -1,0 +1,103 @@
+use crate::models::de::Maybe;
+use crate::models::{CountryId, LocationId, PopId, UnitId};
+use arena_serde::{ArenaDeserialize, ArenaSeed};
+use serde::{Deserialize, de};
+use std::fmt;
+
+#[derive(Debug, PartialEq, ArenaDeserialize)]
+pub struct SubUnitManager<'bump> {
+    #[arena(deserialize_with = "deserialize_units")]
+    pub database: SubUnitDatabase<'bump>,
+}
+
+impl<'bump> SubUnitManager<'bump> {}
+
+#[derive(Debug, PartialEq)]
+pub struct SubUnitDatabase<'bump> {
+    ids: &'bump [SubUnitId],
+    values: &'bump [Option<SubUnit<'bump>>],
+}
+
+impl<'bump> SubUnitDatabase<'bump> {
+    /// Returns an iterator over all units in the database
+    pub fn iter(&self) -> impl Iterator<Item = &SubUnit<'bump>> {
+        self.values.iter().filter_map(|x| x.as_ref())
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Default, ArenaDeserialize,
+)]
+#[serde(transparent)]
+pub struct SubUnitId(u32);
+
+impl SubUnitId {
+    #[inline]
+    pub fn new(id: u32) -> Self {
+        SubUnitId(id)
+    }
+
+    #[inline]
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, ArenaDeserialize, PartialEq)]
+pub struct SubUnit<'bump> {
+    #[arena(default)]
+    pub owner: CountryId,
+    #[arena(default)]
+    pub controller: CountryId,
+    pub home: LocationId,
+    pub unit: UnitId,
+    pub morale: f64,
+    #[arena(default)]
+    pub experience: f64,
+    #[arena(default)]
+    pub strength: f64,
+    #[arena(default)]
+    pub max_strength: f64,
+    #[arena(default)]
+    pub levies: &'bump [PopId],
+}
+
+#[inline]
+fn deserialize_units<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<SubUnitDatabase<'bump>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct SubUnitVisitor<'bump>(&'bump arena_serde::Arena);
+
+    impl<'de, 'bump> de::Visitor<'de> for SubUnitVisitor<'bump> {
+        type Value = SubUnitDatabase<'bump>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map containing sub-unit entries")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut unit_ids = bumpalo::collections::Vec::with_capacity_in(4096, self.0);
+            let mut unit_values = bumpalo::collections::Vec::with_capacity_in(4096, self.0);
+            while let Some((key, value)) = map.next_entry_seed(
+                ArenaSeed::new(self.0),
+                ArenaSeed::<Maybe<SubUnit<'bump>>>::new(self.0),
+            )? {
+                unit_ids.push(key);
+                unit_values.push(value.into_value());
+            }
+
+            let ids = unit_ids.into_bump_slice();
+            let values = unit_values.into_bump_slice();
+            Ok(SubUnitDatabase { ids, values })
+        }
+    }
+
+    deserializer.deserialize_map(SubUnitVisitor(allocator))
+}

--- a/crates/eu5save/src/models/timeline_manager.rs
+++ b/crates/eu5save/src/models/timeline_manager.rs
@@ -1,0 +1,248 @@
+use crate::{
+    Eu5Date,
+    models::{BStr, CountryId, CountryName, CountryTag, LocationId},
+};
+use arena_serde::ArenaDeserialize;
+
+/// Campaign timeline data.
+///
+/// The section holds the data that the rest of the save no longer keeps: the
+/// events that the timeline marks, the countries that no longer exist, and the
+/// dated renames that give a country the correct name at a past date.
+///
+/// Every field is optional. A save from early in a campaign has no note and no
+/// dead country.
+#[derive(Debug, Default, ArenaDeserialize)]
+pub struct TimelineManager<'bump> {
+    #[arena(default)]
+    pub timeline_notes: &'bump [TimelineNote<'bump>],
+    #[arena(default)]
+    pub dead_countries: &'bump [DeadCountry<'bump>],
+    #[arena(default)]
+    pub country_renames: &'bump [CountryRename<'bump>],
+}
+
+/// A named event on the timeline, such as the start of the Black Death.
+#[derive(Debug, ArenaDeserialize)]
+pub struct TimelineNote<'bump> {
+    /// The localization key of the event.
+    pub key: BStr<'bump>,
+    pub date: Eu5Date,
+    /// The location where the event started, if it has one.
+    pub location: Option<LocationId>,
+    /// If true, the population chart shows a marker for the event.
+    #[arena(default)]
+    pub show_in_pop_graph: bool,
+}
+
+/// A country that no longer exists.
+///
+/// The country has no record in `countries.database`, so the timeline uses this
+/// archive to show it in a historical chart or ranking.
+#[derive(Debug, ArenaDeserialize)]
+pub struct DeadCountry<'bump> {
+    pub country_id: CountryId,
+    pub tag: CountryTag<'bump>,
+    /// The coat of arms key the country flew.
+    pub flag: Option<BStr<'bump>>,
+    pub death_date: Eu5Date,
+    pub name: CountryName<'bump>,
+    /// The map color, packed as one integer instead of an `rgb` block.
+    #[arena(default)]
+    pub map_color_hex: u32,
+    /// Annual samples. See [`crate::models::historical_sample_years`].
+    #[arena(default)]
+    pub historical_population: &'bump [f64],
+    #[arena(default)]
+    pub historical_tax_base: &'bump [f64],
+    #[arena(default)]
+    pub historical_economical_base: &'bump [f64],
+    /// The year of the last sample in the historical arrays.
+    pub last_stat_year: Option<i16>,
+}
+
+/// A dated change to the name, tag, flag, or map color of a country.
+#[derive(Debug, ArenaDeserialize)]
+pub struct CountryRename<'bump> {
+    pub country_id: CountryId,
+    /// The date the change took effect.
+    pub date: Eu5Date,
+    pub name: CountryName<'bump>,
+    pub tag: CountryTag<'bump>,
+    pub flag: Option<BStr<'bump>>,
+    /// The map color, packed as one integer instead of an `rgb` block.
+    #[arena(default)]
+    pub map_color_hex: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jomini::{TextDeserializer, common::PdsDate};
+
+    fn deserialize<'bump>(
+        data: &str,
+        allocator: &'bump arena_serde::Arena,
+    ) -> TimelineManager<'bump> {
+        #[derive(ArenaDeserialize)]
+        struct Wrapper<'bump> {
+            timeline_manager: TimelineManager<'bump>,
+        }
+
+        let deserializer =
+            TextDeserializer::from_utf8_slice(data.as_bytes()).expect("valid text data");
+        Wrapper::deserialize_in_arena(&deserializer, allocator)
+            .expect("timeline manager deserializes")
+            .timeline_manager
+    }
+
+    #[test]
+    fn empty_timeline_manager() {
+        let allocator = arena_serde::Arena::new();
+        let timeline = deserialize("timeline_manager={\n}", &allocator);
+        assert!(timeline.timeline_notes.is_empty());
+        assert!(timeline.dead_countries.is_empty());
+        assert!(timeline.country_renames.is_empty());
+    }
+
+    #[test]
+    fn timeline_note() {
+        let allocator = arena_serde::Arena::new();
+        let timeline = deserialize(
+            r#"timeline_manager={
+                timeline_notes={ {
+                    key="timeline_note_black_death"
+                    date=1346.6.1
+                    location=4814
+                    show_in_pop_graph=yes
+                } }
+            }"#,
+            &allocator,
+        );
+
+        let [note] = timeline.timeline_notes else {
+            panic!("expected one note")
+        };
+        assert_eq!(note.key.to_str(), "timeline_note_black_death");
+        assert_eq!(note.date.game_fmt().to_string(), "1346.6.1");
+        assert_eq!(note.location, Some(LocationId::new(4814)));
+        assert!(note.show_in_pop_graph);
+    }
+
+    /// The name of a dead country is a plain string in the simple case and an
+    /// object in the complex case. Both forms are in the same save.
+    #[test]
+    fn dead_countries_with_both_name_forms() {
+        let allocator = arena_serde::Arena::new();
+        let timeline = deserialize(
+            r#"timeline_manager={
+                dead_countries={ {
+                    country_id=2354
+                    tag="AAA00"
+                    flag="AAA00"
+                    death_date=1342.4.1
+                    name="riau_kampar_province"
+                    map_color_hex=4287626951
+                    historical_population={ 17.69766 17.84589 }
+                    historical_tax_base={ 0 2.92113 }
+                    historical_economical_base={ 0.3005 3.11387 }
+                    last_stat_year=1341
+                } {
+                    country_id=2368
+                    tag="AAA13"
+                    flag="POR_REVOLT"
+                    death_date=1343.3.18
+                    name={
+                        name="CIVILWAR_FACTION_pretender_NAME"
+                        key={
+                            Adjective="CIVILWAR_FACTION_pretender_ADJECTIVE"
+                        }
+
+                        bases={
+                            Base="POR"
+                        }
+
+                    }
+                    map_color_hex=4284610724
+                } }
+            }"#,
+            &allocator,
+        );
+
+        let [simple, complex] = timeline.dead_countries else {
+            panic!("expected two dead countries")
+        };
+
+        assert_eq!(simple.country_id, CountryId::new(2354));
+        assert_eq!(simple.tag.as_str(), "AAA00");
+        assert_eq!(simple.flag.unwrap().to_str(), "AAA00");
+        assert_eq!(simple.death_date.game_fmt().to_string(), "1342.4.1");
+        assert_eq!(simple.name.name().to_str(), "riau_kampar_province");
+        assert_eq!(simple.map_color_hex, 4287626951);
+        assert_eq!(simple.historical_population, &[17.69766, 17.84589]);
+        assert_eq!(simple.historical_tax_base, &[0.0, 2.92113]);
+        assert_eq!(simple.historical_economical_base, &[0.3005, 3.11387]);
+        assert_eq!(simple.last_stat_year, Some(1341));
+
+        // A dead country can be without the historical arrays.
+        assert_eq!(
+            complex.name.name().to_str(),
+            "CIVILWAR_FACTION_pretender_NAME"
+        );
+        assert_eq!(complex.flag.unwrap().to_str(), "POR_REVOLT");
+        assert!(complex.historical_population.is_empty());
+        assert_eq!(complex.last_stat_year, None);
+    }
+
+    #[test]
+    fn country_renames() {
+        let allocator = arena_serde::Arena::new();
+        let timeline = deserialize(
+            r#"timeline_manager={
+                country_renames={ {
+                    country_id=2104
+                    date=1341.9.1
+                    name="ADH"
+                    tag="ADH"
+                    flag="ADH"
+                    map_color_hex=4292777777
+                } }
+            }"#,
+            &allocator,
+        );
+
+        let [rename] = timeline.country_renames else {
+            panic!("expected one rename")
+        };
+        assert_eq!(rename.country_id, CountryId::new(2104));
+        assert_eq!(rename.date.game_fmt().to_string(), "1341.9.1");
+        assert_eq!(rename.name.name().to_str(), "ADH");
+        assert_eq!(rename.tag.as_str(), "ADH");
+        assert_eq!(rename.map_color_hex, 4292777777);
+    }
+
+    /// A tag is not always three to five characters. Script can name a formable
+    /// country with a longer tag, like the Sardinia-Piedmont formable.
+    #[test]
+    fn country_rename_with_long_tag() {
+        let allocator = arena_serde::Arena::new();
+        let timeline = deserialize(
+            r#"timeline_manager={
+                country_renames={ {
+                    country_id=2104
+                    date=1341.9.1
+                    name="SAR_piedmont"
+                    tag="SAR_piedmont"
+                    flag="SAR_piedmont"
+                    map_color_hex=4292777777
+                } }
+            }"#,
+            &allocator,
+        );
+
+        let [rename] = timeline.country_renames else {
+            panic!("expected one rename")
+        };
+        assert_eq!(rename.tag.as_str(), "SAR_piedmont");
+    }
+}

--- a/crates/eu5save/src/models/trade_manager.rs
+++ b/crates/eu5save/src/models/trade_manager.rs
@@ -1,0 +1,97 @@
+use crate::models::{GoodName, de::Maybe};
+use arena_serde::{ArenaDeserialize, ArenaSeed};
+use serde::{Deserialize, de};
+use std::fmt;
+
+#[derive(Debug, PartialEq, ArenaDeserialize)]
+pub struct TradeManager<'bump> {
+    #[arena(deserialize_with = "deserialize_trades")]
+    pub database: TradeDatabase<'bump>,
+}
+
+impl<'bump> TradeManager<'bump> {}
+
+#[derive(Debug, PartialEq)]
+pub struct TradeDatabase<'bump> {
+    ids: &'bump [TradeId],
+    values: &'bump [Option<TradeEntry<'bump>>],
+}
+
+impl<'bump> TradeDatabase<'bump> {
+    /// Returns an iterator over all trades in the database
+    pub fn iter(&self) -> impl Iterator<Item = &TradeEntry<'bump>> {
+        self.values.iter().filter_map(|x| x.as_ref())
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Default, ArenaDeserialize,
+)]
+#[serde(transparent)]
+pub struct TradeId(u32);
+
+impl TradeId {
+    #[inline]
+    pub fn new(id: u32) -> Self {
+        TradeId(id)
+    }
+
+    #[inline]
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, ArenaDeserialize, PartialEq)]
+pub struct TradeEntry<'bump> {
+    pub capacity: u32,
+    #[arena(default)]
+    pub size: f64,
+    #[arena(default)]
+    pub power: f64,
+    #[arena(default)]
+    pub effect: f64,
+    #[arena(default)]
+    pub cached: f64,
+    pub which: GoodName<'bump>,
+}
+
+#[inline]
+fn deserialize_trades<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<TradeDatabase<'bump>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct TradeDatabaseVisitor<'bump>(&'bump arena_serde::Arena);
+
+    impl<'de, 'bump> de::Visitor<'de> for TradeDatabaseVisitor<'bump> {
+        type Value = TradeDatabase<'bump>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map containing trade entries")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut trade_ids = bumpalo::collections::Vec::with_capacity_in(4096, self.0);
+            let mut trade_values = bumpalo::collections::Vec::with_capacity_in(4096, self.0);
+            while let Some((key, value)) = map.next_entry_seed(
+                ArenaSeed::new(self.0),
+                ArenaSeed::<Maybe<TradeEntry<'bump>>>::new(self.0),
+            )? {
+                trade_ids.push(key);
+                trade_values.push(value.into_value());
+            }
+
+            let ids = trade_ids.into_bump_slice();
+            let values = trade_values.into_bump_slice();
+            Ok(TradeDatabase { ids, values })
+        }
+    }
+
+    deserializer.deserialize_map(TradeDatabaseVisitor(allocator))
+}

--- a/crates/eu5save/src/models/unit_manager.rs
+++ b/crates/eu5save/src/models/unit_manager.rs
@@ -1,0 +1,91 @@
+use crate::models::de::Maybe;
+use crate::models::{CharacterId, CountryId};
+use arena_serde::{ArenaDeserialize, ArenaSeed};
+use serde::{Deserialize, de};
+use std::fmt;
+
+#[derive(Debug, PartialEq, ArenaDeserialize)]
+pub struct UnitManager<'bump> {
+    #[arena(deserialize_with = "deserialize_units")]
+    pub database: UnitDatabase<'bump>,
+}
+
+impl<'bump> UnitManager<'bump> {}
+
+#[derive(Debug, PartialEq)]
+pub struct UnitDatabase<'bump> {
+    ids: &'bump [UnitId],
+    values: &'bump [Option<Unit>],
+}
+
+impl<'bump> UnitDatabase<'bump> {
+    /// Returns an iterator over all units in the database
+    pub fn iter(&self) -> impl Iterator<Item = &Unit> {
+        self.values.iter().filter_map(|x| x.as_ref())
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Default, ArenaDeserialize,
+)]
+#[serde(transparent)]
+pub struct UnitId(u32);
+
+impl UnitId {
+    #[inline]
+    pub fn new(id: u32) -> Self {
+        UnitId(id)
+    }
+
+    #[inline]
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, ArenaDeserialize, PartialEq)]
+pub struct Unit {
+    #[arena(default)]
+    pub country: CountryId,
+    pub leader: Option<CharacterId>,
+}
+
+#[inline]
+fn deserialize_units<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<UnitDatabase<'bump>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct UnitVisitor<'bump>(&'bump arena_serde::Arena);
+
+    impl<'de, 'bump> de::Visitor<'de> for UnitVisitor<'bump> {
+        type Value = UnitDatabase<'bump>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map containing unit entries")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut unit_ids = bumpalo::collections::Vec::with_capacity_in(1024, self.0);
+            let mut unit_values = bumpalo::collections::Vec::with_capacity_in(1024, self.0);
+            while let Some((key, value)) = map.next_entry_seed(
+                ArenaSeed::new(self.0),
+                ArenaSeed::<Maybe<Unit>>::new(self.0),
+            )? {
+                unit_ids.push(key);
+                unit_values.push(value.into_value());
+            }
+
+            let ids = unit_ids.into_bump_slice();
+            let values = unit_values.into_bump_slice();
+            Ok(UnitDatabase { ids, values })
+        }
+    }
+
+    deserializer.deserialize_map(UnitVisitor(allocator))
+}

--- a/crates/eu5save/src/models/version.rs
+++ b/crates/eu5save/src/models/version.rs
@@ -1,0 +1,80 @@
+use arena_serde::ArenaDeserialize;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Eq, PartialOrd, Ord)]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+pub struct GameVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
+pub(crate) struct GameVersionVisitor;
+
+impl<'de> serde::de::Visitor<'de> for GameVersionVisitor {
+    type Value = GameVersion;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a game version in the format 'major.minor.patch'")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        let mut parts = v.split('.');
+
+        let major = parts.next();
+        let minor = parts.next();
+        let patch = parts.next();
+
+        let major = major
+            .ok_or_else(|| E::custom(format!("Missing major version in: {v}")))?
+            .parse()
+            .map_err(|_| E::custom(format!("Invalid major version: {v}")))?;
+
+        let minor = minor
+            .ok_or_else(|| E::custom(format!("Missing minor version in: {v}")))?
+            .parse()
+            .map_err(|_| E::custom(format!("Invalid minor version: {v}")))?;
+
+        let patch = patch
+            .ok_or_else(|| E::custom(format!("Missing patch version in: {v}")))?
+            .parse()
+            .map_err(|_| E::custom(format!("Invalid patch version: {v}")))?;
+
+        Ok(GameVersion {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for GameVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(GameVersionVisitor)
+    }
+}
+
+impl<'bump> ArenaDeserialize<'bump> for GameVersion {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump arena_serde::Arena,
+    ) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // GameVersion doesn't need arena allocation, so we can just use the standard deserializer
+        Self::deserialize(deserializer)
+    }
+}
+
+impl std::fmt::Display for GameVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}

--- a/crates/eu5save/src/models/war_manager.rs
+++ b/crates/eu5save/src/models/war_manager.rs
@@ -1,0 +1,99 @@
+use crate::{
+    Eu5Date,
+    models::{LocationId, de::Maybe},
+};
+use arena_serde::{ArenaDeserialize, ArenaSeed};
+use serde::{Deserialize, de};
+use std::fmt;
+
+#[derive(Debug, PartialEq, ArenaDeserialize)]
+pub struct WarManager<'bump> {
+    #[arena(deserialize_with = "deserialize_wars")]
+    pub database: WarDatabase<'bump>,
+}
+
+impl<'bump> WarManager<'bump> {}
+
+#[derive(Debug, PartialEq)]
+pub struct WarDatabase<'bump> {
+    ids: &'bump [WarId],
+    values: &'bump [Option<War<'bump>>],
+}
+
+impl<'bump> WarDatabase<'bump> {
+    /// Returns an iterator over all wars in the database
+    pub fn iter(&self) -> impl Iterator<Item = &War<'bump>> {
+        self.values.iter().filter_map(|x| x.as_ref())
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Default, ArenaDeserialize,
+)]
+#[serde(transparent)]
+pub struct WarId(u32);
+
+impl WarId {
+    #[inline]
+    pub fn new(id: u32) -> Self {
+        WarId(id)
+    }
+
+    #[inline]
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, ArenaDeserialize, PartialEq)]
+pub struct War<'bump> {
+    pub start_date: Eu5Date,
+    #[arena(duplicated, alias = "battle")]
+    pub battles: &'bump [Battle],
+}
+
+#[derive(Debug, ArenaDeserialize, PartialEq)]
+pub struct Battle {
+    pub location: LocationId,
+    pub date: Eu5Date,
+}
+
+#[inline]
+fn deserialize_wars<'de, 'bump, D>(
+    deserializer: D,
+    allocator: &'bump arena_serde::Arena,
+) -> Result<WarDatabase<'bump>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct WarVisitor<'bump>(&'bump arena_serde::Arena);
+
+    impl<'de, 'bump> de::Visitor<'de> for WarVisitor<'bump> {
+        type Value = WarDatabase<'bump>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map containing war entries")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut war_ids = bumpalo::collections::Vec::with_capacity_in(128, self.0);
+            let mut war_values = bumpalo::collections::Vec::with_capacity_in(128, self.0);
+            while let Some((key, value)) = map.next_entry_seed(
+                ArenaSeed::new(self.0),
+                ArenaSeed::<Maybe<War<'bump>>>::new(self.0),
+            )? {
+                war_ids.push(key);
+                war_values.push(value.into_value());
+            }
+
+            let ids = war_ids.into_bump_slice();
+            let values = war_values.into_bump_slice();
+            Ok(WarDatabase { ids, values })
+        }
+    }
+
+    deserializer.deserialize_map(WarVisitor(allocator))
+}

--- a/crates/eu5save/tests/fixtures.txt
+++ b/crates/eu5save/tests/fixtures.txt
@@ -1,0 +1,5 @@
+Clandeboye.eu5
+debug-1.0.eu5
+ironman-1.0.eu5
+mp_cas_1374_03_06.eu5
+SP_ironman_95ff2d32-01d9-446a-98bb-9eec434606a5.eu5

--- a/crates/eu5save/tests/samples.rs
+++ b/crates/eu5save/tests/samples.rs
@@ -1,0 +1,341 @@
+use arena_serde::ArenaDeserialize;
+use eu5save::{
+    BasicTokenResolver, Eu5BinaryDeserialization, Eu5File, Eu5Melt, Eu5TextMelt, MeltOptions,
+    ReaderAt, SaveDataKind, SaveResolver,
+    models::{Gamestate, ZipPrelude},
+};
+use highway::HighwayHash;
+use jomini::binary::TokenResolver;
+use rstest::rstest;
+use serde::Deserialize;
+use std::{
+    io::{BufWriter, Read, Seek},
+    sync::LazyLock,
+};
+
+mod utils;
+
+#[derive(Debug, PartialEq, Deserialize)]
+struct TestGamestate {
+    metadata: TestMetadata,
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+struct TestMetadata {
+    playthrough_id: String,
+}
+
+fn hash_read(mut reader: impl std::io::Read) -> String {
+    with_hasher(|writer| {
+        std::io::copy(&mut reader, writer).unwrap();
+    })
+}
+
+fn with_hasher(mut func: impl FnMut(&mut highway::HighwayHasher)) -> String {
+    let hasher = highway::HighwayHasher::new(highway::Key::default());
+    let mut writer = BufWriter::with_capacity(0x8000, hasher);
+    func(writer.get_mut());
+    let result = writer.into_inner().unwrap().finalize256();
+    format!(
+        "0x{:016x}{:016x}{:016x}{:016x}",
+        result[0], result[1], result[2], result[3]
+    )
+}
+
+fn create_test_resolver() -> BasicTokenResolver {
+    // Create a resolver with specific token mappings needed for the test
+    let tokens = b"0x9de metadata\n0x96e playthrough_id\n";
+    BasicTokenResolver::from_text_lines(tokens.as_slice()).expect("failed to create resolver")
+}
+
+fn text_api_assertions<R: ReaderAt>(data: &[u8], mut save: Eu5File<R>) {
+    assert_eq!(save.header().header_len(), 24);
+    assert_eq!(save.header().metadata_len(), 321394);
+    assert_eq!(save.header().kind(), eu5save::SaveHeaderKind::Text);
+    assert!(save.header().kind().is_text());
+
+    let expected_metadata = TestGamestate {
+        metadata: TestMetadata {
+            playthrough_id: String::from("7f9ee4fa-1ab6-4c05-87f4-e11700302fdf"),
+        },
+    };
+
+    let melted_hash = {
+        // We know this is uncompressed text:
+        let eu5save::JominiFileKind::Uncompressed(SaveDataKind::Text(txt)) = save.kind_mut() else {
+            panic!("expected uncompressed text save");
+        };
+
+        with_hasher(|hasher| {
+            (&*txt).melt(hasher).unwrap();
+        })
+    };
+
+    // verify the metadata is extracted as expected
+    let meta_kind = save.meta().unwrap();
+
+    // Extract the text metadata
+    let eu5save::SaveMetadataKind::Text(mut text_meta) = meta_kind else {
+        panic!("expected text metadata");
+    };
+
+    // Verify we can read the raw metadata bytes
+    let mut buf = Vec::new();
+    text_meta.read_to_end(&mut buf).unwrap();
+    assert!(buf.starts_with(b"metadata={"));
+    assert!(buf.ends_with(b"}\n"));
+    let meta_hash = hash_read(buf.as_slice());
+    let input_hash =
+        hash_read(&data[save.header().header_len()..][..save.header().metadata_len() as usize]);
+    assert_eq!(meta_hash, input_hash);
+
+    // Verify we can melt the metadata
+    let meta_kind = save.meta().unwrap();
+    let eu5save::SaveMetadataKind::Text(mut text_meta) = meta_kind else {
+        panic!("expected text metadata");
+    };
+
+    let melted_meta_hash = with_hasher(|hasher| {
+        Eu5TextMelt::melt(&mut text_meta, hasher).unwrap();
+    });
+
+    // The melted metadata should match the input metadata bytes
+    let expected_meta_hash =
+        hash_read(&data[..save.header().header_len() + save.header().metadata_len() as usize]);
+    assert_eq!(melted_meta_hash, expected_meta_hash);
+
+    // Verify that one can deserialize the metadata
+    let eu5save::SaveMetadataKind::Text(mut text_meta) = save.meta().unwrap() else {
+        panic!("expected text metadata");
+    };
+
+    let metadata: TestGamestate = text_meta.deserializer().deserialize().unwrap();
+    assert_eq!(metadata, expected_metadata);
+
+    let eu5save::JominiFileKind::Uncompressed(SaveDataKind::Text(txt)) = save.kind() else {
+        panic!("expected uncompressed text save");
+    };
+
+    // We can deserialize plaintext without the need for a resolver
+    let metadata: TestGamestate = txt.deserializer().deserialize().unwrap();
+    assert_eq!(metadata, expected_metadata);
+
+    // Next we verify that the gamestate can be read, melted, and deserialized.
+    let eu5save::SaveContentKind::Text(mut txt_gamestate) = save.gamestate().unwrap() else {
+        panic!("expected text gamestate");
+    };
+
+    let gamestate_hash = hash_read(&mut txt_gamestate);
+    let eu5save::SaveContentKind::Text(mut txt_gamestate) = save.gamestate().unwrap() else {
+        panic!("expected text gamestate");
+    };
+    let gamestate_metadata: TestGamestate = txt_gamestate.deserializer().deserialize().unwrap();
+    assert_eq!(gamestate_metadata, expected_metadata);
+
+    let kind_hash = hash_read(&mut txt.body().cursor());
+
+    assert_eq!(gamestate_hash, kind_hash);
+    assert_eq!(
+        kind_hash,
+        "0x26aa929f22223bad98ab51f252bfd199b2cb7f9615ecb75f3faeda11589dcb3e"
+    );
+
+    // The melted output of a text uncompressed save should match input bytes.
+    // (And if it matches input bytes then we know that melted output will have
+    // the same parsing behavior).
+    let input_hash = hash_read(data);
+    assert_eq!(input_hash, melted_hash);
+    assert_eq!(
+        input_hash,
+        "0x5435496fab3f477cc14d3702a3fb67d9be9f30c61865df503400dc4f3c7ed103"
+    );
+}
+
+fn binary_api_assertions<R: ReaderAt>(mut save: Eu5File<R>, resolver: &BasicTokenResolver) {
+    assert_eq!(save.header().header_len(), 24);
+    assert!(save.header().kind().is_binary());
+
+    let expected_metadata = TestGamestate {
+        metadata: TestMetadata {
+            playthrough_id: String::from("27a85fde-a436-485c-bf66-609af9fb64dc"),
+        },
+    };
+
+    let melted_output = {
+        // Melt the binary save to text and verify the result
+        let eu5save::JominiFileKind::Zip(zip) = save.kind_mut() else {
+            panic!("expected compressed binary save");
+        };
+
+        let mut melted_output = Vec::new();
+        let melt_options = MeltOptions::default();
+        (&*zip)
+            .melt(melt_options, resolver, &mut melted_output)
+            .unwrap();
+        melted_output
+    };
+
+    // Verify the metadata is extracted as expected and is binary
+    let eu5save::SaveMetadataKind::Binary(mut binary_meta) = save.meta().unwrap() else {
+        panic!("expected binary metadata");
+    };
+
+    // Verify we can deserialize the metadata
+    let metadata: TestGamestate = binary_meta.deserializer(resolver).deserialize().unwrap();
+    assert_eq!(metadata, expected_metadata);
+
+    // Verify that we can Read the metadata
+    let eu5save::SaveMetadataKind::Binary(binary_meta) = save.meta().unwrap() else {
+        panic!("expected binary metadata");
+    };
+    let mut reader = jomini::binary::TokenReader::new(binary_meta);
+    assert!(reader.next().unwrap().is_some());
+
+    // Verify we can melt the metadata
+    let eu5save::SaveMetadataKind::Binary(mut binary_meta) = save.meta().unwrap() else {
+        panic!("expected binary metadata");
+    };
+    let mut melted_metadata = Vec::new();
+    let melt_options = MeltOptions::default();
+    binary_meta
+        .melt(melt_options, resolver, &mut melted_metadata)
+        .unwrap();
+
+    // Verify melted metadata can be re-parsed as text
+    let melted_meta_save =
+        Eu5File::from_slice(melted_metadata.as_slice()).expect("failed to parse melted metadata");
+    assert!(melted_meta_save.header().kind().is_text());
+
+    // Verify the melted metadata content starts with "metadata={"
+    assert!(
+        melted_metadata[melted_meta_save.header().header_len()..].starts_with(b"metadata={"),
+        "melted metadata should start with 'metadata={{'"
+    );
+
+    let eu5save::SaveMetadataKind::Text(_) = melted_meta_save.meta().unwrap() else {
+        panic!("melted metadata should be text format");
+    };
+
+    // Verify that we can deserialize the gamestate
+    let eu5save::SaveContentKind::Binary(mut bin_gamestate) = save.gamestate().unwrap() else {
+        panic!("expected binary gamestate");
+    };
+
+    let gamestate_metadata: TestGamestate =
+        bin_gamestate.deserializer(resolver).deserialize().unwrap();
+    assert_eq!(gamestate_metadata, expected_metadata);
+
+    // Verify that we can Read the gamestate
+    let eu5save::SaveContentKind::Binary(bin_gamestate) = save.gamestate().unwrap() else {
+        panic!("expected binary gamestate");
+    };
+    let mut reader = jomini::binary::TokenReader::new(bin_gamestate);
+    while reader.next().unwrap().is_some() {}
+
+    // Parse the melted output as a new Eu5File and verify it's text
+    let melted_save =
+        Eu5File::from_slice(melted_output.as_slice()).expect("failed to parse melted save");
+
+    assert!(melted_save.header().kind().is_text());
+    let eu5save::JominiFileKind::Uncompressed(SaveDataKind::Text(_)) = melted_save.kind() else {
+        panic!("expected melted save to be uncompressed text");
+    };
+
+    // Verify the melted body starts with "metadata={"
+    assert!(
+        melted_output[melted_save.header().header_len()..].starts_with(b"metadata={"),
+        "melted output should start with 'metadata={{'"
+    );
+}
+
+#[test]
+fn test_txt_api() {
+    let mut file = utils::request_file("debug-1.0.eu5");
+    let mut data = Vec::new();
+    file.read_to_end(&mut data).unwrap();
+    let save = Eu5File::from_slice(data.as_slice()).unwrap();
+    text_api_assertions(data.as_slice(), save);
+
+    file.seek(std::io::SeekFrom::Start(0)).unwrap();
+    let save = Eu5File::from_file(file).expect("failed to parse save from file");
+    text_api_assertions(data.as_slice(), save);
+}
+
+#[test]
+fn test_binary_api() {
+    let resolver = create_test_resolver();
+    let mut file = utils::request_file("ironman-1.0.eu5");
+    let mut data = Vec::new();
+    file.read_to_end(&mut data).expect("failed to read file");
+    file.seek(std::io::SeekFrom::Start(0))
+        .expect("failed to seek file");
+    let save = Eu5File::from_file(file).expect("failed to parse save from file");
+    binary_api_assertions(save, &resolver);
+
+    let save = Eu5File::from_slice(data.as_slice()).expect("failed to parse save from slice");
+    binary_api_assertions(save, &resolver);
+}
+
+static TOKENS: LazyLock<BasicTokenResolver> = LazyLock::new(|| {
+    let file_data = pdx_fixtures::tokens("eu5");
+    let resolver = BasicTokenResolver::from_text_lines(file_data.as_slice()).unwrap();
+    if resolver.is_empty() {
+        eprintln!("EU5 binary tokens not loaded");
+    } else {
+        eprintln!("EU5 binary tokens loaded");
+    }
+    resolver
+});
+
+fn can_deserialize_meta(file: &Eu5File<impl ReaderAt>) {
+    let resolver = &*TOKENS;
+    let bump = arena_serde::Arena::new();
+    match file.meta().unwrap() {
+        eu5save::SaveMetadataKind::Text(mut txt) => {
+            ZipPrelude::deserialize_in_arena(&mut txt.deserializer(), &bump)
+                .expect("failed to deserialize text metadata");
+        }
+        eu5save::SaveMetadataKind::Binary(mut bin) => {
+            // Skip deserialization if we don't have tokens
+            if resolver.is_empty() {
+                return;
+            }
+            ZipPrelude::deserialize_in_arena(&mut bin.deserializer(resolver), &bump)
+                .expect("failed to deserialize binary metadata");
+        }
+    }
+}
+
+fn can_deserialize_gamestate(file: &Eu5File<impl ReaderAt>) {
+    let resolver = &*TOKENS;
+    let bump = arena_serde::Arena::new();
+    match file.gamestate().unwrap() {
+        eu5save::SaveContentKind::Text(mut txt) => {
+            Gamestate::deserialize_in_arena(&mut txt.deserializer(), &bump)
+                .expect("failed to deserialize text gamestate");
+        }
+        eu5save::SaveContentKind::Binary(mut bin) => {
+            // Skip deserialization if we don't have tokens
+            if resolver.is_empty() {
+                return;
+            }
+            let save_resolver =
+                SaveResolver::from_file(file, resolver).expect("failed to create save resolver");
+            Gamestate::deserialize_in_arena(&mut bin.deserializer(&save_resolver), &bump)
+                .expect("failed to deserialize binary gamestate");
+        }
+    }
+}
+
+#[rstest]
+#[case("ironman-1.0.eu5")]
+#[case("debug-1.0.eu5")]
+#[case("Clandeboye.eu5")]
+#[case("mp_cas_1374_03_06.eu5")]
+#[case("SP_ironman_95ff2d32-01d9-446a-98bb-9eec434606a5.eu5")]
+fn deserialization_regression_test(#[case] filename: &str) {
+    let file = utils::request_file(filename);
+    let save = Eu5File::from_file(file).unwrap();
+    can_deserialize_meta(&save);
+    can_deserialize_gamestate(&save);
+}

--- a/crates/eu5save/tests/utils.rs
+++ b/crates/eu5save/tests/utils.rs
@@ -1,0 +1,6 @@
+use std::fs::File;
+
+/// Open an EU5 save fixture, fetching it into the cache on first use.
+pub fn request_file<S: AsRef<str>>(name: S) -> File {
+    pdx_fixtures::request_file("eu5", name.as_ref())
+}

--- a/crates/pdx-cli/Cargo.toml
+++ b/crates/pdx-cli/Cargo.toml
@@ -13,8 +13,10 @@ name = "pdx"
 path = "src/main.rs"
 
 [dependencies]
+arena-serde = { path = "../arena-serde" }
 ck3save = { path = "../ck3save" }
 eu4save = { path = "../eu4save" }
+eu5save = { path = "../eu5save" }
 hoi4save = { path = "../hoi4save" }
 imperator-save = { path = "../imperator-save" }
 jomini = { workspace = true, features = ["envelope", "json"] }

--- a/crates/pdx-cli/src/eu5.rs
+++ b/crates/pdx-cli/src/eu5.rs
@@ -1,0 +1,139 @@
+use crate::{Game, Result};
+use arena_serde::{Arena, ArenaDeserialize, tracked};
+use eu5save::{
+    BasicTokenResolver, Eu5BinaryDeserialization, Eu5File, Eu5Melt, FailedResolveStrategy,
+    MeltOptions, SaveContentKind, SaveResolver, models::Gamestate,
+};
+use jomini::common::PdsDate;
+use std::{fmt::Write as _, io::Write, path::Path};
+
+pub struct Eu5 {
+    data: Vec<u8>,
+    tokens: Vec<u8>,
+}
+
+impl Eu5 {
+    pub fn open(path: &Path) -> Result<Self> {
+        Ok(Self {
+            data: std::fs::read(path)?,
+            tokens: pdx_fixtures::tokens("eu5"),
+        })
+    }
+}
+
+impl Game for Eu5 {
+    fn melt(&self, out: &mut dyn Write) -> Result<()> {
+        let file = Eu5File::from_slice(self.data.as_slice())?;
+        let resolver = BasicTokenResolver::from_text_lines(self.tokens.as_slice())?;
+        let options = MeltOptions::new().on_failed_resolve(FailedResolveStrategy::Error);
+        (&file).melt(options, &resolver, out)?;
+        Ok(())
+    }
+
+    /// Deserialize the gamestate with path tracking, so that a model error
+    /// reports where in the save it occurred.
+    fn debug(&self) -> Result<String> {
+        let file = Eu5File::from_slice(self.data.as_slice())?;
+        let resolver = BasicTokenResolver::from_text_lines(self.tokens.as_slice())?;
+        let arena = Arena::new();
+        let mut path_buf = Vec::new();
+        let track = tracked::Track::new_with(&mut path_buf);
+
+        let save = match file.gamestate()? {
+            SaveContentKind::Text(mut txt) => {
+                let mut deser = txt.deserializer();
+                let deser = tracked::Deserializer::new(&mut deser, &track);
+                Gamestate::deserialize_in_arena(deser, &arena)
+                    .map_err(|e| format!("{}: {e}", track.path()))?
+            }
+            SaveContentKind::Binary(mut bin) => {
+                let resolver = SaveResolver::from_file(&file, &resolver)?;
+                let mut deser = bin.deserializer(&resolver);
+                let deser = tracked::Deserializer::new(&mut deser, &track);
+                Gamestate::deserialize_in_arena(deser, &arena)
+                    .map_err(|e| format!("{}: {e}", track.path()))?
+            }
+        };
+
+        let version = &save.metadata.version;
+        let mut out = format!(
+            "eu5 {}.{}.{} {} countries: {} locations: {} pops: {} arena bytes: {}",
+            version.major,
+            version.minor,
+            version.patch,
+            save.metadata.date.game_fmt(),
+            save.countries.len(),
+            save.locations.len(),
+            save.population.database.len(),
+            arena.allocated_bytes(),
+        );
+
+        for player in save.played_countries {
+            match save.countries.get_entry(player.country) {
+                None => write!(
+                    out,
+                    "\nplayer country not found: {} {:?}",
+                    player.name, player.country
+                )?,
+                Some(country) => write!(
+                    out,
+                    "\nplayer country: {} {:?} {:?}",
+                    player.name,
+                    player.country,
+                    country.tag().to_str()
+                )?,
+            }
+
+            for dep in save.diplomacy_manager.dependencies() {
+                if dep.first == player.country || dep.second == player.country {
+                    write!(out, "\n  {dep:?}")?;
+                }
+            }
+        }
+
+        let max_pop_types = save
+            .locations
+            .iter()
+            .map(|x| x.location().population.pops.len())
+            .max()
+            .unwrap_or(0);
+        let (max_population, max_location) = save.location_max_population();
+        write!(
+            out,
+            "\nmax population types in a location: {max_pop_types}\
+             \nmax population: {max_population} at {max_location:?}"
+        )?;
+
+        let wars = save.war_manager.database.iter().count();
+        let battles: usize = save
+            .war_manager
+            .database
+            .iter()
+            .map(|w| w.battles.len())
+            .sum();
+        write!(
+            out,
+            "\nwars: {wars} battles: {battles} units: {} sub-units: {} loans: {} trades: {}",
+            save.unit_manager.database.iter().count(),
+            save.subunit_manager.database.iter().count(),
+            save.loan_manager.database.iter().count(),
+            save.trade_manager.database.iter().count(),
+        )?;
+
+        let highest_market = save
+            .market_manager
+            .database
+            .iter()
+            .max_by(|a, b| a.market_value().total_cmp(&b.market_value()));
+        if let Some(market) = highest_market {
+            write!(
+                out,
+                "\nhighest market value: {:?} at {}",
+                market.center,
+                market.market_value()
+            )?;
+        }
+
+        Ok(out)
+    }
+}

--- a/crates/pdx-cli/src/main.rs
+++ b/crates/pdx-cli/src/main.rs
@@ -21,6 +21,7 @@ use std::{
 
 mod ck3;
 mod eu4;
+mod eu5;
 mod hoi4;
 mod imperator;
 mod vic3;
@@ -82,6 +83,7 @@ fn game(path: &Path) -> Result<Box<dyn Game>> {
     let ext = path.extension().and_then(|x| x.to_str()).unwrap_or("");
     let game: Box<dyn Game> = match ext {
         "eu4" => Box::new(eu4::Eu4::open(path)?),
+        "eu5" => Box::new(eu5::Eu5::open(path)?),
         "ck3" => Box::new(ck3::Ck3::open(path)?),
         "hoi4" => Box::new(hoi4::Hoi4::open(path)?),
         "rome" => Box::new(imperator::Imperator::open(path)?),

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -22,6 +22,12 @@ features = ["envelope"]
 [dependencies.eu4save]
 path = "../crates/eu4save"
 
+[dependencies.eu5save]
+path = "../crates/eu5save"
+
+[dependencies.arena-serde]
+path = "../crates/arena-serde"
+
 [dependencies.ck3save]
 path = "../crates/ck3save"
 
@@ -92,5 +98,11 @@ doc = false
 [[bin]]
 name = "fuzz_vic3"
 path = "fuzz_targets/fuzz_vic3.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_eu5"
+path = "fuzz_targets/fuzz_eu5.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/fuzz_eu5.rs
+++ b/fuzz/fuzz_targets/fuzz_eu5.rs
@@ -1,0 +1,39 @@
+#![no_main]
+use arena_serde::{Arena, ArenaDeserialize};
+use eu5save::{
+    BasicTokenResolver, Eu5BinaryDeserialization, Eu5Melt, SaveContentKind, SaveResolver,
+    models::Gamestate,
+};
+use libfuzzer_sys::fuzz_target;
+use std::sync::LazyLock;
+
+static TOKENS: LazyLock<BasicTokenResolver> = LazyLock::new(|| {
+    let file_data = pdx_fixtures::tokens("eu5");
+    BasicTokenResolver::from_text_lines(file_data.as_slice()).unwrap()
+});
+
+fn run(data: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+    let file = eu5save::Eu5File::from_slice(data)?;
+
+    // Melt the file
+    let mut sink = std::io::sink();
+    let _ = (&file).melt(eu5save::MeltOptions::new(), &*TOKENS, &mut sink);
+
+    // Try to deserialize the gamestate
+    let arena = Arena::new();
+    match file.gamestate()? {
+        SaveContentKind::Text(mut txt) => {
+            let _ = Gamestate::deserialize_in_arena(&mut txt.deserializer(), &arena);
+        }
+        SaveContentKind::Binary(mut bin) => {
+            let resolver = SaveResolver::from_file(&file, &*TOKENS)?;
+            let _ = Gamestate::deserialize_in_arena(&mut bin.deserializer(&resolver), &arena);
+        }
+    }
+
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(data);
+});


### PR DESCRIPTION
Stacked on #268.

Copy pdx-tools/pdx-tools@dbbad96 `src/eu5save` into `crates/eu5save`. The crate takes `jomini` and its shared dependencies from the workspace, depends on arena-serde by path, and uses pdx-fixtures for token files and save fixtures, so its fetcher and token lookups are gone. The crate had no license field; it now inherits MIT from the workspace. Keep `publish = false` and version 0.1.0 as in pdx-tools.

- **Adapt to arena-serde** (#268): rename the crate path, name `arena_serde::Arena` in the `deserialize_with` signatures, and replace the one `SliceDeserializer` use with `ArenaSeed<&[f64]>`. The models are otherwise as upstream, which already dispatches every field through the derive. The tsify derive stays under `cfg(target_family = "wasm")`.
- Flatten `tests/it` into one test binary, matching the other game crates.
- Replace the `melt` and `debug_save` dev binaries with EU5 support in the pdx CLI (`.eu5`). `pdx debug` deserializes the gamestate through the tracked deserializer so a model error names the path in the save, then prints the same details `debug_save` did: player countries and their dependencies, population and war counts, and the highest value market. The two lines that indexed a fixed country and location are gone, as they only fit one fixture.
- Add a `fuzz_eu5` target, add the crate to the games and ironman CI matrices, and add a README.

Verified locally: `cargo test -p eu5save` passes with and without tokens (all five regression fixtures, text and binary), `pdx debug/melt/json` work on the eu5 fixtures, `fuzz_eu5` checks, and workspace clippy is clean under `-D warnings`.
