### PR TITLE
Unify the wasm story of the game crates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,20 @@ jobs:
     - name: Run clippy (game crates)
       run: cargo clippy --workspace --exclude jomini --exclude jomini_derive --exclude arena-serde --exclude arena-serde-derive --all-targets -- -D warnings
 
+  wasm:
+    name: wasm
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        targets: wasm32-unknown-unknown
+        components: clippy
+    - name: Run clippy
+      run: cargo clippy --target wasm32-unknown-unknown -p jomini -p eu4save -p ck3save -p hoi4save -p imperator-save -p vic3save -p eu5save --features eu4save/tsify,eu5save/tsify -- -D warnings
+
   testbench:
     name: testbench
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ pdx-fixtures = { path = "crates/pdx-fixtures" }
 rawzip = "0.5"
 serde = { version = "1.0.195", features = ["derive"] }
 thiserror = "2.0.0"
+tsify = { version = "0.5.6", default-features = false, features = ["js"] }
+wasm-bindgen = { version = "0.2.118", default-features = false }
 
 [workspace.metadata.release]
 tag-message = "Release {{version}}"

--- a/crates/eu4save/Cargo.toml
+++ b/crates/eu4save/Cargo.toml
@@ -27,8 +27,8 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 zstd = { version = "0.13", default-features = false, optional = true }
 ruzstd = { version = "0.8", optional = true }
-tsify = { version = "0.5.5", default-features = false, optional = true }
-wasm-bindgen = { version = "0.2", default-features = false, optional = true }
+tsify = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
 specta = { version = "1.0.4", optional = true }
 flate2 = { workspace = true }
 rawzip = { workspace = true }

--- a/crates/eu4save/src/extraction.rs
+++ b/crates/eu4save/src/extraction.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 /// Describes the format of the save before decoding
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "tsify", derive(tsify::Tsify), tsify(into_wasm_abi))]
+#[cfg_attr(feature = "tsify", derive(tsify::Tsify))]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub enum Encoding {
     /// Plaintext

--- a/crates/eu4save/src/models.rs
+++ b/crates/eu4save/src/models.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, JominiDeserialize, Serialize)]
-#[cfg_attr(feature = "tsify", derive(tsify::Tsify), tsify(into_wasm_abi))]
+#[cfg_attr(feature = "tsify", derive(tsify::Tsify))]
 pub struct Meta {
     pub campaign_id: String,
     pub save_game: String,
@@ -370,7 +370,7 @@ pub enum GameDifficulty {
 }
 
 #[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "tsify", derive(tsify::Tsify), tsify(into_wasm_abi))]
+#[cfg_attr(feature = "tsify", derive(tsify::Tsify))]
 pub struct GameplayOptions {
     pub difficulty: GameDifficulty,
     pub tax_manpower_modifier: TaxManpowerModifier,

--- a/crates/eu5save/Cargo.toml
+++ b/crates/eu5save/Cargo.toml
@@ -11,16 +11,18 @@ description = "Ergonomically work with Europa Universalis V saves (debug and iro
 keywords = ["eu5", "ironman"]
 categories = ["parsing"]
 
+[features]
+default = []
+tsify = ["dep:tsify", "dep:wasm-bindgen"]
+
 [dependencies]
 arena-serde = { path = "../arena-serde" }
 bumpalo = { workspace = true }
 jomini = { workspace = true, features = ["envelope"] }
 serde = { workspace = true }
 thiserror = { workspace = true }
-
-[target.'cfg(target_family = "wasm")'.dependencies]
-tsify = { version = "0.5.6", default-features = false, features = ["js"] }
-wasm-bindgen = { version = "0.2.118", default-features = false }
+tsify = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 pdx-fixtures = { workspace = true }

--- a/crates/eu5save/src/models/version.rs
+++ b/crates/eu5save/src/models/version.rs
@@ -2,7 +2,7 @@ use arena_serde::ArenaDeserialize;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Eq, PartialOrd, Ord)]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "tsify", derive(tsify::Tsify))]
 pub struct GameVersion {
     pub major: u32,
     pub minor: u32,


### PR DESCRIPTION
eu4save and eu5save both derive tsify types for the TypeScript
declarations that pdx-tools' wasm modules export, but they got there
differently. eu4save has an opt-in `tsify` feature. eu5save pulled
tsify and wasm-bindgen as unconditional dependencies of every wasm
target and derived under `cfg(target_family = "wasm")`, which forces
the two crates on wasm consumers that do not want declarations, and
hides the derive from every native check.

Give eu5save the same `tsify` feature as eu4save, and take tsify and
wasm-bindgen from the workspace so the two crates agree on versions.
wasm-bindgen is only there because the Tsify derive expands to
`wasm_bindgen` items in the deriving crate; nothing calls it.

Add a `wasm` CI job that checks the game crates for
wasm32-unknown-unknown with the tsify features on. Nothing in this
repository compiled those paths before; a break only surfaced when
pdx-tools built.

Drop `tsify(into_wasm_abi)` from the three eu4save types that had it.
tsify 0.5.6 deprecates the attribute: the generated `IntoWasmAbi` impl
leaks (madonoharu/tsify#65), and the replacement is for the caller to
return `tsify::Ts<T>`. A wasm consumer that returned `Meta` or
`GameState` from a `wasm_bindgen` function now wraps it in `Ts`. With
that gone, the wasm job runs clippy with `-D warnings`.

Stacked on #269.