### PR TITLE
Decode EU4dll escaped strings in EU4 text saves

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -46,3 +46,6 @@ serde_path_to_error = "0.1.16"
 
 [profile.bench]
 debug = true
+
+[patch.crates-io]
+jomini = { path = "../crates/jomini" }

--- a/crates/eu4save/src/file.rs
+++ b/crates/eu4save/src/file.rs
@@ -6,9 +6,7 @@ use crate::{
     resolver::SegmentedResolver,
     Encoding, Eu4Error, Eu4ErrorKind, MeltOptions, MeltedDocument,
 };
-use jomini::{
-    binary::TokenResolver, text::ObjectReader, TextDeserializer, TextTape, Windows1252Encoding,
-};
+use jomini::{binary::TokenResolver, text::ObjectReader, TextDeserializer, TextTape};
 use rawzip::{CompressionMethod, FileReader, ReaderAt};
 use serde::de::DeserializeOwned;
 use std::{
@@ -704,7 +702,7 @@ impl<'de, 'a: 'de, R: jomini::binary::TokenResolver> serde::de::Deserializer<'de
             Ok(deser.deserialize_struct(name, fields, visitor)?)
         } else {
             let reader = jomini::text::TokenReader::new(&mut self.reader);
-            let mut deser = TextDeserializer::from_windows1252_reader(reader);
+            let mut deser = TextDeserializer::from_encoded_reader(reader, Eu4Flavor::new());
             Ok(deser.deserialize_struct(name, fields, visitor)?)
         }
     }
@@ -821,7 +819,7 @@ impl<'a> Eu4ParsedText<'a> {
         Ok(Eu4ParsedText { tape })
     }
 
-    pub fn reader(&self) -> ObjectReader<'_, '_, Windows1252Encoding> {
-        self.tape.windows1252_reader()
+    pub fn reader(&self) -> ObjectReader<'_, '_, Eu4Flavor> {
+        ObjectReader::new(&self.tape, Eu4Flavor::new())
     }
 }

--- a/crates/eu4save/src/flavor.rs
+++ b/crates/eu4save/src/flavor.rs
@@ -1,7 +1,12 @@
 use jomini::{binary::BinaryFlavor, Encoding, Windows1252Encoding};
 
-/// The eu4 binary flavor
-#[derive(Debug, Default)]
+/// The eu4 binary flavor and text encoding
+///
+/// Strings are Windows-1252, except for strings from the Japanese and Chinese
+/// localization mods (both built on EU4dll), which escape UCS-2 code points
+/// behind the control bytes `0x10` to `0x13`. Vanilla saves never contain
+/// these bytes, so each string is detected and decoded on its own.
+#[derive(Debug, Default, Clone, Copy)]
 pub struct Eu4Flavor(Windows1252Encoding);
 
 impl Eu4Flavor {
@@ -13,13 +18,34 @@ impl Eu4Flavor {
 
 impl Encoding for Eu4Flavor {
     fn decode<'a>(&self, data: &'a [u8]) -> std::borrow::Cow<'a, str> {
-        // Heuristic to detect chinese escaped strings
-        if matches!(data.first(), Some(0x10..=0x13)) {
+        // Nearly all strings are plain ascii, so one branch-free pass finds
+        // the bytes that need more work: non-ascii, a backslash escape, or an
+        // EU4dll escape. The loop is written so that it vectorizes.
+        let mut plain = true;
+        for &b in data {
+            plain &= b.is_ascii() & (b != b'\\') & !is_eu4dll_escape(b);
+        }
+
+        if plain {
+            let trimmed = data.trim_ascii_end();
+            debug_assert!(std::str::from_utf8(trimmed).is_ok());
+            // SAFETY: every byte is ascii, and ascii is a subset of utf-8
+            let s = unsafe { std::str::from_utf8_unchecked(trimmed) };
+            std::borrow::Cow::Borrowed(s)
+        } else if data.iter().any(|&b| is_eu4dll_escape(b)) {
+            // EU4dll escapes can start anywhere in a string, such as a Latin
+            // family name followed by a localized suffix
             std::borrow::Cow::Owned(decode_eu4_escaped_text(data))
         } else {
             self.0.decode(data)
         }
     }
+}
+
+/// Returns true for the control bytes that start an EU4dll escape sequence
+#[inline]
+fn is_eu4dll_escape(b: u8) -> bool {
+    b & 0xFC == 0x10
 }
 
 impl BinaryFlavor for Eu4Flavor {
@@ -36,7 +62,7 @@ impl BinaryFlavor for Eu4Flavor {
     }
 }
 
-/// Converts the EU4 chinese encoding into a utf-8 string
+/// Converts the EU4dll escaped encoding (Japanese and Chinese mods) into a utf-8 string
 ///
 /// This function was converted from the original C++ code:
 /// https://github.com/matanki-saito/EU4dll/blob/4b5e5e16ec09c6977f1c96dabc7e6bab16590b02/Plugin64/escape_tool.cpp
@@ -74,13 +100,22 @@ pub fn decode_eu4_escaped_text(mut input: &[u8]) -> String {
                     }
                 }
             }
+            // Backslash escapes are dropped like in the Windows-1252 decoder
+            b'\\' => continue,
             _ => cp1252_to_ucs2(cp),
         };
 
         wide_chars.push(code_point as u16);
     }
 
-    String::from_utf16_lossy(&wide_chars)
+    // Trailing whitespace is trimmed after the decode, as the last byte of
+    // an escape payload can be an ascii whitespace byte
+    let mut result = String::from_utf16_lossy(&wide_chars);
+    let trimmed_len = result
+        .trim_end_matches(|c: char| c.is_ascii_whitespace())
+        .len();
+    result.truncate(trimmed_len);
+    result
 }
 
 /// Converts a CP1252 byte to its UCS-2 equivalent
@@ -130,5 +165,22 @@ mod tests {
         let data: [u8; 8] = [210, 63, 1, 0, 0, 0, 0, 0];
         let actual = flavor.visit_f64(data);
         assert_eq!(actual, 2.49860);
+    }
+
+    #[test]
+    fn eu4_escaped_text_drops_backslashes() {
+        // A latin name in quotes with a localized suffix: `"Foo" 隊`
+        let data = b"\\\"Foo\\\" \x10\x8A\x96";
+        let flavor = Eu4Flavor::new();
+        assert_eq!(flavor.decode(data), "\"Foo\" 隊");
+    }
+
+    #[test]
+    fn eu4_escaped_text_trims_trailing_whitespace() {
+        let flavor = Eu4Flavor::new();
+        assert_eq!(flavor.decode(b"\x10\x8A\x96 \n"), "隊");
+
+        // The trailing space is the high byte of the em dash escape
+        assert_eq!(flavor.decode(b"a\x10\x14\x20"), "a\u{2014}");
     }
 }

--- a/crates/eu4save/tests/fixtures.txt
+++ b/crates/eu4save/tests/fixtures.txt
@@ -15,6 +15,7 @@ kandy2.bin.eu4
 losses.eu4
 modded.eu4
 mp_Uesugi.eu4
+mp_shift.eu4
 no-dlc.eu4
 non-ironman-binary.eu4
 nor_lev.eu4

--- a/crates/eu4save/tests/it/samples.rs
+++ b/crates/eu4save/tests/it/samples.rs
@@ -387,3 +387,32 @@ fn fix_crash_on_long_country_tag_debug_mode() {
     let file = Eu4File::from_file(file).unwrap();
     let _save = file.parse_save(&SegmentedResolver::empty());
 }
+
+#[test]
+fn test_eu4_japanese_text() -> Result<(), Box<dyn Error>> {
+    let data = utils::request_file("mp_shift.eu4");
+    let file = Eu4File::from_file(data)?;
+    let save = file.parse_save(&SegmentedResolver::empty())?;
+    assert_eq!(file.encoding(), Encoding::TextZip);
+    assert_eq!(save.meta.player, "TRE");
+    assert_eq!(save.meta.displayed_country_name, "トレビゾンド");
+    assert_eq!(save.game.players_countries[0], "くまねこ");
+
+    // A Latin family name with a localized suffix: the escape does not start
+    // the string
+    let tre = &save
+        .game
+        .countries
+        .iter()
+        .find(|(tag, _)| tag.as_str() == "TRE")
+        .unwrap()
+        .1;
+    let regiment = tre
+        .armies
+        .iter()
+        .flat_map(|a| a.regiments.iter())
+        .find(|r| r.name.starts_with("Choniades"))
+        .unwrap();
+    assert_eq!(regiment.name, "Choniadesの1st 傭兵歩兵");
+    Ok(())
+}

--- a/crates/jomini/src/text/de.rs
+++ b/crates/jomini/src/text/de.rs
@@ -851,6 +851,20 @@ impl TextDeserializer<'_, '_, Utf8Encoding> {
     }
 }
 
+impl<E: Encoding> TextDeserializer<'_, '_, E> {
+    /// (**Experimental**) Create a text deserializer over a reader that decodes
+    /// quoted strings with the given encoding
+    ///
+    /// Considered experimental as it uses a [TokenReader] under the hood, which
+    /// uses a different parsing routine geared toward save files.
+    pub fn from_encoded_reader<'r>(
+        reader: TokenReader<'r>,
+        encoding: E,
+    ) -> TextReaderDeserializer<'r, E> {
+        TextReaderDeserializer { reader, encoding }
+    }
+}
+
 impl<'a, 'b> TextDeserializer<'a, 'b, Windows1252Encoding> {
     /// Convenience method for parsing the given text data and deserializing as windows1252 encoded.
     pub fn from_windows1252_slice(

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -106,3 +106,6 @@ name = "fuzz_eu5"
 path = "fuzz_targets/fuzz_eu5.rs"
 test = false
 doc = false
+
+[patch.crates-io]
+jomini = { path = "../crates/jomini" }


### PR DESCRIPTION
- Allow text deserializers to accept a custom flavor
- Consider the entire string for escaped characters instead of the first one