### PR TITLE
Support UTF-8 EU4 save_name save fields

### DIFF
--- a/crates/eu4save/src/de/mod.rs
+++ b/crates/eu4save/src/de/mod.rs
@@ -10,6 +10,7 @@ mod province_event_value;
 mod province_history;
 mod token_bool;
 mod trade_node;
+mod utf8_string;
 mod vec_pair;
 mod war_history;
 mod yes_map;
@@ -20,6 +21,7 @@ pub(crate) use list_overflow_byte::*;
 pub(crate) use map_capacity::*;
 pub(crate) use map_pair::*;
 pub(crate) use token_bool::*;
+pub(crate) use utf8_string::*;
 pub use vec_pair::*;
 pub(crate) use yes_map::*;
 

--- a/crates/eu4save/src/de/utf8_string.rs
+++ b/crates/eu4save/src/de/utf8_string.rs
@@ -1,0 +1,40 @@
+use jomini::{Encoding, Utf8Encoding};
+use serde::{de, Deserializer};
+use std::fmt;
+
+/// Deserializes a string that the game wrote as utf-8 instead of Windows-1252
+///
+/// The game writes the save file name from the OS file name, which bypasses
+/// the EU4dll string hook that the Japanese and Chinese mods use. A save from
+/// one of these mods stores the file name as utf-8 while every other string
+/// is EU4dll escaped, so this field is decoded from the raw bytes.
+pub(crate) fn deserialize_utf8_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Utf8StringVisitor;
+
+    impl de::Visitor<'_> for Utf8StringVisitor {
+        type Value = String;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a utf-8 string")
+        }
+
+        fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(Utf8Encoding::new().decode(v).into_owned())
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(String::from(v))
+        }
+    }
+
+    deserializer.deserialize_bytes(Utf8StringVisitor)
+}

--- a/crates/eu4save/src/models.rs
+++ b/crates/eu4save/src/models.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 #[cfg_attr(feature = "tsify", derive(tsify::Tsify))]
 pub struct Meta {
     pub campaign_id: String,
+    #[jomini(deserialize_with = "deserialize_utf8_string")]
     pub save_game: String,
     pub player: CountryTag,
     pub displayed_country_name: String,
@@ -57,6 +58,7 @@ impl<'de> Deserialize<'de> for Eu4Save {
         #[derive(Debug, JominiDeserialize)]
         struct Eu4SaveFlatten {
             pub campaign_id: String,
+            #[jomini(deserialize_with = "deserialize_utf8_string")]
             pub save_game: String,
             pub player: CountryTag,
             pub displayed_country_name: String,

--- a/crates/eu4save/tests/it/samples.rs
+++ b/crates/eu4save/tests/it/samples.rs
@@ -396,6 +396,10 @@ fn test_eu4_japanese_text() -> Result<(), Box<dyn Error>> {
     assert_eq!(file.encoding(), Encoding::TextZip);
     assert_eq!(save.meta.player, "TRE");
     assert_eq!(save.meta.displayed_country_name, "トレビゾンド");
+
+    // The save name comes from the OS file name, so it is utf-8 instead of
+    // EU4dll escaped
+    assert_eq!(save.meta.save_game, "mp_グーラカーン1633_09_07.eu4");
     assert_eq!(save.game.players_countries[0], "くまねこ");
 
     // A Latin family name with a localized suffix: the escape does not start


### PR DESCRIPTION
Best guess is that EU4 writes out the literal file name, without caring.